### PR TITLE
fix(db): share bounded connection pools across ORM and checkpointer

### DIFF
--- a/lib/api/main.py
+++ b/lib/api/main.py
@@ -41,12 +41,15 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Seed default runtime configs on startup."""
+    """Seed default runtime configs on startup; close shared pools on shutdown."""
     from lib.services.app_configs import seed_all_defaults
+    from lib.workflows.checkpointer import close_checkpointer_pool
 
     await seed_all_defaults()
-
-    yield
+    try:
+        yield
+    finally:
+        await close_checkpointer_pool()
 
 
 app = FastAPI(

--- a/lib/config/database.py
+++ b/lib/config/database.py
@@ -12,8 +12,15 @@ def get_async_url(url: str) -> str:
     return url
 
 
-# SQLAlchemy engine
-async_engine = create_async_engine(get_async_url(env_config.DATABASE_URL), echo=False)
+# SQLAlchemy engine — ORM access via AsyncSessionLocal.
+# A separate psycopg pool for langgraph's checkpointer lives in
+# lib/workflows/checkpointer.py (langgraph requires psycopg_pool specifically).
+async_engine = create_async_engine(
+    get_async_url(env_config.DATABASE_URL),
+    echo=False,
+    pool_size=8,
+    max_overflow=3,
+)
 
 # Session factory
 AsyncSessionLocal = async_sessionmaker(

--- a/lib/services/vector_store.py
+++ b/lib/services/vector_store.py
@@ -7,8 +7,8 @@ from langchain_core.documents import Document
 from langchain_postgres import PGVector
 from langchain_text_splitters import Language, RecursiveCharacterTextSplitter
 from pydantic import BaseModel, Field
-from sqlalchemy.ext.asyncio import create_async_engine
 
+from lib.config.database import async_engine
 from lib.config.llm_error_logger import log_embedding_error
 from lib.config.llm_models import EMBEDDING_MODEL_LARGE, init_embeddings
 from lib.config.rate_limiter import get_rate_limiter, hash_api_key
@@ -126,25 +126,21 @@ def get_collection_id(file_hash: str) -> str:
 class VectorStoreService:
     """Service for vector storage and retrieval operations."""
 
-    def __init__(self, connection_string: str, openai_api_key: str):
-        """Initialize vector store with database connection."""
+    def __init__(self, openai_api_key: str):
+        """Initialize vector store using the shared async engine.
+
+        Reuses the process-wide ``async_engine`` from ``lib.config.database``
+        instead of creating a second engine/pool, so all DB access shares one
+        bounded connection pool (prevents Postgres ``too many clients``).
+        """
         self.embeddings = init_embeddings(api_key=openai_api_key)
         self._rate_limiter = get_rate_limiter(hash_api_key(openai_api_key))
 
-        # Always use async engine since all our methods are async
-        # Convert postgresql:// to postgresql+psycopg:// for SQLAlchemy async engine
-        if connection_string.startswith("postgresql://"):
-            async_url = connection_string.replace(
-                "postgresql://", "postgresql+psycopg://", 1
-            )
-        else:
-            async_url = connection_string
-
-        self.async_engine = create_async_engine(async_url)
+        self.async_engine = async_engine
         self._vectorstore_cache: dict[str, PGVector] = {}
         self._indexing_locks: dict[str, asyncio.Lock] = {}
 
-        logger.info("VectorStore initialized with async engine")
+        logger.info("VectorStore initialized with shared async engine")
 
     def _get_vectorstore(self, collection_id: str) -> PGVector:
         """

--- a/lib/workflows/checkpointer.py
+++ b/lib/workflows/checkpointer.py
@@ -1,11 +1,61 @@
+import asyncio
 from contextlib import asynccontextmanager
+
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
+from psycopg.rows import dict_row
+from psycopg_pool import AsyncConnectionPool
 
 from lib.config.env import config
+
+# psycopg pool for langgraph's AsyncPostgresSaver. Opened lazily by
+# _ensure_pool_ready(); min_size=0 so idle processes hold no DB connections.
+checkpointer_pool = AsyncConnectionPool(
+    conninfo=config.DATABASE_URL,
+    min_size=0,
+    max_size=4,
+    kwargs={
+        "autocommit": True,
+        "prepare_threshold": 0,
+        "row_factory": dict_row,
+    },
+    open=False,
+)
+
+_opened = False
+_open_lock = asyncio.Lock()
+
+
+async def _ensure_pool_ready() -> None:
+    """Open the shared psycopg pool and run checkpoint migrations once."""
+    global _opened
+    if _opened:
+        return
+    async with _open_lock:
+        if _opened:
+            return
+        await checkpointer_pool.open(wait=True)
+        # Idempotent; creates checkpoint tables on first startup.
+        await AsyncPostgresSaver(conn=checkpointer_pool).setup()
+        _opened = True
 
 
 @asynccontextmanager
 async def get_checkpointer():
-    async with AsyncPostgresSaver.from_conn_string(config.DATABASE_URL) as checkpointer:
-        await checkpointer.setup()
-        yield checkpointer
+    """Yield an AsyncPostgresSaver backed by the shared psycopg pool.
+
+    A fresh saver is created per call (it's cheap — just assigns attrs and
+    creates an asyncio.Lock). All savers share ``checkpointer_pool`` so the
+    per-process connection count stays bounded, while each saver has its own
+    lock so concurrent workflow runs don't serialize on a global checkpoint
+    lock.
+    """
+    await _ensure_pool_ready()
+    yield AsyncPostgresSaver(conn=checkpointer_pool)
+
+
+async def close_checkpointer_pool() -> None:
+    """Close the shared pool; called from the FastAPI lifespan shutdown hook."""
+    global _opened
+    if _opened:
+        await checkpointer_pool.close()
+        _opened = False

--- a/lib/workflows/runner.py
+++ b/lib/workflows/runner.py
@@ -235,9 +235,7 @@ def create_context(
 
     # Only initialize vector store if we have an API key (needed for embeddings)
     vector_store = (
-        VectorStoreService(env_config.DATABASE_URL, openai_api_key)
-        if openai_api_key
-        else None
+        VectorStoreService(openai_api_key) if openai_api_key else None
     )
 
     file_artifacts_service = FileArtifactsService(config.project_id, revision=revision)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -506,7 +506,7 @@ def create_test_context(
     return ContextSchema(
         openai_api_key=openai_api_key or config.OPENAI_API_KEY,
         vector_store=vector_store
-        or VectorStoreService(config.DATABASE_URL, config.OPENAI_API_KEY or "test-key"),
+        or VectorStoreService(config.OPENAI_API_KEY or "test-key"),
         project_id=project_id,
         file_artifacts_service=file_artifacts_service or MockFileArtifactsService(),
         user_id=user_id,

--- a/tests/evals/llm/test_claim_verifier.py
+++ b/tests/evals/llm/test_claim_verifier.py
@@ -76,7 +76,7 @@ async def _build_cases(dataset_file_name: str):
     if not config.OPENAI_API_KEY:
         raise ValueError("OPENAI_API_KEY is not set")
 
-    vector_store = VectorStoreService(config.DATABASE_URL, config.OPENAI_API_KEY)
+    vector_store = VectorStoreService(config.OPENAI_API_KEY)
 
     for supporting_doc in supporting_docs_set:
         file_doc = await create_test_file_document_from_path(supporting_doc)

--- a/tests/unit/services/test_vector_store.py
+++ b/tests/unit/services/test_vector_store.py
@@ -2,7 +2,9 @@
 
 import pytest
 
+from lib.config.database import async_engine as shared_async_engine
 from lib.services.vector_store import (
+    VectorStoreService,
     _char_offset_to_line,
     _splitter,
     build_chunk_docs,
@@ -124,3 +126,26 @@ class TestBuildChunkDocs:
         assert len(docs) >= 1
         assert docs[0].metadata["file_name"] == "report.pdf"
         assert docs[0].metadata["collection_id"] == "col_abc"
+
+
+class TestVectorStoreServiceSharedEngine:
+    """Regression tests guarding the single-engine invariant.
+
+    The service must reuse ``lib.config.database.async_engine`` instead of
+    creating its own SQLAlchemy engine/pool. Owning a second pool defeats
+    the main engine's ``pool_size``/``max_overflow`` caps — pools declared
+    elsewhere don't share that budget, so total per-process connections
+    could exceed Postgres ``max_connections`` and trigger
+    ``FATAL: sorry, too many clients already``.
+    """
+
+    def test_uses_shared_async_engine(self):
+        """VectorStoreService.async_engine is the same object as the shared engine."""
+        service = VectorStoreService("test-key")
+        assert service.async_engine is shared_async_engine
+
+    def test_multiple_instances_share_one_engine(self):
+        """Instantiating the service multiple times must not create extra pools."""
+        a = VectorStoreService("test-key-a")
+        b = VectorStoreService("test-key-b")
+        assert a.async_engine is b.async_engine is shared_async_engine

--- a/tests/unit/test_checkpointer.py
+++ b/tests/unit/test_checkpointer.py
@@ -1,0 +1,115 @@
+"""Unit tests for the shared checkpointer pool.
+
+Langgraph's AsyncPostgresSaver must be backed by a single shared psycopg pool
+(bounded per-process), with a fresh saver created per call so concurrent
+workflow runs don't contend on a global checkpoint lock.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lib.workflows import checkpointer as checkpointer_module
+from lib.workflows.checkpointer import (
+    checkpointer_pool,
+    close_checkpointer_pool,
+    get_checkpointer,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_pool_state():
+    """Reset module-level _opened flag and mock the DB-touching calls."""
+    checkpointer_module._opened = False
+    with (
+        patch.object(checkpointer_pool, "open", new_callable=AsyncMock) as mock_open,
+        patch.object(checkpointer_pool, "close", new_callable=AsyncMock) as mock_close,
+        patch(
+            "lib.workflows.checkpointer.AsyncPostgresSaver.setup",
+            new_callable=AsyncMock,
+        ) as mock_setup,
+    ):
+        yield mock_open, mock_close, mock_setup
+    checkpointer_module._opened = False
+
+
+@pytest.mark.asyncio
+async def test_savers_share_the_pool():
+    """Every get_checkpointer() call yields a saver bound to the shared pool."""
+    async with get_checkpointer() as saver_a:
+        async with get_checkpointer() as saver_b:
+            assert saver_a.conn is checkpointer_pool
+            assert saver_b.conn is checkpointer_pool
+
+
+@pytest.mark.asyncio
+async def test_savers_are_distinct_instances():
+    """Each call yields a fresh saver so per-saver asyncio.Lock doesn't
+    globally serialize concurrent workflow runs."""
+    async with get_checkpointer() as saver_a:
+        async with get_checkpointer() as saver_b:
+            assert saver_a is not saver_b
+            assert saver_a.lock is not saver_b.lock
+
+
+@pytest.mark.asyncio
+async def test_pool_opened_and_setup_run_only_once(reset_pool_state):
+    """Back-to-back calls must not re-open the pool or re-run migrations."""
+    mock_open, _, mock_setup = reset_pool_state
+
+    async with get_checkpointer():
+        pass
+    async with get_checkpointer():
+        pass
+    async with get_checkpointer():
+        pass
+
+    assert mock_open.await_count == 1
+    assert mock_setup.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_pool_opened_once_under_concurrency(reset_pool_state):
+    """The double-checked lock must hold under simultaneous first-use calls."""
+    mock_open, _, mock_setup = reset_pool_state
+
+    async def use_checkpointer():
+        async with get_checkpointer() as saver:
+            return saver
+
+    savers = await asyncio.gather(*[use_checkpointer() for _ in range(20)])
+
+    assert len(savers) == 20
+    assert all(s.conn is checkpointer_pool for s in savers)
+    assert mock_open.await_count == 1
+    assert mock_setup.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_close_allows_reopen(reset_pool_state):
+    """After close_checkpointer_pool, the next call re-opens and re-runs setup."""
+    mock_open, mock_close, mock_setup = reset_pool_state
+
+    async with get_checkpointer():
+        pass
+    assert mock_open.await_count == 1
+    assert mock_setup.await_count == 1
+
+    await close_checkpointer_pool()
+    assert mock_close.await_count == 1
+
+    async with get_checkpointer():
+        pass
+    assert mock_open.await_count == 2
+    assert mock_setup.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_close_without_open_is_noop(reset_pool_state):
+    """Closing before anything was opened must not call pool.close()."""
+    _, mock_close, _ = reset_pool_state
+
+    await close_checkpointer_pool()
+
+    assert mock_close.await_count == 0


### PR DESCRIPTION
## Summary

- `VectorStoreService` now reuses the shared SQLAlchemy `async_engine` instead of owning its own engine/pool.
- The langgraph checkpointer (`AsyncPostgresSaver`) is now backed by a bounded module-level psycopg pool rather than opening a fresh connection per workflow run.
- The shared SQLAlchemy engine gets explicit `pool_size=8` / `max_overflow=3` caps.

## Motivation

Investigating `RANDZ-529` (`FATAL: sorry, too many clients already`) uncovered three independent DB connection sources per API process:

1. `lib/config/database.py` — SQLAlchemy `async_engine` (on `dev`, uncapped; the fork caps it).
2. `lib/services/vector_store.py` — a second SQLAlchemy engine created inside `VectorStoreService.__init__`, entirely outside that cap.
3. `lib/workflows/checkpointer.py` — psycopg `AsyncConnection` via `AsyncPostgresSaver.from_conn_string(...)`, opened fresh per workflow run and held for the whole run's duration. With `LANGGRAPH_MAX_CONCURRENCY=30` and concurrent workflow runs, these stack up quickly.

With all three on the same Postgres instance and multiple API replicas, total connections blew past Postgres `max_connections`.

## What's Changed

### Backend

- `lib/services/vector_store.py` — `VectorStoreService.__init__` now only takes `openai_api_key`. It reuses `lib.config.database.async_engine` instead of calling `create_async_engine(...)`. The redundant `postgresql://` → `postgresql+psycopg://` rewrite is removed (the shared engine already does it via `get_async_url`).
- `lib/workflows/runner.py`, `tests/conftest.py`, `tests/evals/llm/test_claim_verifier.py` — updated to the single-arg `VectorStoreService(...)` constructor.
- `lib/config/database.py` — adds `pool_size=8`, `max_overflow=3` to `async_engine` and a short comment pointing to the co-located checkpointer pool.
- `lib/workflows/checkpointer.py` — rewritten. A module-level `psycopg_pool.AsyncConnectionPool(min_size=0, max_size=4)` is declared with `open=False`. `_ensure_pool_ready()` lazily opens it and calls `AsyncPostgresSaver(...).setup()` exactly once, guarded by an `asyncio.Lock`. `get_checkpointer()` yields a fresh `AsyncPostgresSaver(conn=pool)` per call — each has its own `asyncio.Lock` so concurrent workflow runs don't serialize globally, but all share the bounded pool. Added `close_checkpointer_pool()` for clean shutdown. `min_size=0` means idle processes hold zero DB connections.
- `lib/api/main.py` — FastAPI `lifespan` now calls `close_checkpointer_pool()` on shutdown.

### Tests

- `tests/unit/services/test_vector_store.py` — new `TestVectorStoreServiceSharedEngine` with `test_uses_shared_async_engine` and `test_multiple_instances_share_one_engine` guarding the single-engine invariant.
- `tests/unit/test_checkpointer.py` (new) — six tests with `pool.open`, `pool.close`, and `AsyncPostgresSaver.setup` mocked:
  - `test_savers_share_the_pool`
  - `test_savers_are_distinct_instances` (guards per-saver lock)
  - `test_pool_opened_and_setup_run_only_once`
  - `test_pool_opened_once_under_concurrency` (double-checked lock under `asyncio.gather`)
  - `test_close_allows_reopen`
  - `test_close_without_open_is_noop`

## Risks and Mitigations

- **Behavior change for the checkpointer.** Connections are now checked out from a pool only during cursor ops rather than held for the whole workflow. Confirmed in `langgraph.checkpoint.postgres._ainternal.get_connection` — pool-backed savers do `async with pool.connection() as conn` per cursor scope. `AsyncPostgresSaver.__init__` explicitly accepts either `AsyncConnection` or `AsyncConnectionPool`.
- **Undersized pool causing checkpoint queuing.** `max_size=4` assumes checkpoint ops are ms-scale and per-run checkpoint writes serialize on each saver's own lock. If queuing becomes visible, bump `max_size` in `lib/workflows/checkpointer.py`. `pool_timeout` defaults to 30s, so brief bursts are safe.
- **Breaking a non-FastAPI caller of the checkpointer.** Eval scripts and unit tests still use the same `async with get_checkpointer()` idiom — callsite signatures are unchanged. Lazy pool init means no lifespan is required; the pool opens on first use wherever it's called from.
- **SQLAlchemy pool caps tighter than before.** `dev` previously had no explicit caps. With `pool_size=8 + max_overflow=3`, pool exhaustion would manifest as SQLAlchemy `QueuePool limit reached` (client-side queue timeout), not Postgres-side rejection. If that surfaces, the caps can be tuned in one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)