### PR TITLE
chore(api): remove revision from workflow start inputs [RANDZ-524]

### DIFF
--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -97,12 +97,6 @@ export type AbbreviationScanV2Config = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'abbreviation_scan_v2';
@@ -189,12 +183,6 @@ export type AboutThisGerConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -340,12 +328,6 @@ export type AdvocacyToneWorkflowConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -746,12 +728,6 @@ export type ChunkSplittingWorkflowConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'chunk_splitting';
@@ -839,12 +815,6 @@ export type CitationDetectionConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -972,12 +942,6 @@ export type CitationSuggesterWorkflowConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -1214,12 +1178,6 @@ export type ClaimExtractionWorkflowConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'claim_extraction';
@@ -1362,12 +1320,6 @@ export type ClaimReferenceValidationWorkflowConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -1593,12 +1545,6 @@ export type DocumentProcessingWorkflowConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'document_processing';
@@ -1759,12 +1705,6 @@ export type DocumentSummarizationWorkflowConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -2428,12 +2368,6 @@ export type FootnoteExtractionConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'footnote_extraction';
@@ -2568,12 +2502,6 @@ export type HumanApprovalConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   type?: WorkflowRunType;
 };
 
@@ -2729,12 +2657,6 @@ export type InferenceValidationV2WorkflowConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -3095,12 +3017,6 @@ export type LiteratureReviewWorkflowConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'literature_review';
@@ -3177,12 +3093,6 @@ export type LiveReportsWorkflowConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -3289,12 +3199,6 @@ export type MethodologicalAlignmentWorkflowConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -3835,12 +3739,6 @@ export type ReferenceDownloaderWorkflowConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'reference_downloader';
@@ -3888,12 +3786,6 @@ export type ReferenceExtractionConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -4109,12 +4001,6 @@ export type ReferenceFileMatchingConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -4341,12 +4227,6 @@ export type ReferenceValidationWorkflowConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'reference_validation';
@@ -4544,12 +4424,6 @@ export type ResultsExtractionWorkflowConfig = {
    */
   publication_date?: string | null;
   /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
-  /**
    * Type
    */
   type?: 'results_extraction';
@@ -4603,12 +4477,6 @@ export type Reviewer2Config = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * Type
    */
@@ -4783,12 +4651,6 @@ export type SimpleDeepAgentConfig = {
    * Publication date of the document (YYYY-MM-DD format)
    */
   publication_date?: string | null;
-  /**
-   * Revision
-   *
-   * The project revision this workflow run belongs to
-   */
-  revision?: number;
   /**
    * The workflow type, set per-manifest at runtime
    */

--- a/lib/api/services/workflow_runner.py
+++ b/lib/api/services/workflow_runner.py
@@ -55,13 +55,14 @@ async def _prepare_workflow_items(
     workflow_types: List[WorkflowRunType],
     request: StartMultipleWorkflowsRequest,
     user: User,
-) -> tuple[Project, List[str], List[AutoRunWorkflowItem]]:
+) -> tuple[Project, int, List[str], List[AutoRunWorkflowItem]]:
     """
     Resolve dependencies, apply skip logic, create run records, and build the
     list of items ready for execution.
 
     Returns a tuple of:
     - project: the resolved Project instance
+    - revision: the project revision this batch targets (always current_revision)
     - all_workflow_run_ids: IDs of all newly created run records (including
       human-trigger workflows that won't be auto-run)
     - auto_run_items: subset of items that should actually be executed
@@ -139,7 +140,7 @@ async def _prepare_workflow_items(
             )
         )
 
-    return project, workflow_run_ids, auto_run_items
+    return project, revision, workflow_run_ids, auto_run_items
 
 
 async def start_workflow_run(
@@ -162,11 +163,9 @@ async def start_workflow_run(
 
     await assert_project_has_main_file(config.project_id, project.current_revision)
 
+    # Workflows always run against the project's current revision; API/MCP
+    # clients don't supply a revision when starting workflows.
     revision = project.current_revision
-    # Ensure the config's revision matches the project's current revision so the
-    # workflow context (and any state lookups driven by it) target the right
-    # revision. Callers of POST /api/workflows/start don't send a revision.
-    config.revision = revision
     existing_run = await get_project_workflow_run_by_type(
         config.project_id, config.type, revision=revision
     )
@@ -191,6 +190,7 @@ async def start_workflow_run(
         thread_id=thread_id,
         workflow_run_id=workflow_run_id,
         user=user,
+        revision=revision,
     )
 
     return workflow_run_id
@@ -217,7 +217,7 @@ async def start_multiple_workflow_runs(
     Raises:
         HTTPException: If project_id is missing or project doesn't exist
     """
-    _, workflow_run_ids, auto_run_items = await _prepare_workflow_items(
+    _, revision, workflow_run_ids, auto_run_items = await _prepare_workflow_items(
         workflow_types, request, user
     )
 
@@ -229,6 +229,7 @@ async def start_multiple_workflow_runs(
             _run_multiple_workflows_concurrently,
             items=auto_run_items,
             user=user,
+            revision=revision,
         )
     else:
         logger.info(
@@ -258,7 +259,7 @@ async def run_multiple_workflows_blocking(
     Returns:
         A tuple of (project, list of workflow_run_ids for all created runs)
     """
-    project, workflow_run_ids, auto_run_items = await _prepare_workflow_items(
+    project, revision, workflow_run_ids, auto_run_items = await _prepare_workflow_items(
         workflow_types, request, user
     )
 
@@ -268,6 +269,7 @@ async def run_multiple_workflows_blocking(
             thread_id=item.thread_id,
             workflow_run_id=item.workflow_run_id,
             user=user,
+            revision=revision,
         )
 
     return project, workflow_run_ids
@@ -302,6 +304,7 @@ async def resume_workflow_run(
         thread_id=thread_id,
         workflow_run_id=str(workflow_run.id),
         user=user,
+        revision=workflow_run.revision,
     )
 
     return str(workflow_run.id)
@@ -310,6 +313,7 @@ async def resume_workflow_run(
 async def _run_multiple_workflows_concurrently(
     items: List[AutoRunWorkflowItem],
     user: User,
+    revision: int,
 ) -> None:
     """
     Run multiple workflows concurrently using asyncio.gather().
@@ -320,6 +324,7 @@ async def _run_multiple_workflows_concurrently(
     Args:
         items: List of workflow items containing config, thread_id, and workflow_run_id
         user: User running the workflows
+        revision: The project revision this batch targets
     """
     if not items:
         return
@@ -335,6 +340,7 @@ async def _run_multiple_workflows_concurrently(
             thread_id=item.thread_id,
             workflow_run_id=item.workflow_run_id,
             user=user,
+            revision=revision,
         )
         for item in items
     ]

--- a/lib/workflows/abbreviation_scan_v2/manifest.py
+++ b/lib/workflows/abbreviation_scan_v2/manifest.py
@@ -44,6 +44,7 @@ class AbbreviationScanV2Manifest(
         self,
         config: AbbreviationScanV2Config,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> AbbreviationScanV2State:
         return AbbreviationScanV2State(
             type=WorkflowRunType.ABBREVIATION_SCAN_V2,

--- a/lib/workflows/about_this_ger/manifest.py
+++ b/lib/workflows/about_this_ger/manifest.py
@@ -41,6 +41,7 @@ class AboutThisGerManifest(WorkflowManifest[AboutThisGerState, AboutThisGerConfi
         self,
         config: AboutThisGerConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> AboutThisGerState:
         return AboutThisGerState(
             type=WorkflowRunType.ABOUT_THIS_GER,

--- a/lib/workflows/advocacy_tone/manifest.py
+++ b/lib/workflows/advocacy_tone/manifest.py
@@ -41,6 +41,7 @@ class AdvocacyToneManifest(
         self,
         config: AdvocacyToneWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> AdvocacyToneState:
         """Create and return the initial state of the workflow."""
         return AdvocacyToneState(

--- a/lib/workflows/chunk_splitting/manifest.py
+++ b/lib/workflows/chunk_splitting/manifest.py
@@ -43,6 +43,7 @@ class ChunkSplittingManifest(
         self,
         config: ChunkSplittingWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ChunkSplittingState:
         """Create initial state from DOCUMENT_PROCESSING dependency."""
         return ChunkSplittingState(

--- a/lib/workflows/citation_detection/manifest.py
+++ b/lib/workflows/citation_detection/manifest.py
@@ -43,6 +43,7 @@ class CitationDetectionManifest(
         self,
         config: CitationDetectionConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> CitationDetectionState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/citation_suggester/manifest.py
+++ b/lib/workflows/citation_suggester/manifest.py
@@ -48,6 +48,7 @@ class CitationSuggesterManifest(
         self,
         config: CitationSuggesterWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> CitationSuggesterState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/claim_extraction/manifest.py
+++ b/lib/workflows/claim_extraction/manifest.py
@@ -42,6 +42,7 @@ class ClaimExtractionManifest(
         self,
         config: ClaimExtractionWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ClaimExtractionState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/claim_reference_validation/manifest.py
+++ b/lib/workflows/claim_reference_validation/manifest.py
@@ -81,6 +81,7 @@ class ClaimReferenceValidationManifest(
         self,
         config: ClaimReferenceValidationWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ClaimReferenceValidationState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/config_factory.py
+++ b/lib/workflows/config_factory.py
@@ -40,7 +40,6 @@ def create_workflow_config(
         "publication_date": (
             project.publication_date.isoformat() if project.publication_date else None
         ),
-        "revision": project.current_revision,
     }
 
     try:

--- a/lib/workflows/document_processing/manifest.py
+++ b/lib/workflows/document_processing/manifest.py
@@ -44,13 +44,14 @@ class DocumentProcessingManifest(
         self,
         config: DocumentProcessingWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> DocumentProcessingState:
         """Create and return the initial state of the workflow."""
 
         from lib.services.files import get_files_by_project_id, load_file_document
 
         project_files = await get_files_by_project_id(
-            config.project_id, revision=config.revision
+            config.project_id, revision=revision
         )
         main_file = next(
             (file for file in project_files if file.role == FileRole.MAIN),

--- a/lib/workflows/document_summarization/manifest.py
+++ b/lib/workflows/document_summarization/manifest.py
@@ -44,6 +44,7 @@ class DocumentSummarizationManifest(
         self,
         config: DocumentSummarizationWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> DocumentSummarizationState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/footnote_extraction/manifest.py
+++ b/lib/workflows/footnote_extraction/manifest.py
@@ -43,6 +43,7 @@ class FootnoteExtractionManifest(
         self,
         config: FootnoteExtractionConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> FootnoteExtractionState:
         """
         Create initial state from DOCUMENT_PROCESSING dependency.

--- a/lib/workflows/human_approval/manifest.py
+++ b/lib/workflows/human_approval/manifest.py
@@ -49,6 +49,7 @@ class HumanApprovalManifest(WorkflowManifest[HumanApprovalState, HumanApprovalCo
         self,
         config: HumanApprovalConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> HumanApprovalState:
         return HumanApprovalState(
             type=WorkflowRunType.HUMAN_APPROVAL,

--- a/lib/workflows/inference_validation_v2/manifest.py
+++ b/lib/workflows/inference_validation_v2/manifest.py
@@ -41,6 +41,7 @@ class InferenceValidationV2Manifest(
         self,
         config: InferenceValidationV2WorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> InferenceValidationV2State:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/literature_review/manifest.py
+++ b/lib/workflows/literature_review/manifest.py
@@ -41,6 +41,7 @@ class LiteratureReviewManifest(
         self,
         config: LiteratureReviewWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> LiteratureReviewState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/live_reports/manifest.py
+++ b/lib/workflows/live_reports/manifest.py
@@ -41,6 +41,7 @@ class LiveReportsManifest(
         self,
         config: LiveReportsWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> LiveReportsState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/manifest.py
+++ b/lib/workflows/manifest.py
@@ -85,7 +85,10 @@ class WorkflowManifest[WorkflowStateType, WorkflowConfigType](ABC):
 
     @abstractmethod
     async def create_initial_state(
-        self, config: WorkflowConfigType, existing_states: List[WorkflowState]
+        self,
+        config: WorkflowConfigType,
+        existing_states: List[WorkflowState],
+        revision: int,
     ) -> WorkflowStateType:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/methodological_alignment/manifest.py
+++ b/lib/workflows/methodological_alignment/manifest.py
@@ -42,6 +42,7 @@ class MethodologicalAlignmentManifest(
         self,
         config: MethodologicalAlignmentWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> MethodologicalAlignmentState:
         """Create and return the initial state of the workflow."""
 

--- a/lib/workflows/models.py
+++ b/lib/workflows/models.py
@@ -55,10 +55,6 @@ class BaseWorkflowConfig(BaseModel):
     publication_date: Optional[str] = Field(
         default=None, description="Publication date of the document (YYYY-MM-DD format)"
     )
-    revision: int = Field(
-        default=1,
-        description="The project revision this workflow run belongs to",
-    )
 
     @classmethod
     def requires_api_key(cls) -> bool:

--- a/lib/workflows/reference_downloader/manifest.py
+++ b/lib/workflows/reference_downloader/manifest.py
@@ -54,6 +54,7 @@ class ReferenceDownloaderManifest(
         self,
         config: ReferenceDownloaderWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ReferenceDownloaderState:
         """Create and return the initial state of the workflow."""
         return ReferenceDownloaderState(

--- a/lib/workflows/reference_extraction/manifest.py
+++ b/lib/workflows/reference_extraction/manifest.py
@@ -43,6 +43,7 @@ class ReferenceExtractionManifest(
         self,
         config: ReferenceExtractionConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ReferenceExtractionState:
         """
         Create initial state from DOCUMENT_PROCESSING dependency.

--- a/lib/workflows/reference_file_matching/manifest.py
+++ b/lib/workflows/reference_file_matching/manifest.py
@@ -58,6 +58,7 @@ class ReferenceFileMatchingManifest(
         self,
         config: ReferenceFileMatchingConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ReferenceFileMatchingState:
         """
         Create initial state from REFERENCE_EXTRACTION dependency.

--- a/lib/workflows/reference_validation/manifest.py
+++ b/lib/workflows/reference_validation/manifest.py
@@ -99,6 +99,7 @@ class ReferenceValidationManifest(
         self,
         config: ReferenceValidationWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ReferenceValidationState:
         """Create and return the initial state of the workflow."""
         return ReferenceValidationState(

--- a/lib/workflows/registry.py
+++ b/lib/workflows/registry.py
@@ -129,7 +129,7 @@ def get_state_type(type: WorkflowRunType) -> Type[BaseWorkflowState]:
     return manifest.get_state_type()
 
 
-async def create_state(config: BaseWorkflowConfig) -> WorkflowState:
+async def create_state(config: BaseWorkflowConfig, revision: int) -> WorkflowState:
     """
     Create initial state for a workflow from the config.
 
@@ -139,10 +139,10 @@ async def create_state(config: BaseWorkflowConfig) -> WorkflowState:
 
     # Include internal workflows so dependencies can access their states
     workflow_runs = await get_project_workflow_runs(
-        config.project_id, revision=config.revision, include_internal=True
+        config.project_id, revision=revision, include_internal=True
     )
     existing_states: List[WorkflowState] = [
         run.state for run in workflow_runs if run.state is not None
     ]
     manifest = get_workflow_manifest(config.type)
-    return await manifest.create_initial_state(config, existing_states)
+    return await manifest.create_initial_state(config, existing_states, revision)

--- a/lib/workflows/results_extraction/manifest.py
+++ b/lib/workflows/results_extraction/manifest.py
@@ -37,6 +37,7 @@ class ResultsExtractionManifest(
         self,
         config: ResultsExtractionWorkflowConfig,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> ResultsExtractionState:
         return ResultsExtractionState(
             type=WorkflowRunType.RESULTS_EXTRACTION,

--- a/lib/workflows/reviewer_2/manifest.py
+++ b/lib/workflows/reviewer_2/manifest.py
@@ -35,6 +35,7 @@ class Reviewer2Manifest(WorkflowManifest[Reviewer2State, Reviewer2Config]):
         self,
         config: Reviewer2Config,
         existing_states: List[WorkflowState],
+        revision: int,
     ) -> Reviewer2State:
         return Reviewer2State(
             type=WorkflowRunType.REVIEWER_2,

--- a/lib/workflows/runner.py
+++ b/lib/workflows/runner.py
@@ -32,7 +32,11 @@ logger = logging.getLogger(__name__)
 
 
 async def run_workflow_with_dependency_check(
-    config: WorkflowConfig, thread_id: str, workflow_run_id: str, user: User
+    config: WorkflowConfig,
+    thread_id: str,
+    workflow_run_id: str,
+    user: User,
+    revision: int,
 ) -> None:
     """
     Run a workflow after checking and waiting for its dependencies to complete.
@@ -46,12 +50,13 @@ async def run_workflow_with_dependency_check(
         thread_id: The LangGraph thread ID for checkpointing
         workflow_run_id: The unique ID of this workflow run (for same-type locking)
         user: The user running the workflow
+        revision: The project revision this workflow run belongs to
     """
 
     try:
         # Wait for same-type lock and dependencies to complete
         await wait_for_dependencies(
-            config.type, config.project_id, workflow_run_id, revision=config.revision
+            config.type, config.project_id, workflow_run_id, revision=revision
         )
 
         # Run the workflow
@@ -60,6 +65,7 @@ async def run_workflow_with_dependency_check(
             thread_id=thread_id,
             workflow_run_id=workflow_run_id,
             user=user,
+            revision=revision,
         )
 
     except WorkflowCancelledError:
@@ -73,15 +79,21 @@ async def run_workflow_with_dependency_check(
 
 
 async def run_workflow_from_config(
-    config: WorkflowConfig, thread_id: str, workflow_run_id: str, user: User
+    config: WorkflowConfig,
+    thread_id: str,
+    workflow_run_id: str,
+    user: User,
+    revision: int,
 ) -> WorkflowState:
     graph = create_graph(config.type)
-    context = create_context(config, workflow_run_id=workflow_run_id, user=user)
+    context = create_context(
+        config, workflow_run_id=workflow_run_id, user=user, revision=revision
+    )
 
     # Redact the OpenAI API key from the config so it doesn't get saved in the state
     config.openai_api_key = "[REDACTED]"
 
-    state = await create_state(config)
+    state = await create_state(config, revision=revision)
 
     with propagate_attributes(user_id=context.user_id):
         return await run_workflow(
@@ -202,6 +214,7 @@ async def run_workflow(
 
 def create_context(
     config: BaseWorkflowConfig,
+    revision: int,
     workflow_run_id: str | None = None,
     user: User | None = None,
 ) -> ContextSchema:
@@ -227,7 +240,7 @@ def create_context(
         else None
     )
 
-    file_artifacts_service = FileArtifactsService(config.project_id, revision=config.revision)
+    file_artifacts_service = FileArtifactsService(config.project_id, revision=revision)
 
     return ContextSchema(
         openai_api_key=openai_api_key,
@@ -236,7 +249,7 @@ def create_context(
         project_id=config.project_id,
         workflow_run_id=workflow_run_id,
         file_artifacts_service=file_artifacts_service,
-        revision=config.revision,
+        revision=revision,
     )
 
 

--- a/lib/workflows/simple_deep_agent/manifest_base.py
+++ b/lib/workflows/simple_deep_agent/manifest_base.py
@@ -81,6 +81,7 @@ class SimpleDeepAgentManifest(
         self,
         config: SimpleDeepAgentConfig,
         existing_states: List["WorkflowState"],
+        revision: int,
     ) -> SimpleDeepAgentState:
         return SimpleDeepAgentState(type=self.type, config=config)
 


### PR DESCRIPTION
## Summary

Removes `revision` as a client-facing input parameter on workflow start endpoints (REST + MCP). Workflows always run against `project.current_revision`; clients can no longer supply a revision when starting a workflow. Read endpoints that accept a revision (for fetching past revision data) are unchanged.

Resolves [RANDZ-524](https://linear.app/ae-studio/issue/RANDZ-524/chore-remove-revision-from-api-inputs).

## Motivation

`BaseWorkflowConfig` exposed a `revision: int` field, which leaked into the OpenAPI schema for `POST /api/workflows/start` and into the MCP tool surface. The service layer already silently overrode any client-supplied value with `project.current_revision` (`start_workflow_run` and `_prepare_workflow_items`), so a client that carefully set `revision: 2` got the current revision instead — no effect, no error. This was misleading and coupled a server-resolved runtime concern to the client-facing workflow config.

## What's Changed

### Backend

- **`lib/workflows/models.py`** — dropped the `revision: int` field from `BaseWorkflowConfig`. This is the core change that removes `revision` from every workflow config subclass's OpenAPI schema.
- **`lib/workflows/config_factory.py`** — `create_workflow_config` no longer sets `revision`; it's not a field anymore.
- **`lib/workflows/runner.py`** — added an explicit `revision: int` parameter to `run_workflow_with_dependency_check`, `run_workflow_from_config`, and `create_context`, so revision is threaded through the execution chain instead of read from `config.revision`. Used for `wait_for_dependencies`, `FileArtifactsService`, and `ContextSchema`.
- **`lib/workflows/registry.py`** — `create_state` now takes `revision` and forwards it to `get_project_workflow_runs` and `manifest.create_initial_state`.
- **`lib/workflows/manifest.py`** — updated the abstract `create_initial_state` signature to require `revision: int`.
- **~22 manifest overrides** (`lib/workflows/*/manifest.py`, `lib/workflows/simple_deep_agent/manifest_base.py`) — mechanical signature updates to accept the new `revision` parameter. Only `document_processing/manifest.py` actually uses it (for `get_files_by_project_id`); the rest accept and ignore it for Liskov compatibility.
- **`lib/api/services/workflow_runner.py`** — callers resolve `revision` from `project.current_revision` (start paths) or `workflow_run.revision` (resume) and pass it explicitly. `_prepare_workflow_items` now returns `(project, revision, workflow_run_ids, auto_run_items)` so the concurrent and blocking runners have a single source of truth. Removed the obsolete `config.revision = revision` override line.

### Frontend

- **`frontend/lib/generated-api/types.gen.ts`** — regenerated with `pnpm run openapi-generate` now that the backend schema no longer exposes `revision` on any WorkflowConfig subtype. Revision still appears on response/read types (project details, issue, file, revision summary) — those are read paths and are intentionally preserved.

## Risks and Mitigations

- **Risk:** A consumer was relying on `config.revision` being present on workflow config objects internally.
  **Mitigation:** `rg "config\.revision"` returns zero hits across the repo after the refactor. Any runtime-node code that still needs revision can read it from `runtime.context.revision` (already populated via `ContextSchema`), which is what `reference_downloader/nodes/fetch_references.py` already does.

- **Risk:** Clients that previously sent `{"revision": N}` in the request body would get a surprising behavior change.
  **Mitigation:** The field previously had no effect anyway (server always overrode it). With Pydantic's default `extra="ignore"`, a stale client still gets accepted; revision is silently dropped — same net result as before.

- **Risk:** The abstract `create_initial_state` signature change breaks any out-of-tree manifest implementation.
  **Mitigation:** All in-tree manifests are updated. No public API surface exists for external manifests.

- **Risk:** Workflow resume (`approve_workflow_run`) previously relied on `config.revision` indirectly.
  **Mitigation:** `resume_workflow_run` now sources revision from the persisted `workflow_run.revision` field, which is authoritative for the original run's revision.

## Test plan

- [x] `uv run pytest` — 522 passed, 3 skipped
- [x] `rg "config\.revision"` — zero hits
- [x] `pnpm exec tsc --noEmit` — passes
- [x] OpenAPI schema spot-check: `ClaimExtractionWorkflowConfig.properties` no longer includes `revision`
- [x] Regenerated frontend types no longer emit `revision?: number` on WorkflowConfig subtypes
- [ ] Manual E2E: start a workflow via `POST /api/workflows/start` without `revision` → uses `current_revision`
- [ ] Manual E2E: `GET /api/project/{id}?revision=N` still returns past revision data

🤖 Generated with [Claude Code](https://claude.com/claude-code)