### PR TITLE
fix(workflow-runner): sync config.revision with project current revision

### DIFF
--- a/lib/api/services/workflow_runner.py
+++ b/lib/api/services/workflow_runner.py
@@ -163,6 +163,10 @@ async def start_workflow_run(
     await assert_project_has_main_file(config.project_id, project.current_revision)
 
     revision = project.current_revision
+    # Ensure the config's revision matches the project's current revision so the
+    # workflow context (and any state lookups driven by it) target the right
+    # revision. Callers of POST /api/workflows/start don't send a revision.
+    config.revision = revision
     existing_run = await get_project_workflow_run_by_type(
         config.project_id, config.type, revision=revision
     )


### PR DESCRIPTION
## Summary

- POST /api/workflows/start now overrides `config.revision` with `project.current_revision` before scheduling the background task, so the workflow context targets the correct revision.

## Motivation

Clients of `POST /api/workflows/start` (e.g. the References tab's "Fetch from web" action in `frontend/components/results/tabs/reference-review/mutations.ts`) don't send a `revision`, so `WorkflowConfig.revision` defaulted to `1` (`lib/workflows/models.py:58-61`). `start_workflow_run` correctly read `revision = project.current_revision` and saved that onto the `workflow_runs` row, but passed the untouched `config` (still revision `1`) to `run_workflow_with_dependency_check`. That stale revision flowed into `ContextSchema.revision` via `create_context`, and nodes that read `runtime.context.revision` hit the wrong revision's workflow state.

Concrete failure observed on a revision-4 project: the reference downloader successfully downloaded and promoted 7 supporting files, but every call to `add_file_to_reference` warned `Invalid reference_id … for project …` and returned `False`. `_get_extraction_workflow_state` loaded revision 1's extracted references (different UUIDs than revision 4's), so the guard `if reference_id not in valid_ids` fired for every reference and no file↔reference matches were persisted. The Files tab showed the downloads; the References tab showed nothing linked.

The start-multiple path is unaffected because it goes through `create_workflow_config`, which already sets `revision` from `project.current_revision` (`lib/workflows/config_factory.py:43`). This was likely overlooked when the revisions feature landed (commit `9f4fb1a0 feat(revisions): add revision system for main document replacement`).

## What's Changed

### Backend

- `lib/api/services/workflow_runner.py` — In `start_workflow_run`, overwrite `config.revision = revision` before creating the run record and scheduling the background task. Also adds an explanatory comment about why this is necessary for callers that don't send a revision.

### Frontend

- No changes.

## Risks and Mitigations

- **Overrides a client-provided `revision`.** Today no client sends one, and conceptually the workflow should always run against the project's current revision, so silently ignoring a client-supplied revision is the desired behavior. A follow-up could remove `revision` from `BaseWorkflowConfig` entirely so it can't be client-specified; out of scope for this fix.
- **Only fixes newly started workflows.** Previously affected projects (like the one that surfaced this bug) will need their reference matches replayed manually or by re-running the downloader after this lands. Not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)