### PR TITLE
Restrict Claude GitHub Actions to repo contributors only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,10 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: |
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR'
 
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,16 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event.sender.author_association == 'OWNER' ||
+        github.event.sender.author_association == 'MEMBER' ||
+        github.event.sender.author_association == 'COLLABORATOR'
+      ) && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Add contributor checks to both Claude GitHub Actions workflows so they only run for users with `OWNER`, `MEMBER`, or `COLLABORATOR` association on the repo.

## Motivation
The repository is public, so without this guard any external user could trigger Claude workflows by opening PRs or leaving `@claude` comments, consuming quota and potentially causing unintended behavior.

## What's Changed

### Backend
_No backend changes._

### Frontend
_No frontend changes._

### GitHub Actions
- `.github/workflows/claude-code-review.yml` — Added `if` condition on the job checking `github.event.pull_request.author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`.
- `.github/workflows/claude.yml` — Wrapped the existing `@claude` mention conditions with an additional `github.event.sender.author_association` check for the same three associations.

## Risks and Mitigations
- **Risk**: A legitimate collaborator whose association isn't one of the three allowed values won't be able to trigger the workflows. This is intentional and expected — only people with explicit repo access should be able to invoke Claude.
- **Mitigation**: The three allowed associations (`OWNER`, `MEMBER`, `COLLABORATOR`) cover all users with direct repository access on GitHub.

Made with [Cursor](https://cursor.com)