### PR TITLE
chore(workflows): reorder analysis categories per RANDZ-516

### DIFF
--- a/lib/workflows/categories.py
+++ b/lib/workflows/categories.py
@@ -21,23 +21,6 @@ class CategoryConfig(NamedTuple):
 
 WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
     CategoryConfig(
-        slug="language",
-        label="Language",
-        workflows=[
-            WorkflowRunType.ADVOCACY_TONE,
-        ],
-    ),
-    CategoryConfig(
-        slug="technical_compliance",
-        label="Technical Compliance",
-        workflows=[
-            WorkflowRunType.ABBREVIATION_SCAN_V2,
-            WorkflowRunType.ABOUT_THIS_GER,
-            WorkflowRunType.DOCUMENT_STRUCTURE,
-            WorkflowRunType.FIGURES_TABLES_CHECK,
-        ],
-    ),
-    CategoryConfig(
         slug="citation_check",
         label="Citation Check",
         workflows=[
@@ -53,6 +36,23 @@ WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
             WorkflowRunType.METHODOLOGICAL_ALIGNMENT,
             WorkflowRunType.RESULTS_EXTRACTION,
             WorkflowRunType.REVIEWER_2,
+        ],
+    ),
+    CategoryConfig(
+        slug="technical_compliance",
+        label="Technical Compliance",
+        workflows=[
+            WorkflowRunType.ABBREVIATION_SCAN_V2,
+            WorkflowRunType.ABOUT_THIS_GER,
+            WorkflowRunType.DOCUMENT_STRUCTURE,
+            WorkflowRunType.FIGURES_TABLES_CHECK,
+        ],
+    ),
+    CategoryConfig(
+        slug="language",
+        label="Language",
+        workflows=[
+            WorkflowRunType.ADVOCACY_TONE,
         ],
     ),
     CategoryConfig(


### PR DESCRIPTION
## Summary

- Reorder the analysis categories to match the ordering specified in [RANDZ-516](https://linear.app/ae-studio/issue/RANDZ-516/analysis-type-ordering-citation-check-substantive-review-technical): **Citation Check → Substantive Review → Technical Compliance → Language**.
- Research & Writing Assistant is not mentioned in the ticket and is kept at the end.

## Motivation

RAND wants the analysis categories presented in a specific order that reflects their review priority: citation checks first, then substantive review, then technical compliance, then language.

## What's Changed

### Backend

- `lib/workflows/categories.py` — reorder the entries in `WORKFLOW_DISPLAY_CONFIG`. This file is the single source of truth for category ordering; the `/api/workflow-types` endpoint, the workflow-type selector UI, and the health-monitor dashboard all derive their order from this list, so no other changes are needed. Workflow ordering *within* each category is unchanged.

### Frontend

- None.

## Risks and Mitigations

- **Risk:** UI surfaces that cache the category order could briefly show the old ordering until reloaded. **Mitigation:** order is fetched on each page load via `/api/workflow-types`; no client-side persistent cache to invalidate.
- **Risk:** Tests that assert specific category order could fail. **Mitigation:** change is contained to a display-only config; no tests reference the order explicitly (none found touching `WORKFLOW_DISPLAY_CONFIG` ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)