### PR TITLE
Add MCP tools for project files and TUS uploads

### DIFF
--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -1,6 +1,8 @@
 import json
+from datetime import datetime, timedelta, timezone
 
 import aiofiles
+import jwt as pyjwt
 from fastmcp import FastMCP
 from fastmcp.dependencies import CurrentContext
 from fastmcp.server.auth import AccessToken
@@ -19,8 +21,17 @@ from lib.models.project import AccessLevel
 from lib.models.user import User
 from lib.services.docx_workflow_service import DocxManipulatorType, get_or_generate_docx
 from lib.services.file_finalization import finalize_file
+from lib.services.files import delete_project_files, get_files_by_project_id
 from lib.services.projects import create_project as create_project_record
-from lib.services.projects import get_project_access, get_project_detailed_from_project, get_user_projects
+from lib.services.projects import (
+    get_project_access,
+    get_project_detailed_from_project,
+    get_user_projects,
+)
+from lib.services.references import (
+    get_file_reference_matches,
+    remove_file_from_references,
+)
 from lib.services.users import get_or_create_user_by_email
 from lib.services.workflow_types import get_workflow_types_for_user
 from lib.workflows.models import SeverityEnum, WorkflowRunType
@@ -76,6 +87,7 @@ async def _get_project_details_json(
     project_detailed = await get_project_detailed_from_project(
         project=project,
         access_level=access_level,
+        include_internal=True,
     )
     data = project_detailed.model_dump(mode="json", exclude={"files", "feedbacks"})
     data["project_url"] = _build_project_url(project_id)
@@ -297,6 +309,168 @@ async def export_project_docx(
         docx_bytes = await f.read()
 
     return File(data=docx_bytes, format="docx", name=filename)
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        destructiveHint=False,
+        idempotentHint=True,
+        readOnlyHint=True,
+        openWorldHint=False,
+    )
+)
+async def list_project_files(
+    project_id: str,
+    token: AccessToken = CurrentAccessToken(),
+) -> str:
+    """
+    List all files for a project and their reference associations.
+
+    Returns a JSON array where each entry contains:
+      file_id, file_name, file_size, file_type, role, reference_id (null if unmatched).
+
+    Use get_project to retrieve available reference IDs from the workflow state
+    (look inside workflow_runs for type "reference_extraction" → state.extracted_references).
+    """
+    user = await _resolve_user(token)
+    project, _ = await get_project_access(
+        project_id, user=user, required_level=AccessLevel.READ
+    )
+
+    files = await get_files_by_project_id(project.id)
+    matches = await get_file_reference_matches(project_id)
+    file_to_reference = {m.file_id: m.reference_id for m in matches}
+
+    return json.dumps(
+        [
+            {
+                "file_id": str(f.id),
+                "file_name": f.file_name,
+                "file_size": f.file_size,
+                "file_type": f.file_type,
+                "role": str(f.role) if f.role else None,
+                "reference_id": file_to_reference.get(str(f.id)),
+            }
+            for f in files
+        ]
+    )
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        destructiveHint=True,
+        idempotentHint=False,
+        readOnlyHint=False,
+        openWorldHint=False,
+    )
+)
+async def remove_reference_file(
+    project_id: str,
+    file_id: str,
+    token: AccessToken = CurrentAccessToken(),
+) -> str:
+    """
+    Remove a supporting file from a project and clean up its reference association.
+
+    Deletes the file record and its disk content (unless shared with another project),
+    then removes any reference-file match that pointed to this file.
+
+    Returns JSON with the deleted file_id and the list of reference IDs that were unlinked.
+    Use list_project_files to discover file IDs for a project.
+    """
+    user = await _resolve_user(token)
+    project, _ = await get_project_access(
+        project_id, user=user, required_level=AccessLevel.WRITE
+    )
+
+    deleted_count = await delete_project_files(project.id, target_file_ids=[file_id])
+    if deleted_count == 0:
+        raise ValueError(f"File {file_id!r} not found in project {project_id!r}")
+
+    removed_reference_ids = await remove_file_from_references(project_id, file_id)
+
+    return json.dumps(
+        {
+            "file_id": file_id,
+            "removed_from_reference_ids": removed_reference_ids,
+        }
+    )
+
+
+def _build_tus_url() -> str:
+    """Derive the TUS endpoint URL from MCP_BASE_URL by stripping the /mcp suffix."""
+    base = env_config.MCP_BASE_URL
+    if base.endswith("/mcp"):
+        base = base[: -len("/mcp")]
+    return base.rstrip("/") + "/tus"
+
+
+@mcp.tool(
+    annotations=ToolAnnotations(
+        destructiveHint=False,
+        idempotentHint=False,
+        readOnlyHint=False,
+        openWorldHint=False,
+    )
+)
+async def get_tus_upload_credentials(
+    project_id: str,
+    reference_id: str | None = None,
+    token: AccessToken = CurrentAccessToken(),
+) -> str:
+    """
+    Get credentials and URL to upload a supporting file via the TUS resumable upload protocol.
+
+    Returns a bearer token (valid for 15 minutes) and the TUS endpoint URL. Use any TUS client
+    library (e.g. tus-js-client, tuspy) to perform the upload. Start the upload before the token
+    expires; in-progress TUS uploads are not interrupted by expiry.
+
+    Steps:
+    1. Call this tool with project_id and optional reference_id.
+    2. Create a TUS upload at tus_url with:
+       - Header: Authorization: Bearer <bearer_token>
+       - TUS metadata fields from required_metadata (include filename for the stored file name)
+    3. Upload the file using the TUS protocol (supports chunked / resumable uploads).
+
+    reference_id: optional ID of the reference to link the file to. Obtain reference IDs
+        from get_project (workflow_runs → type "reference_extraction" → state.extracted_references[].id).
+    """
+    user = await _resolve_user(token)
+    await get_project_access(project_id, user=user, required_level=AccessLevel.WRITE)
+
+    now = datetime.now(timezone.utc)
+    payload = {
+        "email": user.email,
+        "name": user.name,
+        "iss": "ai-reviewer",
+        "aud": "ai-reviewer-api",
+        "iat": now,
+        "exp": now + timedelta(minutes=15),
+    }
+    bearer_token = pyjwt.encode(payload, env_config.AUTH_SECRET, algorithm="HS512")
+
+    required_metadata: dict[str, str | None] = {
+        "project_id": project_id,
+        "reference_id": reference_id,
+        "role": "support",
+    }
+
+    return json.dumps(
+        {
+            "tus_url": _build_tus_url(),
+            "bearer_token": bearer_token,
+            "expires_in_seconds": 900,
+            "required_metadata": required_metadata,
+            "instructions": (
+                "Use any TUS client to upload the file. "
+                "The bearer_token is valid for 15 minutes — start the upload before it expires. "
+                "Set 'Authorization: Bearer <bearer_token>' on every request. "
+                "Pass required_metadata as TUS Upload-Metadata (add a 'filename' field "
+                "to control the stored file name). "
+                "The upload endpoint supports files up to 500 MB and resumable chunked transfers."
+            ),
+        }
+    )
 
 
 mcp_app = mcp.http_app(

--- a/lib/services/references.py
+++ b/lib/services/references.py
@@ -181,6 +181,14 @@ async def _get_extraction_workflow_state(
     return run, state
 
 
+async def get_file_reference_matches(project_id: str) -> List[ReferenceFileMatch]:
+    """Return the current reference-file matches for a project (empty list if none)."""
+    _, state = await _get_file_matching_workflow_state(project_id)
+    if state is None:
+        return []
+    return list(state.matches)
+
+
 async def remove_file_from_references(project_id: str, file_id: str) -> List[str]:
     """
     Remove file_id from any matches in the ReferenceFileMatching workflow state.

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -36,6 +36,9 @@ EXPECTED_TOOL_NAMES = {
     "get_project",
     "list_projects",
     "export_project_docx",
+    "list_project_files",
+    "remove_reference_file",
+    "get_tus_upload_credentials",
 }
 
 

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -1,6 +1,7 @@
 """Unit tests for MCP tool functions with mocked service dependencies."""
 
 import json
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -15,12 +16,16 @@ _mcp_auth_mod.create_mcp_auth = lambda: None
 from lib.api.mcp import (  # noqa: E402
     _build_project_url,
     _build_settings_url,
+    _build_tus_url,
     _require_api_key,
     _resolve_user,
     create_project,
     export_project_docx,
     get_project,
+    get_tus_upload_credentials,
+    list_project_files,
     list_projects,
+    remove_reference_file,
     run_workflow,
 )
 
@@ -391,3 +396,264 @@ async def test_get_project_returns_details():
 
     mock_details.assert_awaited_once_with("p1", AccessLevel.READ, user)
     assert json.loads(result)["title"] == "Test"
+
+
+# --- list_project_files ---
+
+
+@pytest.mark.asyncio
+async def test_list_project_files_returns_files_with_reference():
+    from lib.workflows.reference_file_matching.state import MatchSource, ReferenceFileMatch
+
+    user = _make_user()
+    project = MagicMock()
+    project.id = uuid4()
+    project_id = str(project.id)
+
+    file1 = MagicMock()
+    file1.id = uuid4()
+    file1.file_name = "paper.pdf"
+    file1.file_size = 12345
+    file1.file_type = "application/pdf"
+    file1.role = "support"
+
+    ref_id = str(uuid4())
+    match = ReferenceFileMatch(reference_id=ref_id, file_id=str(file1.id), source=MatchSource.MANUAL_UPLOAD)
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.get_files_by_project_id", new=AsyncMock(return_value=[file1])),
+        patch("lib.api.mcp.get_file_reference_matches", new=AsyncMock(return_value=[match])),
+    ):
+        raw = await list_project_files(project_id=project_id, token=_make_token())
+
+    data = json.loads(raw)
+    assert len(data) == 1
+    assert data[0]["file_id"] == str(file1.id)
+    assert data[0]["file_name"] == "paper.pdf"
+    assert data[0]["file_size"] == 12345
+    assert data[0]["file_type"] == "application/pdf"
+    assert data[0]["role"] == "support"
+    assert data[0]["reference_id"] == ref_id
+
+
+@pytest.mark.asyncio
+async def test_list_project_files_null_reference_when_unmatched():
+    user = _make_user()
+    project = MagicMock()
+    project.id = uuid4()
+
+    file1 = MagicMock()
+    file1.id = uuid4()
+    file1.file_name = "extra.pdf"
+    file1.file_size = 500
+    file1.file_type = "application/pdf"
+    file1.role = "support"
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.get_files_by_project_id", new=AsyncMock(return_value=[file1])),
+        patch("lib.api.mcp.get_file_reference_matches", new=AsyncMock(return_value=[])),
+    ):
+        raw = await list_project_files(project_id=str(project.id), token=_make_token())
+
+    data = json.loads(raw)
+    assert data[0]["reference_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_project_files_returns_empty_list():
+    user = _make_user()
+    project = MagicMock()
+    project.id = uuid4()
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.get_files_by_project_id", new=AsyncMock(return_value=[])),
+        patch("lib.api.mcp.get_file_reference_matches", new=AsyncMock(return_value=[])),
+    ):
+        raw = await list_project_files(project_id=str(project.id), token=_make_token())
+
+    assert json.loads(raw) == []
+
+
+# --- remove_reference_file ---
+
+
+@pytest.mark.asyncio
+async def test_remove_reference_file_returns_file_and_unlinked_refs():
+    user = _make_user()
+    project = MagicMock()
+    project.id = uuid4()
+    file_id = str(uuid4())
+    ref_id = str(uuid4())
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.delete_project_files", new=AsyncMock(return_value=1)),
+        patch("lib.api.mcp.remove_file_from_references", new=AsyncMock(return_value=[ref_id])),
+    ):
+        raw = await remove_reference_file(
+            project_id=str(project.id), file_id=file_id, token=_make_token()
+        )
+
+    data = json.loads(raw)
+    assert data["file_id"] == file_id
+    assert data["removed_from_reference_ids"] == [ref_id]
+
+
+@pytest.mark.asyncio
+async def test_remove_reference_file_raises_when_not_found():
+    user = _make_user()
+    project = MagicMock()
+    project.id = uuid4()
+    file_id = str(uuid4())
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.delete_project_files", new=AsyncMock(return_value=0)),
+    ):
+        with pytest.raises(ValueError, match="not found in project"):
+            await remove_reference_file(
+                project_id=str(project.id), file_id=file_id, token=_make_token()
+            )
+
+
+@pytest.mark.asyncio
+async def test_remove_reference_file_with_no_associations():
+    user = _make_user()
+    project = MagicMock()
+    project.id = uuid4()
+    file_id = str(uuid4())
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.delete_project_files", new=AsyncMock(return_value=1)),
+        patch("lib.api.mcp.remove_file_from_references", new=AsyncMock(return_value=[])),
+    ):
+        raw = await remove_reference_file(
+            project_id=str(project.id), file_id=file_id, token=_make_token()
+        )
+
+    data = json.loads(raw)
+    assert data["removed_from_reference_ids"] == []
+
+
+# --- _build_tus_url ---
+
+
+def test_build_tus_url_strips_mcp_suffix():
+    with patch("lib.api.mcp.env_config") as mock_cfg:
+        mock_cfg.MCP_BASE_URL = "https://app.example.com/mcp"
+        result = _build_tus_url()
+    assert result == "https://app.example.com/tus"
+
+
+def test_build_tus_url_handles_trailing_slash_after_stripping():
+    with patch("lib.api.mcp.env_config") as mock_cfg:
+        mock_cfg.MCP_BASE_URL = "https://app.example.com/mcp"
+        result = _build_tus_url()
+    assert not result.endswith("//tus")
+    assert result.endswith("/tus")
+
+
+# --- get_tus_upload_credentials ---
+
+
+@pytest.mark.asyncio
+async def test_get_tus_upload_credentials_returns_required_fields():
+    import jwt as pyjwt
+
+    user = _make_user()
+    project = MagicMock()
+    project.id = uuid4()
+    project_id = str(uuid4())
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.env_config") as mock_cfg,
+    ):
+        mock_cfg.MCP_BASE_URL = "https://app.example.com/mcp"
+        mock_cfg.AUTH_SECRET = "test-secret"
+        raw = await get_tus_upload_credentials(project_id=project_id, token=_make_token())
+
+    data = json.loads(raw)
+    assert data["tus_url"] == "https://app.example.com/tus"
+    assert "bearer_token" in data
+    assert data["expires_in_seconds"] == 900
+    assert data["required_metadata"]["project_id"] == project_id
+    assert data["required_metadata"]["role"] == "support"
+    assert data["required_metadata"]["reference_id"] is None
+    assert "instructions" in data
+
+    decoded = pyjwt.decode(
+        data["bearer_token"],
+        "test-secret",
+        algorithms=["HS512"],
+        issuer="ai-reviewer",
+        audience="ai-reviewer-api",
+    )
+    assert decoded["email"] == user.email
+    assert decoded["name"] == user.name
+
+
+@pytest.mark.asyncio
+async def test_get_tus_upload_credentials_includes_reference_id():
+    user = _make_user()
+    project = MagicMock()
+    ref_id = str(uuid4())
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
+        patch("lib.api.mcp.env_config") as mock_cfg,
+    ):
+        mock_cfg.MCP_BASE_URL = "https://app.example.com/mcp"
+        mock_cfg.AUTH_SECRET = "test-secret"
+        raw = await get_tus_upload_credentials(
+            project_id=str(uuid4()), reference_id=ref_id, token=_make_token()
+        )
+
+    data = json.loads(raw)
+    assert data["required_metadata"]["reference_id"] == ref_id
+
+
+@pytest.mark.asyncio
+async def test_get_tus_upload_credentials_bearer_token_expires_in_one_hour():
+    from datetime import datetime, timezone
+
+    import jwt as pyjwt
+
+    user = _make_user()
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(MagicMock(), MagicMock()))),
+        patch("lib.api.mcp.env_config") as mock_cfg,
+    ):
+        mock_cfg.MCP_BASE_URL = "https://app.example.com/mcp"
+        mock_cfg.AUTH_SECRET = "test-secret"
+        before = datetime.now(timezone.utc)
+        raw = await get_tus_upload_credentials(project_id=str(uuid4()), token=_make_token())
+        after = datetime.now(timezone.utc)
+
+    data = json.loads(raw)
+    decoded = pyjwt.decode(
+        data["bearer_token"],
+        "test-secret",
+        algorithms=["HS512"],
+        issuer="ai-reviewer",
+        audience="ai-reviewer-api",
+    )
+    exp = datetime.fromtimestamp(decoded["exp"], tz=timezone.utc)
+    iat = datetime.fromtimestamp(decoded["iat"], tz=timezone.utc)
+
+    assert exp - iat >= timedelta(minutes=14)
+    assert exp - iat <= timedelta(minutes=15, seconds=5)


### PR DESCRIPTION
## Summary
- Add `list_project_files` tool to list files with their reference associations
- Add `remove_reference_file` tool to delete a file and clean up reference links
- Add `get_tus_upload_credentials` tool to generate short-lived bearer tokens for resumable file uploads via TUS protocol
- Add `get_file_reference_matches` helper in references service
- Fix `test_lists_all_expected_tools` to include the three new tool names

## Test plan
- [x] All 32 unit tests in `test_mcp_tools.py` pass (including new tests for the 3 tools)
- [x] `test_lists_all_expected_tools` in `test_mcp_server.py` passes with updated expected set
- [x] Full test suite passes (488 passed, 3 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)