### PR TITLE
Fix 3 incorrect reference_validation eval dataset entries

### DIFF
--- a/evals_inspectai/e2e/reference_validation/dataset.json
+++ b/evals_inspectai/e2e/reference_validation/dataset.json
@@ -87,7 +87,7 @@
   {
     "input": "Najoung Kim and Tal Linzen. Cogs: A compositional generalization challenge based on semantic interpretation. In NAACL, 2021.",
     "target_final_result": "found_with_inconsistencies",
-    "target_answer": "Replace the incorrect author list (and add the arXiv identifier) to match the actual NeurIPS 2022 paper by Takuya Ito et al."
+    "target_answer": "Venue is wrong (should be EMNLP, not NAACL) and year is wrong (should be 2020, not 2021). Authors are correct."
   },
   {
     "input": "Brenden M. Lake and Marco Baroni. Generalization without systematicity: On the compositional skills of sequence-to-sequence recurrent networks. ICML, 2018.",
@@ -231,8 +231,8 @@
   },
   {
     "input": "Carter, Ashton B., \"0% Headquarters Reductions,\" memorandum to secretaries of the military departments et al., U.S. Department of Defense, July 31, 2013.",
-    "target_final_result": "valid",
-    "target_answer": "Valid government memorandum citation with potential small inconsistencies"
+    "target_final_result": "found_with_inconsistencies",
+    "target_answer": "The title is incorrect: the actual memo subject is '20% Headquarters Reductions', not '0% Headquarters Reductions'. Author, publisher, and date are correct."
   },
   {
     "input": "Embassy of the United States in Jordan, \"The United States and the Hashemite Kingdom of Jordan Sign Memorandum of Understanding on Assistance,\" press release, September 23, 2008.",

--- a/evals_inspectai/internal/reference_validation/reference_validation.py
+++ b/evals_inspectai/internal/reference_validation/reference_validation.py
@@ -16,7 +16,7 @@ from lib.agents.reference_validator import (
 @task
 def reference_validation():
     dataset = json_dataset(
-        "../../e2e/reference_validation/dataset.jsonl",
+        "../../e2e/reference_validation/dataset.json",
         FieldSpec(target="target_final_result", metadata=["target_answer"]),
     )
 


### PR DESCRIPTION
## Summary

- Corrects 2 incorrect expected values in the `reference_validation` eval dataset, verified against real-world sources
- Fixes the internal eval's dataset file path (`.jsonl` → `.json`)

## Motivation

Running the internal `reference_validation` eval (2 epochs, 52 samples) revealed 14 failing samples. After manually verifying each failure against the actual sources (web search, fetching URLs, checking government databases), 2 of the failures turned out to be dataset errors rather than agent errors.

## What's Changed

### Backend

**`evals_inspectai/e2e/reference_validation/dataset.json`**
- **Sample 18** (Kim & Linzen "COGS" paper): Fixed a copy-paste error in `target_answer`. The previous answer incorrectly said to "replace with Ito et al. NeurIPS 2022 paper" — a completely unrelated paper. The real issues are: venue is wrong (should be EMNLP, not NAACL) and year is wrong (should be 2020, not 2021).
- **Sample 47** (Carter "0% Headquarters Reductions" memo): Changed `target_final_result` from `valid` to `found_with_inconsistencies`. The actual memo subject is "**20%** Headquarters Reductions" per USNI News, SlideShare scan of the memo, and DVIDS reporting.

**`evals_inspectai/internal/reference_validation/reference_validation.py`**
- Fixed dataset path from `dataset.jsonl` to `dataset.json` (the actual file extension).

## Risks and Mitigations

Low risk — only eval dataset and eval task file are changed, no production code affected. The fixes were individually verified against authoritative sources (arXiv, ACL Anthology, USNI News).

🤖 Generated with [Claude Code](https://claude.com/claude-code)