### PR TITLE
fix(mcp): resolve email from Azure Entra ID upstream_claims

### DIFF
--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -56,15 +56,23 @@ def _looks_like_email(value: str) -> bool:
 
 async def _resolve_user(token: AccessToken) -> User:
     """Resolve the DB user from an authenticated OAuth access token."""
-    email = token.claims.get("email")
-    name = token.claims.get("name")
-    # Azure Entra ID nests identity under upstream_claims
-    if not email:
-        upstream = token.claims.get("upstream_claims", {})
-        email = upstream.get("email") or upstream.get("preferred_username")
-    if not name:
-        upstream = token.claims.get("upstream_claims", {})
-        name = upstream.get("name") or email
+    claims = token.claims
+    upstream = claims.get("upstream_claims", {})
+    # Azure Entra ID: email is optional and preferred_username (UPN) may be
+    # the only identifier.  FastMCP validates the upstream Azure JWT and
+    # exposes its claims at the top level, but also embeds them under
+    # "upstream_claims" in its own reference JWT — check both paths.
+    email = (
+        claims.get("email")
+        or claims.get("preferred_username")
+        or upstream.get("email")
+        or upstream.get("preferred_username")
+    )
+    name = (
+        claims.get("name")
+        or upstream.get("name")
+        or email
+    )
     if not email:
         raise RuntimeError("Token missing 'email' claim")
     if not _looks_like_email(email):

--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -48,12 +48,29 @@ mcp = FastMCP(
 )
 
 
+def _looks_like_email(value: str) -> bool:
+    """Minimal check: contains exactly one '@' with text on both sides."""
+    parts = value.split("@")
+    return len(parts) == 2 and all(parts)
+
+
 async def _resolve_user(token: AccessToken) -> User:
     """Resolve the DB user from an authenticated OAuth access token."""
     email = token.claims.get("email")
-    name = token.claims.get("name", email)
+    name = token.claims.get("name")
+    # Azure Entra ID nests identity under upstream_claims
+    if not email:
+        upstream = token.claims.get("upstream_claims", {})
+        email = upstream.get("email") or upstream.get("preferred_username")
+    if not name:
+        upstream = token.claims.get("upstream_claims", {})
+        name = upstream.get("name") or email
     if not email:
         raise RuntimeError("Token missing 'email' claim")
+    if not _looks_like_email(email):
+        raise RuntimeError(
+            f"Resolved identity '{email}' is not a valid email address"
+        )
     return await get_or_create_user_by_email(email=email, name=name)
 
 

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -162,7 +162,42 @@ async def test_resolve_user_falls_back_email_as_name():
 
 
 @pytest.mark.asyncio
-async def test_resolve_user_azure_upstream_email():
+async def test_resolve_user_azure_preferred_username_top_level():
+    """Azure v2.0 tokens expose preferred_username at the top level."""
+    token = MagicMock()
+    token.claims = {"preferred_username": "jane@example.com", "name": "Jane Doe"}
+    mock_user = _make_user(email="jane@example.com", name="Jane Doe")
+
+    with patch(
+        "lib.api.mcp.get_or_create_user_by_email",
+        new=AsyncMock(return_value=mock_user),
+    ) as mock_get:
+        result = await _resolve_user(token)
+
+    mock_get.assert_awaited_once_with(email="jane@example.com", name="Jane Doe")
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_azure_preferred_username_no_name():
+    """Falls back to preferred_username as the display name."""
+    token = MagicMock()
+    token.claims = {"preferred_username": "jane@example.com"}
+    mock_user = _make_user(email="jane@example.com", name="jane@example.com")
+
+    with patch(
+        "lib.api.mcp.get_or_create_user_by_email",
+        new=AsyncMock(return_value=mock_user),
+    ) as mock_get:
+        result = await _resolve_user(token)
+
+    mock_get.assert_awaited_once_with(email="jane@example.com", name="jane@example.com")
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_azure_upstream_claims_email():
+    """FastMCP reference JWT embeds Azure claims under upstream_claims."""
     token = MagicMock()
     token.claims = {"upstream_claims": {"email": "jane@example.com", "name": "Jane Doe"}}
     mock_user = _make_user(email="jane@example.com", name="Jane Doe")
@@ -178,7 +213,8 @@ async def test_resolve_user_azure_upstream_email():
 
 
 @pytest.mark.asyncio
-async def test_resolve_user_azure_upstream_preferred_username():
+async def test_resolve_user_azure_upstream_claims_preferred_username():
+    """Falls back to upstream_claims.preferred_username when no email."""
     token = MagicMock()
     token.claims = {"upstream_claims": {"preferred_username": "jane@example.com"}}
     mock_user = _make_user(email="jane@example.com", name="jane@example.com")
@@ -194,15 +230,15 @@ async def test_resolve_user_azure_upstream_preferred_username():
 
 
 @pytest.mark.asyncio
-async def test_resolve_user_azure_upstream_with_name():
+async def test_resolve_user_email_takes_priority_over_preferred_username():
+    """Top-level email wins over preferred_username."""
     token = MagicMock()
     token.claims = {
-        "upstream_claims": {
-            "preferred_username": "jane@example.com",
-            "name": "Jane Doe",
-        }
+        "email": "official@example.com",
+        "preferred_username": "alias@example.com",
+        "name": "Jane Doe",
     }
-    mock_user = _make_user(email="jane@example.com", name="Jane Doe")
+    mock_user = _make_user(email="official@example.com", name="Jane Doe")
 
     with patch(
         "lib.api.mcp.get_or_create_user_by_email",
@@ -210,14 +246,14 @@ async def test_resolve_user_azure_upstream_with_name():
     ) as mock_get:
         result = await _resolve_user(token)
 
-    mock_get.assert_awaited_once_with(email="jane@example.com", name="Jane Doe")
+    mock_get.assert_awaited_once_with(email="official@example.com", name="Jane Doe")
     assert result is mock_user
 
 
 @pytest.mark.asyncio
-async def test_resolve_user_raises_when_no_email_in_upstream_claims():
+async def test_resolve_user_raises_when_no_email_anywhere():
     token = MagicMock()
-    token.claims = {"upstream_claims": {"name": "No Email User"}}
+    token.claims = {"name": "No Email User", "upstream_claims": {"name": "No Email"}}
 
     with pytest.raises(RuntimeError, match="Token missing 'email' claim"):
         await _resolve_user(token)
@@ -226,7 +262,7 @@ async def test_resolve_user_raises_when_no_email_in_upstream_claims():
 @pytest.mark.asyncio
 async def test_resolve_user_raises_when_preferred_username_not_email():
     token = MagicMock()
-    token.claims = {"upstream_claims": {"preferred_username": "jdoe"}}
+    token.claims = {"preferred_username": "jdoe"}
 
     with pytest.raises(RuntimeError, match="not a valid email address"):
         await _resolve_user(token)

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -161,6 +161,77 @@ async def test_resolve_user_falls_back_email_as_name():
     mock_get.assert_awaited_once_with(email="bob@example.com", name="bob@example.com")
 
 
+@pytest.mark.asyncio
+async def test_resolve_user_azure_upstream_email():
+    token = MagicMock()
+    token.claims = {"upstream_claims": {"email": "jane@example.com", "name": "Jane Doe"}}
+    mock_user = _make_user(email="jane@example.com", name="Jane Doe")
+
+    with patch(
+        "lib.api.mcp.get_or_create_user_by_email",
+        new=AsyncMock(return_value=mock_user),
+    ) as mock_get:
+        result = await _resolve_user(token)
+
+    mock_get.assert_awaited_once_with(email="jane@example.com", name="Jane Doe")
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_azure_upstream_preferred_username():
+    token = MagicMock()
+    token.claims = {"upstream_claims": {"preferred_username": "jane@example.com"}}
+    mock_user = _make_user(email="jane@example.com", name="jane@example.com")
+
+    with patch(
+        "lib.api.mcp.get_or_create_user_by_email",
+        new=AsyncMock(return_value=mock_user),
+    ) as mock_get:
+        result = await _resolve_user(token)
+
+    mock_get.assert_awaited_once_with(email="jane@example.com", name="jane@example.com")
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_azure_upstream_with_name():
+    token = MagicMock()
+    token.claims = {
+        "upstream_claims": {
+            "preferred_username": "jane@example.com",
+            "name": "Jane Doe",
+        }
+    }
+    mock_user = _make_user(email="jane@example.com", name="Jane Doe")
+
+    with patch(
+        "lib.api.mcp.get_or_create_user_by_email",
+        new=AsyncMock(return_value=mock_user),
+    ) as mock_get:
+        result = await _resolve_user(token)
+
+    mock_get.assert_awaited_once_with(email="jane@example.com", name="Jane Doe")
+    assert result is mock_user
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_raises_when_no_email_in_upstream_claims():
+    token = MagicMock()
+    token.claims = {"upstream_claims": {"name": "No Email User"}}
+
+    with pytest.raises(RuntimeError, match="Token missing 'email' claim"):
+        await _resolve_user(token)
+
+
+@pytest.mark.asyncio
+async def test_resolve_user_raises_when_preferred_username_not_email():
+    token = MagicMock()
+    token.claims = {"upstream_claims": {"preferred_username": "jdoe"}}
+
+    with pytest.raises(RuntimeError, match="not a valid email address"):
+        await _resolve_user(token)
+
+
 # --- create_project ---
 
 


### PR DESCRIPTION
## Summary

- Fix MCP auth crash for Azure Entra ID users by falling back to `upstream_claims` for email/name resolution
- Add email format validation to guard against non-email UPNs from `preferred_username`

## Motivation

RAND users authenticating via Azure Entra ID get a `RuntimeError: Token missing 'email' claim` because the MCP server only checks for a top-level `email` claim. Azure Entra ID (via FastMCP's `AzureProvider`) nests user identity under `upstream_claims.preferred_username` / `upstream_claims.email` instead. The Entra ID auth setup is working correctly — the token has the `mcp-access` scope and user identity, just under a different key path.

## What's Changed

### Backend

- **`lib/api/mcp.py`** — Updated `_resolve_user` to fall back to `upstream_claims.email` and `upstream_claims.preferred_username` when top-level `email` is absent. Added `_looks_like_email` helper to reject non-email UPNs. Existing behavior for Google OAuth tokens is preserved.
- **`tests/unit/test_mcp_tools.py`** — Added 5 new tests covering Azure upstream claims scenarios: email fallback, preferred_username fallback, name resolution, missing email error, and non-email UPN rejection.

### Frontend

No frontend changes.

## Risks and Mitigations

- **Risk:** `preferred_username` may not always be a valid email. **Mitigation:** Added `_looks_like_email` check that raises a clear error if the resolved identity isn't an email address.
- **Risk:** Regression for Google OAuth users. **Mitigation:** Existing tests still pass — top-level claims are checked first before falling back to `upstream_claims`.

Closes RANDZ-530

🤖 Generated with [Claude Code](https://claude.com/claude-code)