### PR TITLE
feat(mcp): add MCP_CIMD_ENABLED env var

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -41,6 +41,9 @@ AUTH_MICROSOFT_ENTRA_ID_SECRET=
 AUTH_MICROSOFT_ENTRA_ID_ISSUER=
 # Public URL of the MCP server (must include /mcp path)
 MCP_BASE_URL=http://localhost:8000/mcp
+# Enable CIMD for MCP OAuth providers (default: false)
+# Disable if clients are behind VPNs that cannot reach the CIMD endpoint
+# MCP_CIMD_ENABLED=false
 
 # Shareable links
 FRONTEND_URL=http://localhost:3000

--- a/lib/api/mcp_auth.py
+++ b/lib/api/mcp_auth.py
@@ -40,7 +40,7 @@ def create_mcp_auth():
                 "openid",
                 "https://www.googleapis.com/auth/userinfo.email",
             ],
-            enable_cimd=False,  # Disable Cimd to avoid issues with Claude Code behind VPNs not able to reach the CIMD endpoint
+            enable_cimd=config.MCP_CIMD_ENABLED,
         )
 
     if (
@@ -62,7 +62,7 @@ def create_mcp_auth():
             base_url=base_url,
             issuer_url=issuer_url,
             required_scopes=["mcp-access"],
-            enable_cimd=False,  # Disable Cimd to avoid issues with Claude Code behind VPNs not able to reach the CIMD endpoint
+            enable_cimd=config.MCP_CIMD_ENABLED,
         )
 
     raise RuntimeError(

--- a/lib/config/env.py
+++ b/lib/config/env.py
@@ -51,6 +51,10 @@ class Config(BaseModel):
         default="http://localhost:8000/mcp",
         description="Public URL of the MCP server (must include /mcp path)",
     )
+    MCP_CIMD_ENABLED: bool = Field(
+        default=False,
+        description="Whether to enable CIMD for MCP OAuth providers. Disable if clients are behind VPNs that cannot reach the CIMD endpoint.",
+    )
 
     # File uploads
     FILE_UPLOADS_MOUNT_PATH: str
@@ -97,4 +101,5 @@ config = Config(
     AUTH_MICROSOFT_ENTRA_ID_SECRET=os.getenv("AUTH_MICROSOFT_ENTRA_ID_SECRET"),
     AUTH_MICROSOFT_ENTRA_ID_ISSUER=os.getenv("AUTH_MICROSOFT_ENTRA_ID_ISSUER"),
     MCP_BASE_URL=os.getenv("MCP_BASE_URL", "http://localhost:8000/mcp"),
+    MCP_CIMD_ENABLED=os.getenv("MCP_CIMD_ENABLED", "false").lower() == "true",
 )

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -33,6 +33,7 @@ def test_create_mcp_auth_raises_without_credentials():
     mock_config.AUTH_MICROSOFT_ENTRA_ID_SECRET = None
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = None
     mock_config.MCP_BASE_URL = "http://localhost:8000/mcp"
+    mock_config.MCP_CIMD_ENABLED = False
 
     with patch("lib.api.mcp_auth.config", mock_config):
         with pytest.raises(RuntimeError, match="MCP auth requires either Google"):
@@ -44,6 +45,7 @@ def test_create_mcp_auth_with_google_credentials():
     mock_config.AUTH_GOOGLE_ID = "google-client-id"
     mock_config.AUTH_GOOGLE_SECRET = "google-client-secret"
     mock_config.MCP_BASE_URL = "https://api.example.com/mcp"
+    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -76,6 +78,7 @@ def test_create_mcp_auth_with_entra_id_credentials():
         "https://login.microsoftonline.com/tenant-abc/v2.0"
     )
     mock_config.MCP_BASE_URL = "https://api.example.com/mcp"
+    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -107,6 +110,7 @@ def test_create_mcp_auth_google_takes_priority():
         "https://login.microsoftonline.com/tenant/v2.0"
     )
     mock_config.MCP_BASE_URL = "http://localhost:8000/mcp"
+    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -134,6 +138,7 @@ def test_create_mcp_auth_extracts_tenant_from_issuer():
         "https://login.microsoftonline.com/my-tenant-123/v2.0"
     )
     mock_config.MCP_BASE_URL = "http://localhost/mcp"
+    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -145,3 +150,64 @@ def test_create_mcp_auth_extracts_tenant_from_issuer():
 
     call_kwargs = MockProvider.call_args.kwargs
     assert call_kwargs["tenant_id"] == "my-tenant-123"
+
+
+def test_create_mcp_auth_cimd_enabled_google():
+    """CIMD flag is forwarded to Google provider when enabled."""
+    mock_config = MagicMock()
+    mock_config.AUTH_GOOGLE_ID = "google-client-id"
+    mock_config.AUTH_GOOGLE_SECRET = "google-client-secret"
+    mock_config.MCP_BASE_URL = "https://api.example.com/mcp"
+    mock_config.MCP_CIMD_ENABLED = True
+
+    with (
+        patch("lib.api.mcp_auth.config", mock_config),
+        patch(
+            "fastmcp.server.auth.providers.google.GoogleProvider"
+        ) as MockProvider,
+    ):
+        create_mcp_auth()
+
+    MockProvider.assert_called_once_with(
+        client_id="google-client-id",
+        client_secret="google-client-secret",
+        base_url="https://api.example.com/mcp",
+        issuer_url="https://api.example.com",
+        required_scopes=[
+            "openid",
+            "https://www.googleapis.com/auth/userinfo.email",
+        ],
+        enable_cimd=True,
+    )
+
+
+def test_create_mcp_auth_cimd_enabled_entra_id():
+    """CIMD flag is forwarded to Azure provider when enabled."""
+    mock_config = MagicMock()
+    mock_config.AUTH_GOOGLE_ID = None
+    mock_config.AUTH_GOOGLE_SECRET = None
+    mock_config.AUTH_MICROSOFT_ENTRA_ID_ID = "entra-id"
+    mock_config.AUTH_MICROSOFT_ENTRA_ID_SECRET = "entra-secret"
+    mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = (
+        "https://login.microsoftonline.com/tenant-abc/v2.0"
+    )
+    mock_config.MCP_BASE_URL = "https://api.example.com/mcp"
+    mock_config.MCP_CIMD_ENABLED = True
+
+    with (
+        patch("lib.api.mcp_auth.config", mock_config),
+        patch(
+            "fastmcp.server.auth.providers.azure.AzureProvider"
+        ) as MockProvider,
+    ):
+        create_mcp_auth()
+
+    MockProvider.assert_called_once_with(
+        client_id="entra-id",
+        client_secret="entra-secret",
+        tenant_id="tenant-abc",
+        base_url="https://api.example.com/mcp",
+        issuer_url="https://api.example.com",
+        required_scopes=["mcp-access"],
+        enable_cimd=True,
+    )


### PR DESCRIPTION
## Summary

- Add `MCP_CIMD_ENABLED` environment variable to control whether CIMD is enabled for MCP OAuth providers
- Defaults to `false` for backward compatibility (prevents issues with Claude Code clients behind VPNs)

## Motivation

CIMD was previously hardcoded to disabled in both Google and Azure MCP auth providers. This change makes it configurable via an environment variable so deployments that can reach the CIMD endpoint can opt in without code changes.

Closes RANDZ-519

## What's Changed

### Backend
- **`lib/config/env.py`** — Added `MCP_CIMD_ENABLED` boolean field (default `False`) to the `Config` model, read from the `MCP_CIMD_ENABLED` environment variable
- **`lib/api/mcp_auth.py`** — Replaced hardcoded `enable_cimd=False` with `enable_cimd=config.MCP_CIMD_ENABLED` in both `GoogleProvider` and `AzureProvider` instantiations
- **`.env.template`** — Added commented-out `MCP_CIMD_ENABLED` entry with documentation
- **`tests/unit/test_mcp_auth.py`** — Added `MCP_CIMD_ENABLED` to all existing mock configs; added two new tests verifying `enable_cimd=True` is forwarded to both Google and Azure providers

## Risks and Mitigations

- **Low risk** — Default behavior is unchanged (`false`). Existing deployments are unaffected unless the env var is explicitly set to `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)