### PR TITLE
fix(projects): show issues from old revisions in the UI

### DIFF
--- a/lib/services/projects.py
+++ b/lib/services/projects.py
@@ -12,7 +12,7 @@ from sqlmodel import and_, col
 from lib.config.database import get_async_db_session
 from lib.models.feedback import FeedbackType
 from lib.models.file import File, FileListItem
-from lib.models.issue import Issue, IssueStatus
+from lib.models.issue import Issue
 from lib.models.project import AccessLevel, FeedbackVisibility, Project
 from lib.models.user import User, UserRole
 from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
@@ -398,17 +398,6 @@ async def create_new_revision(project_id: str, user: User) -> tuple[int, List[Wo
             WorkflowRunType(row[0]) if isinstance(row[0], str) else row[0]
             for row in result.all()
         ]
-
-        # Archive active issues from the old revision
-        await session.execute(
-            update(Issue)
-            .where(
-                col(Issue.project_id) == project_id,
-                col(Issue.revision) == old_revision,
-                col(Issue.status) == IssueStatus.ACTIVE,
-            )
-            .values(status=IssueStatus.ARCHIVED)
-        )
 
         # Increment project revision
         await session.execute(


### PR DESCRIPTION
## Summary

- Fixes issues from old revisions not showing up in the UI when using the revision switcher
- Removes unnecessary archival of issues during new revision creation

## Motivation

When a new revision was created, `create_new_revision()` archived all active issues from the previous revision. Since `get_project_issues()` excludes archived issues by default, switching to an old revision via the UI showed zero issues. Additionally, this conflated system-archived issues with user-archived ones, losing track of which issues the user intentionally dismissed.

## What's Changed

### Backend
- **`lib/services/projects.py`** — Removed the `update(Issue)...ARCHIVED` block from `create_new_revision()` that was archiving all active issues when a new revision was created. Issues already have a `revision` column, and queries already filter by revision, so the archival was redundant. Also cleaned up the unused `IssueStatus` import.

## Risks and Mitigations

- **Low risk**: The revision filter on `get_project_issues()` already scopes issues to the correct revision, so removing the archival step does not leak issues across revisions.
- **Existing archived issues**: Issues that were already archived by this logic in production will remain archived. If recovery is needed, a data migration can restore them based on revision number.

Fixes [RANDZ-518](https://linear.app/ae-studio/issue/RANDZ-518)

🤖 Generated with [Claude Code](https://claude.com/claude-code)