### PR TITLE
feat(logging): log LLM and embedding errors with model, provider, and endpoint (RANDZ-514)

### DIFF
--- a/lib/config/llm_error_logger.py
+++ b/lib/config/llm_error_logger.py
@@ -1,0 +1,350 @@
+"""Structured logging for LLM (chat + embeddings) errors.
+
+Emits grep-friendly single-line log records when an LLM or embeddings call
+fails, including the agent/caller name, model, provider, and — when it can be
+discovered from metadata — the API endpoint. Rate-limit (HTTP 429) failures
+use a distinct `LLM_RATE_LIMIT` prefix so they can be isolated with a simple
+`grep '^LLM_RATE_LIMIT'`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Optional
+from uuid import UUID
+
+from langchain_core.callbacks import BaseCallbackHandler
+
+if TYPE_CHECKING:
+    # Imported only for typing to avoid a circular import:
+    # lib.workflows.context -> lib.services.vector_store -> lib.config.llm_error_logger.
+    # At runtime we duck-type access to context.workflow_run_id / context.project_id.
+    from lib.workflows.context import ContextSchema
+
+logger = logging.getLogger(__name__)
+
+_RATE_LIMIT_PREFIX = "LLM_RATE_LIMIT"
+_GENERIC_ERROR_PREFIX = "LLM_ERROR"
+
+# Attribute names used by common LangChain chat/embeddings classes to hold
+# the provider base URL. Checked in order; the first non-empty value wins.
+_ENDPOINT_ATTRS = ("openai_api_base", "anthropic_api_url", "base_url")
+
+_UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class _CallMetadata:
+    """Metadata captured at LLM call start, consumed at error/end time.
+
+    The callback receives `serialized` + `metadata` + `tags` only on
+    `on_chat_model_start` / `on_llm_start` — not on `on_llm_error` — so we
+    cache what we need keyed by the call's `run_id`.
+    """
+
+    agent_name: str
+    model_name: str
+    provider: str
+    endpoint: Optional[str]
+
+
+def _is_rate_limit_error(error: BaseException) -> bool:
+    """Return True if the given exception looks like a provider 429.
+
+    Works across OpenAI/Anthropic SDKs (both set `status_code=429` on their
+    `RateLimitError` subclasses) and any other httpx-style error that exposes
+    a `status_code` attribute.
+    """
+    return getattr(error, "status_code", None) == 429
+
+
+def _flatten_message(error: BaseException) -> str:
+    """Return a grep-friendly, single-line error message.
+
+    Newlines and double quotes are replaced so the `message="..."` field
+    stays parseable by simple `grep`/`awk` pipelines, but the full text is
+    preserved.
+    """
+    return str(error).replace("\n", " ").replace('"', "'").strip()
+
+
+def _status_code(error: BaseException) -> str:
+    code = getattr(error, "status_code", None)
+    return str(code) if code is not None else "-"
+
+
+def _endpoint_from_obj(obj: Any) -> Optional[str]:
+    """Try to read a base URL / endpoint string off a chat model or embeddings
+    client. Returns None if no known attribute is set."""
+    if obj is None:
+        return None
+    for attr in _ENDPOINT_ATTRS:
+        value = getattr(obj, attr, None)
+        if value:
+            return str(value)
+    # Some LangChain wrappers expose the underlying SDK client; check its base_url.
+    client = getattr(obj, "client", None) or getattr(obj, "_client", None)
+    if client is not None:
+        base_url = getattr(client, "base_url", None)
+        if base_url:
+            return str(base_url)
+    return None
+
+
+def _endpoint_from_error(error: BaseException) -> Optional[str]:
+    """Try to read the request URL off an httpx-style error's response."""
+    response = getattr(error, "response", None)
+    if response is None:
+        return None
+    request = getattr(response, "request", None)
+    if request is None:
+        return None
+    url = getattr(request, "url", None)
+    return str(url) if url else None
+
+
+def _endpoint_from_serialized(
+    serialized: Optional[dict[str, Any]], extra_kwargs: dict[str, Any]
+) -> Optional[str]:
+    """Pull a base URL out of LangChain's `serialized` dict or the
+    `invocation_params` kwarg passed alongside `on_(chat_model|llm)_start`."""
+    candidates: list[dict[str, Any]] = []
+    if isinstance(serialized, dict):
+        inner = serialized.get("kwargs")
+        if isinstance(inner, dict):
+            candidates.append(inner)
+    invocation_params = extra_kwargs.get("invocation_params")
+    if isinstance(invocation_params, dict):
+        candidates.append(invocation_params)
+    for candidate in candidates:
+        for attr in _ENDPOINT_ATTRS:
+            value = candidate.get(attr)
+            if value:
+                return str(value)
+    return None
+
+
+def _agent_name_from_metadata(
+    metadata: Optional[dict[str, Any]], tags: Optional[list[str]]
+) -> str:
+    """Derive a meaningful "agent" label for the log line.
+
+    LangGraph injects `langgraph_node` into the runnable metadata, which is
+    the most useful identifier from the runner's perspective — it tells the
+    operator which workflow stage was running when the call failed. Falls
+    back to other hints before giving up.
+    """
+    if metadata:
+        node = metadata.get("langgraph_node")
+        if node:
+            return str(node)
+    if tags:
+        for tag in tags:
+            if tag.startswith("graph:node:"):
+                return tag.removeprefix("graph:node:")
+    return _UNKNOWN
+
+
+def _format_log_line(
+    *,
+    is_rate_limit: bool,
+    caller: str,
+    model_name: str,
+    provider: str,
+    endpoint: Optional[str],
+    workflow_run_id: Optional[str],
+    project_id: Optional[str],
+    status: str,
+    error_type: str,
+    message: str,
+) -> str:
+    """Build a single-line `PREFIX key=value …` record.
+
+    Fields with no value are rendered as `-` so the column layout is stable
+    (helpful for `awk`). The `endpoint` field is omitted entirely when we
+    couldn't discover a value — we prefer omission over guessing.
+    """
+    prefix = _RATE_LIMIT_PREFIX if is_rate_limit else _GENERIC_ERROR_PREFIX
+    parts = [
+        prefix,
+        f"agent={caller or _UNKNOWN}",
+        f"model={model_name or _UNKNOWN}",
+        f"provider={provider or '-'}",
+    ]
+    if endpoint:
+        parts.append(f"endpoint={endpoint}")
+    parts.extend(
+        [
+            f"workflow_run_id={workflow_run_id or '-'}",
+            f"project_id={project_id or '-'}",
+            f"status={status}",
+            f"error_type={error_type}",
+            f'message="{message}"',
+        ]
+    )
+    return " ".join(parts)
+
+
+def _emit(line: str, *, is_rate_limit: bool) -> None:
+    if is_rate_limit:
+        logger.warning(line)
+    else:
+        logger.error(line)
+
+
+class ErrorLoggingCallback(BaseCallbackHandler):
+    """LangChain callback that logs LLM errors with model/endpoint context.
+
+    Designed to be attached once per workflow run (in `lib/workflows/runner.py`),
+    next to the langfuse handler. The callback derives model, provider,
+    endpoint, and the workflow stage ("agent") dynamically from each call's
+    metadata — it doesn't need per-agent wiring.
+
+    The workflow context (workflow_run_id, project_id) is bound at
+    construction time because it's stable for the duration of a single
+    workflow execution.
+    """
+
+    def __init__(
+        self,
+        *,
+        workflow_run_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+    ) -> None:
+        self._workflow_run_id = workflow_run_id
+        self._project_id = project_id
+        # Per-call metadata captured at start, consumed at error/end.
+        # Bounded — entries removed in on_llm_end / on_llm_error.
+        self._calls: dict[UUID, _CallMetadata] = {}
+
+    # --- start hooks: capture metadata keyed by run_id -------------------
+
+    def on_chat_model_start(
+        self,
+        serialized: dict[str, Any],
+        messages: Any,  # list[list[BaseMessage]] — typing loose to avoid import
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._calls[run_id] = self._build_metadata(
+            serialized=serialized, tags=tags, metadata=metadata, extra_kwargs=kwargs
+        )
+
+    def on_llm_start(
+        self,
+        serialized: dict[str, Any],
+        prompts: list[str],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[list[str]] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._calls[run_id] = self._build_metadata(
+            serialized=serialized, tags=tags, metadata=metadata, extra_kwargs=kwargs
+        )
+
+    @staticmethod
+    def _build_metadata(
+        *,
+        serialized: dict[str, Any],
+        tags: Optional[list[str]],
+        metadata: Optional[dict[str, Any]],
+        extra_kwargs: dict[str, Any],
+    ) -> _CallMetadata:
+        # LangChain populates `metadata["ls_model_name"]` and
+        # `metadata["ls_provider"]` for all chat models via LangSmithParams.
+        model_name = (metadata or {}).get("ls_model_name") or _UNKNOWN
+        provider = (metadata or {}).get("ls_provider") or ""
+        endpoint = _endpoint_from_serialized(serialized, extra_kwargs)
+        return _CallMetadata(
+            agent_name=_agent_name_from_metadata(metadata, tags),
+            model_name=str(model_name),
+            provider=str(provider),
+            endpoint=endpoint,
+        )
+
+    # --- end / error hooks: consume cached metadata ----------------------
+
+    def on_llm_end(
+        self,
+        response: Any,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        # Successful call — drop the cached metadata to avoid unbounded growth.
+        self._calls.pop(run_id, None)
+
+    def on_llm_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[list[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        meta = self._calls.pop(run_id, None)
+        is_rate_limit = _is_rate_limit_error(error)
+        line = _format_log_line(
+            is_rate_limit=is_rate_limit,
+            caller=meta.agent_name if meta else _UNKNOWN,
+            model_name=meta.model_name if meta else _UNKNOWN,
+            provider=meta.provider if meta else "",
+            endpoint=(meta.endpoint if meta else None) or _endpoint_from_error(error),
+            workflow_run_id=self._workflow_run_id,
+            project_id=self._project_id,
+            status=_status_code(error),
+            error_type=type(error).__name__,
+            message=_flatten_message(error),
+        )
+        _emit(line, is_rate_limit=is_rate_limit)
+
+
+def log_embedding_error(
+    error: BaseException,
+    *,
+    caller: str,
+    model: str,
+    provider: str,
+    embeddings_client: Any = None,
+    context: Optional[ContextSchema] = None,
+) -> None:
+    """Log an error from an embeddings call in the same format as chat errors.
+
+    Unlike chat models, embeddings calls in this codebase don't run through a
+    LangChain callback (they're invoked directly from `vector_store.py` and
+    `reference_embedding_matcher.py`). This helper is called from the
+    `except` block of those call sites.
+    """
+    is_rate_limit = _is_rate_limit_error(error)
+    endpoint = _endpoint_from_obj(embeddings_client) or _endpoint_from_error(error)
+    line = _format_log_line(
+        is_rate_limit=is_rate_limit,
+        caller=caller,
+        model_name=model,
+        provider=provider,
+        endpoint=endpoint,
+        workflow_run_id=(
+            str(context.workflow_run_id)
+            if context is not None and getattr(context, "workflow_run_id", None)
+            else None
+        ),
+        project_id=(
+            str(context.project_id)
+            if context is not None and getattr(context, "project_id", None)
+            else None
+        ),
+        status=_status_code(error),
+        error_type=type(error).__name__,
+        message=_flatten_message(error),
+    )
+    _emit(line, is_rate_limit=is_rate_limit)

--- a/lib/services/reference_embedding_matcher.py
+++ b/lib/services/reference_embedding_matcher.py
@@ -10,7 +10,8 @@ from typing import List, Optional
 import numpy as np
 from pydantic import BaseModel
 
-from lib.config.llm_models import init_embeddings
+from lib.config.llm_error_logger import log_embedding_error
+from lib.config.llm_models import EMBEDDING_MODEL_LARGE, init_embeddings
 from lib.config.rate_limiter import get_rate_limiter, hash_api_key
 from lib.workflows.document_summarization.state import FileSummary
 
@@ -72,7 +73,17 @@ class ReferenceEmbeddingMatcher:
         logger.info(f"Embedding {len(texts)} document summaries")
 
         await self._rate_limiter.aacquire()
-        vectors = await self._embeddings.aembed_documents(texts)
+        try:
+            vectors = await self._embeddings.aembed_documents(texts)
+        except Exception as e:
+            log_embedding_error(
+                e,
+                caller="reference_embedding_matcher.index_summaries",
+                model=EMBEDDING_MODEL_LARGE,
+                provider="openai",
+                embeddings_client=self._embeddings,
+            )
+            raise
         # We need to pre-normalize during indexing to avoid repeated computation
         self._doc_embeddings_normalized = _normalize(np.array(vectors))
 
@@ -96,7 +107,17 @@ class ReferenceEmbeddingMatcher:
 
         logger.info(f"Embedding {len(reference_texts)} reference texts")
         await self._rate_limiter.aacquire()
-        ref_vectors = await self._embeddings.aembed_documents(reference_texts)
+        try:
+            ref_vectors = await self._embeddings.aembed_documents(reference_texts)
+        except Exception as e:
+            log_embedding_error(
+                e,
+                caller="reference_embedding_matcher.find_candidates",
+                model=EMBEDDING_MODEL_LARGE,
+                provider="openai",
+                embeddings_client=self._embeddings,
+            )
+            raise
         ref_normalized = _normalize(np.array(ref_vectors))
 
         # We need to compute cosine similarity via dot product of normalized vectors: (num_refs, num_docs) to return the correct similarity scores

--- a/lib/services/vector_store.py
+++ b/lib/services/vector_store.py
@@ -9,7 +9,8 @@ from langchain_text_splitters import Language, RecursiveCharacterTextSplitter
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from lib.config.llm_models import init_embeddings
+from lib.config.llm_error_logger import log_embedding_error
+from lib.config.llm_models import EMBEDDING_MODEL_LARGE, init_embeddings
 from lib.config.rate_limiter import get_rate_limiter, hash_api_key
 
 logger = logging.getLogger(__name__)
@@ -195,7 +196,17 @@ class VectorStoreService:
 
         vectorstore = self._get_vectorstore(collection_id)
         await self._rate_limiter.aacquire()
-        results = await vectorstore.asimilarity_search(query="", k=1)
+        try:
+            results = await vectorstore.asimilarity_search(query="", k=1)
+        except Exception as e:
+            log_embedding_error(
+                e,
+                caller="vector_store.is_collection_indexed",
+                model=EMBEDDING_MODEL_LARGE,
+                provider="openai",
+                embeddings_client=self.embeddings,
+            )
+            raise
         return len(results) > 0
 
     async def index_document(
@@ -220,7 +231,17 @@ class VectorStoreService:
                 batch_end = min(batch_start + EMBEDDING_BATCH_SIZE, total_docs)
                 batch = docs[batch_start:batch_end]
                 await self._rate_limiter.aacquire()
-                await vectorstore.aadd_documents(batch)
+                try:
+                    await vectorstore.aadd_documents(batch)
+                except Exception as e:
+                    log_embedding_error(
+                        e,
+                        caller="vector_store.index_document",
+                        model=EMBEDDING_MODEL_LARGE,
+                        provider="openai",
+                        embeddings_client=self.embeddings,
+                    )
+                    raise
                 logger.debug(
                     f"Indexed batch {batch_start}-{batch_end} of {total_docs} chunks"
                 )
@@ -248,7 +269,19 @@ class VectorStoreService:
             vectorstore = self._get_vectorstore(collection_id)
 
             await self._rate_limiter.aacquire()
-            results = await vectorstore.asimilarity_search_with_score(query, k=top_k)
+            try:
+                results = await vectorstore.asimilarity_search_with_score(
+                    query, k=top_k
+                )
+            except Exception as e:
+                log_embedding_error(
+                    e,
+                    caller="vector_store.retrieve_relevant_passages",
+                    model=EMBEDDING_MODEL_LARGE,
+                    provider="openai",
+                    embeddings_client=self.embeddings,
+                )
+                raise
 
             logger.info(
                 f"Retrieved {len(results)} passages from collection {collection_id} "

--- a/lib/workflows/runner.py
+++ b/lib/workflows/runner.py
@@ -8,6 +8,7 @@ from langgraph.graph.state import CompiledStateGraph
 from lib.services.workflow_orchestration import wait_for_dependencies
 from lib.config.env import config as env_config
 from lib.config.langfuse import langfuse_handler
+from lib.config.llm_error_logger import ErrorLoggingCallback
 from lib.models.user import User
 from lib.models.workflow_run import WorkflowRunStatus, WorkflowRunType
 from lib.services.file_artifacts_service.file_artifacts_service import (
@@ -124,11 +125,16 @@ async def run_workflow(
     # Mark as RUNNING
     await update_workflow_run_status(workflow_run_id, WorkflowRunStatus.RUNNING)
 
+    error_logging_callback = ErrorLoggingCallback(
+        workflow_run_id=workflow_run_id,
+        project_id=project_id,
+    )
+
     async with get_checkpointer() as checkpointer:
         app = graph.compile(checkpointer=checkpointer).with_config(
             {
                 "run_name": f"{workflow_type.value}",
-                "callbacks": [langfuse_handler],
+                "callbacks": [langfuse_handler, error_logging_callback],
                 "metadata": {"langfuse_session_id": project_id},
                 "max_concurrency": env_config.LANGGRAPH_MAX_CONCURRENCY,
             }

--- a/tests/unit/test_llm_error_logger.py
+++ b/tests/unit/test_llm_error_logger.py
@@ -1,0 +1,348 @@
+"""Tests for the LLM error logger (ErrorLoggingCallback + log_embedding_error).
+
+Covers:
+- 429 detection across openai/anthropic SDKs and via fallback `status_code` attr.
+- Distinct `LLM_RATE_LIMIT` vs `LLM_ERROR` prefix selection.
+- Per-call metadata captured at `on_chat_model_start` and consumed at
+  `on_llm_error`, including agent name from `metadata.langgraph_node`.
+- Endpoint discovery from serialized LLM kwargs / fallback to error response.
+- Cleanup on `on_llm_end` so the per-call cache stays bounded.
+- The `log_embedding_error` helper format.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import anthropic
+import httpx
+import openai
+import pytest
+
+from lib.config.llm_error_logger import (
+    ErrorLoggingCallback,
+    log_embedding_error,
+)
+from lib.services.file_artifacts_service.file_artifacts_service_type import (
+    FileArtifactsServiceType,
+)
+from lib.workflows.context import ContextSchema
+
+_LOGGER_NAME = "lib.config.llm_error_logger"
+
+
+def _make_context() -> ContextSchema:
+    """Minimal ContextSchema for tests."""
+    return ContextSchema(
+        project_id="proj-123",
+        workflow_run_id="run-456",
+        file_artifacts_service=MagicMock(spec=FileArtifactsServiceType),
+    )
+
+
+def _make_response(
+    status_code: int, url: str = "https://api.example.com/v1/x"
+) -> httpx.Response:
+    request = httpx.Request("POST", url)
+    return httpx.Response(status_code=status_code, request=request)
+
+
+def _make_openai_rate_limit_error() -> openai.RateLimitError:
+    response = _make_response(429, "https://api.openai.com/v1/chat/completions")
+    return openai.RateLimitError(message="rate limited", response=response, body=None)
+
+
+def _make_anthropic_rate_limit_error() -> anthropic.RateLimitError:
+    response = _make_response(429, "https://api.anthropic.com/v1/messages")
+    return anthropic.RateLimitError(
+        message="rate limited", response=response, body=None
+    )
+
+
+def _make_callback() -> ErrorLoggingCallback:
+    return ErrorLoggingCallback(
+        workflow_run_id="run-456",
+        project_id="proj-123",
+    )
+
+
+def _start_chat_model(
+    callback: ErrorLoggingCallback,
+    *,
+    run_id: UUID,
+    node: str = "extract_claims",
+    model_name: str = "gpt-5-mini",
+    provider: str = "openai",
+    base_url: str | None = None,
+) -> None:
+    """Drive the standard `on_chat_model_start` invocation that LangChain
+    fires before every chat-model call. Mirrors the metadata LangChain core
+    populates via LangSmithParams, plus LangGraph's `langgraph_node` key."""
+    metadata: dict[str, Any] = {
+        "ls_model_name": model_name,
+        "ls_provider": provider,
+        "ls_model_type": "chat",
+        "langgraph_node": node,
+    }
+    serialized: dict[str, Any] = {"id": ["langchain", "ChatOpenAI"], "kwargs": {}}
+    if base_url is not None:
+        serialized["kwargs"]["openai_api_base"] = base_url
+    callback.on_chat_model_start(
+        serialized,
+        messages=[],
+        run_id=run_id,
+        metadata=metadata,
+        tags=[],
+    )
+
+
+def _last_log_record(caplog: pytest.LogCaptureFixture) -> logging.LogRecord:
+    records = [r for r in caplog.records if r.name == _LOGGER_NAME]
+    assert records, "Expected at least one log record from the llm error logger"
+    return records[-1]
+
+
+def test_callback_logs_rate_limit_with_429_prefix(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    callback = _make_callback()
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id, node="reference_validator")
+    callback.on_llm_error(_make_openai_rate_limit_error(), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    assert record.levelno == logging.WARNING
+    assert record.message.startswith("LLM_RATE_LIMIT ")
+    assert "agent=reference_validator" in record.message
+    assert "model=gpt-5-mini" in record.message
+    assert "provider=openai" in record.message
+    assert "status=429" in record.message
+    assert "workflow_run_id=run-456" in record.message
+    assert "project_id=proj-123" in record.message
+
+
+def test_callback_logs_other_errors_with_generic_prefix(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    callback = _make_callback()
+    caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id)
+    callback.on_llm_error(TimeoutError("read timed out"), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    assert record.levelno == logging.ERROR
+    assert record.message.startswith("LLM_ERROR ")
+    assert "error_type=TimeoutError" in record.message
+    assert "status=-" in record.message
+    assert 'message="read timed out"' in record.message
+
+
+def test_callback_detects_anthropic_rate_limit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    callback = _make_callback()
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(
+        callback,
+        run_id=run_id,
+        model_name="claude-sonnet-4-5",
+        provider="anthropic",
+    )
+    callback.on_llm_error(_make_anthropic_rate_limit_error(), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    assert record.message.startswith("LLM_RATE_LIMIT ")
+    assert "model=claude-sonnet-4-5" in record.message
+    assert "provider=anthropic" in record.message
+    assert "status=429" in record.message
+    assert "error_type=RateLimitError" in record.message
+
+
+def test_callback_detects_429_via_status_code_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An exception type unknown to us is still recognized as a rate limit
+    when it carries `status_code=429`."""
+
+    class _FakeError(Exception):
+        status_code = 429
+
+    callback = _make_callback()
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id)
+    callback.on_llm_error(_FakeError("throttled"), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    assert record.message.startswith("LLM_RATE_LIMIT ")
+    assert "status=429" in record.message
+
+
+def test_callback_includes_endpoint_when_in_serialized(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When `serialized.kwargs` carries a base_url, it shows up as endpoint=."""
+    callback = _make_callback()
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(
+        callback, run_id=run_id, base_url="https://api.openai.com/v1"
+    )
+    callback.on_llm_error(_make_openai_rate_limit_error(), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    assert "endpoint=https://api.openai.com/v1" in record.message
+
+
+def test_callback_falls_back_to_endpoint_from_error_response(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When serialized has no base_url, the error's response.request.url
+    should be used as the endpoint."""
+    callback = _make_callback()
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id, base_url=None)
+    callback.on_llm_error(_make_openai_rate_limit_error(), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    assert "endpoint=https://api.openai.com/v1/chat/completions" in record.message
+
+
+def test_callback_omits_endpoint_when_not_discoverable(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No `endpoint=` field when nothing in serialized or the error reveals one."""
+    callback = _make_callback()
+    caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id, base_url=None)
+    # A plain TimeoutError has no response/request — nothing to discover.
+    callback.on_llm_error(TimeoutError("nope"), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    assert "endpoint=" not in record.message
+
+
+def test_callback_uses_unknown_when_metadata_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Errors without a preceding on_chat_model_start (e.g. start was missed
+    or the call originated outside the graph) still get logged with placeholders
+    rather than crashing."""
+    callback = _make_callback()
+    caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
+
+    callback.on_llm_error(TimeoutError("orphan"), run_id=uuid4())
+
+    record = _last_log_record(caplog)
+    assert record.message.startswith("LLM_ERROR ")
+    assert "agent=unknown" in record.message
+    assert "model=unknown" in record.message
+
+
+def test_callback_releases_metadata_on_llm_end() -> None:
+    """on_llm_end clears the per-call cache so it doesn't grow unbounded
+    across a long-running workflow."""
+    callback = _make_callback()
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id)
+    assert run_id in callback._calls
+
+    callback.on_llm_end(response=MagicMock(), run_id=run_id)
+    assert run_id not in callback._calls
+
+
+def test_callback_releases_metadata_on_llm_error() -> None:
+    """on_llm_error also clears the per-call cache (errors and successes both
+    terminate the call)."""
+    callback = _make_callback()
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id)
+    assert run_id in callback._calls
+
+    callback.on_llm_error(TimeoutError("x"), run_id=run_id)
+    assert run_id not in callback._calls
+
+
+def test_log_embedding_error_helper_format(caplog: pytest.LogCaptureFixture) -> None:
+    fake_embeddings = MagicMock(spec=["openai_api_base"])
+    fake_embeddings.openai_api_base = "https://api.openai.com/v1"
+    caplog.set_level(logging.WARNING, logger=_LOGGER_NAME)
+
+    log_embedding_error(
+        _make_openai_rate_limit_error(),
+        caller="vector_store.index_document",
+        model="text-embedding-3-large",
+        provider="openai",
+        embeddings_client=fake_embeddings,
+        context=_make_context(),
+    )
+
+    record = _last_log_record(caplog)
+    assert record.message.startswith("LLM_RATE_LIMIT ")
+    assert "agent=vector_store.index_document" in record.message
+    assert "model=text-embedding-3-large" in record.message
+    assert "provider=openai" in record.message
+    assert "endpoint=https://api.openai.com/v1" in record.message
+    assert "status=429" in record.message
+    assert "workflow_run_id=run-456" in record.message
+    assert "project_id=proj-123" in record.message
+
+
+def test_log_embedding_error_handles_missing_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """vector_store doesn't currently hold a ContextSchema — log line should
+    still be emitted, with workflow_run_id=- and project_id=- placeholders."""
+    caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
+
+    log_embedding_error(
+        TimeoutError("oops"),
+        caller="vector_store.is_collection_indexed",
+        model="text-embedding-3-large",
+        provider="openai",
+        embeddings_client=None,
+        context=None,
+    )
+
+    record = _last_log_record(caplog)
+    assert record.message.startswith("LLM_ERROR ")
+    assert "workflow_run_id=-" in record.message
+    assert "project_id=-" in record.message
+
+
+def test_message_is_flattened_to_single_line_without_truncation(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Multi-line messages are flattened to one line (so each log record stays
+    a single grep-friendly line) but the full text is preserved."""
+    callback = _make_callback()
+    caplog.set_level(logging.ERROR, logger=_LOGGER_NAME)
+
+    run_id = uuid4()
+    _start_chat_model(callback, run_id=run_id)
+
+    long_payload = "x" * 500
+    long_message = f"boom\nwith newlines and {long_payload}"
+    callback.on_llm_error(RuntimeError(long_message), run_id=run_id)
+
+    record = _last_log_record(caplog)
+    # Only one line per log record (newlines flattened to spaces).
+    assert "\n" not in record.message
+    # Full payload retained — nothing dropped or truncated.
+    assert long_payload in record.message
+    assert "with newlines and" in record.message


### PR DESCRIPTION
## Summary

- Emits a single grep-friendly log line for every failed chat-model or embedding call, including `model`, `provider`, `endpoint`, workflow stage, and workflow/project IDs.
- Rate-limit (HTTP 429) errors get a distinct `LLM_RATE_LIMIT` prefix so they can be isolated with `grep '^LLM_RATE_LIMIT'`.
- Chat-model logging is attached once at the workflow runner (next to the langfuse handler); embeddings use a small helper at their call sites.

## Motivation

Linear: [RANDZ-514](https://linear.app/ae-studio/issue/RANDZ-514/rate-limit-include-model-and-api-endpoint-in-rate-limit-error-logs).

~1,400 rate-limit errors were being pulled from the logs last week to track throttling, but today's log lines only surface the agent, not the **model** or **endpoint** being throttled. That forces a code lookup to know which model needs a dedicated API key or quota bump — a prerequisite for the upcoming per-model key work (JC's dedicated key for mini models) and ongoing triage of blocked reviews.

The codebase doesn't currently catch or log LLM 429s itself — those errors come from the OpenAI SDK's internal retry logger. This PR starts logging LLM errors explicitly with structured context, with rate-limit errors tagged distinctly so existing grep workflows keep working.

## What's Changed

### Backend

- **`lib/config/llm_error_logger.py`** (new) — `ErrorLoggingCallback` (a `BaseCallbackHandler`) + `log_embedding_error` helper. The callback caches per-call metadata (model, provider, endpoint, LangGraph node) keyed by `run_id` on `on_chat_model_start` / `on_llm_start`, consumes it on `on_llm_error`, and clears it on `on_llm_end` so the cache stays bounded. 429 detection is SDK-agnostic (`getattr(error, "status_code", None) == 429`). Endpoint is read from LangChain's serialized LLM kwargs with a fallback to the error's `response.request.url`; omitted from the log line when nothing is discoverable.
- **`lib/workflows/runner.py`** — attaches the `ErrorLoggingCallback` once per workflow run next to `langfuse_handler`, bound to `workflow_run_id` and `project_id`. Single attachment point; catches every chat-model call inside the graph without per-agent wiring.
- **`lib/services/vector_store.py`** — wraps each of the 3 embedding call sites (`is_collection_indexed`, `index_document`, `retrieve_relevant_passages`) in a try/except that calls `log_embedding_error(...)` and re-raises. Embeddings don't flow through the LangChain runnable system, so they need explicit logging.
- **`lib/services/reference_embedding_matcher.py`** — same pattern for the 2 embedding call sites (`index_summaries`, `find_candidates`).

### Tests

- **`tests/unit/test_llm_error_logger.py`** (new) — 13 tests covering 429 detection (OpenAI, Anthropic, status_code fallback), prefix selection (`LLM_RATE_LIMIT` vs `LLM_ERROR`), endpoint discovery (from serialized kwargs, from error response, omitted when absent), agent-name extraction from `metadata.langgraph_node`, `unknown` fallbacks for orphan errors, cleanup on `on_llm_end` / `on_llm_error`, and the embeddings helper format.
- Full unit suite: 421 passed, 3 skipped, no regressions.

### Log format

Rate limits:

```
LLM_RATE_LIMIT agent=verify_claims model=gpt-5-mini provider=openai endpoint=https://api.openai.com/v1 workflow_run_id=<id> project_id=<id> status=429 error_type=RateLimitError message="Rate limit reached..."
```

Other errors:

```
LLM_ERROR agent=extract_claims model=gpt-5 provider=openai endpoint=https://api.openai.com/v1 workflow_run_id=<id> project_id=<id> status=504 error_type=APIStatusError message="..."
```

## Risks and Mitigations

- **Behaviour change in the `agent=` field.** Chat-model logs now carry the **LangGraph node name** (e.g. `verify_claims`) rather than the agent class label (e.g. `Reference Validator`). This is more useful for stage-level triage, but downstream scripts keyed on the old label need updating. Flagged explicitly on the Linear ticket for Dulani.
- **Coverage gap outside the runner.** Any chat-model call that doesn't flow through `app.astream(...)` (eval flows, ad-hoc scripts, MCP tools) won't trigger the callback; those lines will show `agent=unknown` when called via the runner, and won't log at all when executed fully outside it. Acceptable since the operational logs in scope come from the running app.
- **Per-call metadata cache growth.** The callback stores metadata per `run_id` between start and end/error. Mitigated by popping entries in both `on_llm_end` and `on_llm_error`; the cache is bounded by the number of in-flight chat-model calls at any instant.
- **Pre-existing in-memory rate limiter multi-worker issue** and **per-model API keys** remain out of scope and tracked as separate tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)