### PR TITLE
Fix reference validator false negatives for non-existent URLs

### DIFF
--- a/evals_inspectai/e2e/reference_validation/dataset.json
+++ b/evals_inspectai/e2e/reference_validation/dataset.json
@@ -253,5 +253,10 @@
     "input": "Brandon Vigliarolo. \"Anthropic accidentally exposes Claude Code source code.\" The Register. Mar 31, 2026. https://www.theregister.com/2026/03/31/anthropic_claude_code_source_code/ (The Register, 2026)",
     "target_final_result": "found_with_inconsistencies",
     "target_answer": "The title is incorrect. The actual article headline on The Register is 'Anthropic goes nude, exposes Claude Code source by accident', not 'Anthropic accidentally exposes Claude Code source code'. The validator must use the title from the article's content body (the on-page headline), not a sanitized version from metadata tags or search snippets. Author, publisher, year, and URL are correct."
+  },
+  {
+    "input": "Microsoft Security Blog. (2024, April 1). Navigating the cyber threat landscape with AI. https://www.microsoft.com/en-us/security/blog/2024/04/01/navigating-cyber-threat-landscape-ai",
+    "target_final_result": "not_found",
+    "target_answer": "This blog post does not exist at the given URL and cannot be found via web search. The agent must not validate a reference based solely on the URL having a plausible pattern; it must verify the content actually exists by searching for the title or confirming the URL resolves to real content."
   }
 ]

--- a/lib/agents/reference_validator.py
+++ b/lib/agents/reference_validator.py
@@ -73,9 +73,12 @@ You will receive one reference item from a document's bibliography. Use web sear
 
 # Validation procedure
 
-1. Search for the reference online to find a matching legitimate source.
-2. For each field (author, title, publisher, year, identifier), compare the reference's value against what you found online.
-3. Determine whether the reference is valid overall.
+1. If the reference includes a URL, fetch that exact URL to confirm it resolves to real content. Do not assume a URL is valid just because it has a plausible domain or path structure.
+   - If the URL is live, check whether the page content matches the reference's metadata (title, author, year, etc.) and proceed with field-by-field validation.
+   - If the URL is dead (404, error page, etc.), search for the exact title to determine whether the cited work exists elsewhere. Only consider it a match if the title and authors are the same — a different work on a similar topic is not a match. If you find the exact work at a different URL, flag the URL as inconsistent. If you cannot find the exact work anywhere, the reference is `not_found`.
+2. Search for the reference online to find a matching legitimate source.
+3. For each field (author, title, publisher, year, identifier), compare the reference's value against what you found online.
+4. Determine whether the reference is valid overall.
 
 # Field validation rules
 

--- a/lib/agents/reference_validator.py
+++ b/lib/agents/reference_validator.py
@@ -75,7 +75,8 @@ You will receive one reference item from a document's bibliography. Use web sear
 
 1. If the reference includes a URL, fetch that exact URL to confirm it resolves to real content. Do not assume a URL is valid just because it has a plausible domain or path structure.
    - If the URL is live, check whether the page content matches the reference's metadata (title, author, year, etc.) and proceed with field-by-field validation.
-   - If the URL is dead (404, error page, etc.), search for the exact title to determine whether the cited work exists elsewhere. Only consider it a match if the title and authors are the same — a different work on a similar topic is not a match. If you find the exact work at a different URL, flag the URL as inconsistent. If you cannot find the exact work anywhere, the reference is `not_found`.
+   - If the reference is a bare URL with no bibliographic metadata, apply the "Bare URL references" rules below regardless of whether the URL is reachable.
+   - If the URL is dead (404, error page, etc.) and the reference includes bibliographic metadata (title, authors), search for the exact title to determine whether the cited work exists elsewhere. Only consider it a match if the title and authors are the same — a different work on a similar topic is not a match. If you find the exact work at a different URL, flag the URL as inconsistent. If you cannot find the exact work anywhere, the reference is `not_found`.
 2. Search for the reference online to find a matching legitimate source.
 3. For each field (author, title, publisher, year, identifier), compare the reference's value against what you found online.
 4. Determine whether the reference is valid overall.


### PR DESCRIPTION
## Summary

- Reference validator was marking non-existent URLs as valid based on URL pattern alone
- Updated validation prompt to require fetching/verifying URLs before trusting them
- Added eval test case for the reported false negative

## Motivation

Reported by Emily in Slack: a fabricated Microsoft Security Blog reference was marked as "valid" because the URL followed a plausible pattern, even though the blog post doesn't exist. The agent never verified the URL resolves to real content.

## What's Changed

### Backend
- **`lib/agents/reference_validator.py`** — Added URL verification step to the validation procedure: fetch the exact URL, and if dead, search for exact title/authors before concluding the work exists. A different work on a similar topic is not a match.
- **`evals_inspectai/e2e/reference_validation/dataset.json`** — Added test case for a non-existent Microsoft Security Blog reference with a plausible URL pattern.

## Risks and Mitigations

- **Risk**: The prompt change could cause the agent to be more aggressive in marking references as `not_found` when URLs are temporarily down. **Mitigation**: The instructions explicitly allow finding the exact work at a different URL and flagging just the URL as inconsistent.
- **Risk**: 1 in 5 eval runs still fails (agent matches a thematically similar but different article). **Mitigation**: This is a significant improvement from 1/5 → 4/5 correct, and the remaining case is an LLM judgment edge case.

Closes RANDZ-520

🤖 Generated with [Claude Code](https://claude.com/claude-code)