### PR TITLE
feat(reference-validation): add messages for reference error checker

### DIFF
--- a/frontend/components/results/tabs/reference-review/validation-results-box.tsx
+++ b/frontend/components/results/tabs/reference-review/validation-results-box.tsx
@@ -2,6 +2,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { LabeledValue } from '@/components/labeled-value';
 import { Markdown } from '@/components/markdown';
+import { AgentMessagesDialog } from '@/components/shared/agent-messages-dialog';
 import {
   ReferenceValidationFinalResult,
   ReferenceValidationItem,
@@ -15,6 +16,7 @@ import {
   ChevronRightIcon,
   ClipboardCheck,
   Loader2,
+  MessageSquare,
   SearchX,
   XCircle,
 } from 'lucide-react';
@@ -47,9 +49,11 @@ export function ValidationResultsBox({
 }: ValidationResultsBoxProps) {
   const paddingClass = sizeClasses[size];
   const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isMessagesOpen, setIsMessagesOpen] = React.useState(false);
 
   const status = validation.status ?? ReferenceValidationStatus.Pending;
   const result = validation.validation_result;
+  const hasMessages = validation.messages && validation.messages.length > 0;
 
   // Handle cancelled state (workflow was cancelled before this item was processed)
   if (status === ReferenceValidationStatus.Cancelled) {
@@ -173,10 +177,18 @@ export function ValidationResultsBox({
             {config.label}
           </span>
         </div>
-        <Button variant="outline" size="xs" onClick={() => setIsExpanded(!isExpanded)}>
-          {isExpanded ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
-          {isExpanded ? 'Hide details' : 'Show details'}
-        </Button>
+        <div className="flex items-center gap-1.5">
+          {hasMessages && (
+            <Button variant="outline" size="xs" onClick={() => setIsMessagesOpen(true)} title="View agent messages">
+              <MessageSquare className="size-4" />
+              Messages
+            </Button>
+          )}
+          <Button variant="outline" size="xs" onClick={() => setIsExpanded(!isExpanded)}>
+            {isExpanded ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
+            {isExpanded ? 'Hide details' : 'Show details'}
+          </Button>
+        </div>
       </div>
 
       {/* Reference text (when showReference is enabled) */}
@@ -268,6 +280,15 @@ export function ValidationResultsBox({
             </div>
           )}
         </div>
+      )}
+
+      {hasMessages && (
+        <AgentMessagesDialog
+          messages={validation.messages!}
+          open={isMessagesOpen}
+          onOpenChange={setIsMessagesOpen}
+          title={showReference && referenceLabel ? `Messages — ${referenceLabel}` : undefined}
+        />
       )}
     </div>
   );

--- a/frontend/components/shared/agent-messages-dialog.tsx
+++ b/frontend/components/shared/agent-messages-dialog.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ReadonlyThread } from '@/components/assistant-ui/readonly-thread';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { AssistantRuntimeProvider, ThreadMessageLike, useExternalStoreRuntime } from '@assistant-ui/react';
+import { convertLangChainMessages, LangChainMessage } from '@assistant-ui/react-langgraph';
+
+interface AgentMessagesDialogProps {
+  messages: Array<{ [key: string]: unknown }>;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+}
+
+export function AgentMessagesDialog({ messages, open, onOpenChange, title }: AgentMessagesDialogProps) {
+  const displayedMessages = messages;
+
+  const runtime = useExternalStoreRuntime({
+    messages: displayedMessages,
+    convertMessage: (message) => convertLangChainMessages(message as LangChainMessage, {}) as ThreadMessageLike,
+    isRunning: false,
+    onNew: async () => {},
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-5xl h-[80vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="text-base">{title ?? 'Agent Messages'}</DialogTitle>
+        </DialogHeader>
+        <div className="flex-1 min-h-0">
+          <AssistantRuntimeProvider runtime={runtime}>
+            <ReadonlyThread />
+          </AssistantRuntimeProvider>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -4252,6 +4252,14 @@ export type ReferenceValidationItem = {
    * Error message, present on failure.
    */
   error?: string | null;
+  /**
+   * Messages
+   *
+   * LLM conversation messages from the agent invocation.
+   */
+  messages?: Array<{
+    [key: string]: unknown;
+  }>;
 };
 
 /**

--- a/lib/workflows/reference_validation/nodes/reference_validation.py
+++ b/lib/workflows/reference_validation/nodes/reference_validation.py
@@ -1,5 +1,7 @@
 import logging
+from typing import List
 
+from langchain_core.messages import BaseMessage
 from langgraph.runtime import Runtime
 from langgraph.types import Overwrite, Send
 
@@ -75,9 +77,10 @@ async def validate_single_reference(state: dict, runtime: Runtime[ContextSchema]
     validation_result = None
     error = None
     status = ReferenceValidationStatus.COMPLETED
+    agent_messages: List[BaseMessage] = []
 
     try:
-        validation_result, messages = await agent.ainvoke(
+        validation_result, agent_messages = await agent.ainvoke(
             {"reference": input_reference}
         )
     except Exception as e:
@@ -95,6 +98,7 @@ async def validate_single_reference(state: dict, runtime: Runtime[ContextSchema]
                 status=status,
                 validation_result=validation_result,
                 error=error,
+                messages=agent_messages,
             )
         ]
     }

--- a/lib/workflows/reference_validation/state.py
+++ b/lib/workflows/reference_validation/state.py
@@ -1,7 +1,8 @@
 from enum import Enum
 from typing import Annotated, List, Literal, Optional
 
-from pydantic import BaseModel, Field
+from langchain_core.messages import BaseMessage
+from pydantic import BaseModel, Field, field_serializer
 
 from lib.agents.reference_validator import BibliographyItemValidation
 from lib.workflows.models import BaseWorkflowConfig, BaseWorkflowState, WorkflowRunType
@@ -41,6 +42,15 @@ class ReferenceValidationItem(BaseModel):
         default=None,
         description="Error message, present on failure.",
     )
+    messages: List[BaseMessage] = Field(
+        default_factory=list,
+        description="LLM conversation messages from the agent invocation.",
+    )
+
+    @field_serializer("messages")
+    @classmethod
+    def _serialize_messages(cls, messages: List[BaseMessage]) -> list[dict]:
+        return [m.model_dump() for m in messages]
 
 
 def merge_validation_results(


### PR DESCRIPTION
## Summary

- Store LLM conversation messages for each reference validation in the workflow state
- Add a reusable `AgentMessagesDialog` component to view agent messages in a dialog
- Add a "Messages" button on each completed reference validation result that opens the dialog

## Motivation

To facilitate debugging of what's happening behind the scenes during reference validation. Similar to the Messages tab available for simple deep agents, users can now inspect the full LLM conversation (including web search tool calls) for each individual reference check.

## What's Changed

### Backend
- **`lib/workflows/reference_validation/state.py`** — Added `messages: List[BaseMessage]` field with `field_serializer` to `ReferenceValidationItem`, following the same pattern as `SimpleDeepAgentState`
- **`lib/workflows/reference_validation/nodes/reference_validation.py`** — Store the messages returned by `ReferenceValidatorAgent` in the validation item (previously captured but discarded)

### Frontend
- **`frontend/components/shared/agent-messages-dialog.tsx`** (new) — Generic reusable dialog for displaying LLM conversation messages using `ReadonlyThread` and `@assistant-ui/react`. Can be reused for other workflows
- **`frontend/components/results/tabs/reference-review/validation-results-box.tsx`** — Added "Messages" button next to "Show details" on each completed validation, opens `AgentMessagesDialog`
- **`frontend/lib/generated-api/types.gen.ts`** — Auto-regenerated to include the new `messages` field

## Risks and Mitigations

- **Increased state size**: Storing messages per reference increases the LangGraph checkpoint size. Messages are only stored on success (empty list on error), and the reference validator conversations are typically short (system prompt + reference + web search). Risk is low.
- **Backward compatibility**: The `messages` field defaults to an empty list, so existing workflow runs without messages will render correctly (the Messages button simply won't appear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)