### PR TITLE
feat(evals): distinguish rate-limit errors from failed scores

### DIFF
--- a/evals_inspectai/common/api_client.py
+++ b/evals_inspectai/common/api_client.py
@@ -11,6 +11,8 @@ from typing import Any
 import httpx
 import jwt
 
+from evals_inspectai.common.errors import check_workflow_errors
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "http://localhost:8000"
@@ -168,6 +170,7 @@ async def poll_workflow_run_until_complete(
             status = run_detail.get("run", {}).get("status")
             if status == "completed":
                 logger.info("Workflow run %s completed", workflow_run_id)
+                check_workflow_errors(run_detail.get("state") or {})
                 return run_detail
             logger.debug(
                 "Workflow run %s status=%s, polling again in %ss",
@@ -209,6 +212,7 @@ async def poll_until_complete(
                         workflow_type,
                         run.get("id"),
                     )
+                    check_workflow_errors(run_detail.get("state") or {})
                     return run_detail
                 logger.debug(
                     "Workflow %s status=%s, polling again in %ss",

--- a/evals_inspectai/common/api_solver.py
+++ b/evals_inspectai/common/api_solver.py
@@ -12,7 +12,6 @@ from evals_inspectai.common.api_client import (
     upload_and_start_analysis,
 )
 from evals_inspectai.common.converters import messages_from_langchain
-from evals_inspectai.common.errors import check_workflow_errors
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +48,6 @@ def api_workflow_agent(
         )
 
         workflow_state = run_detail.get("state") or {}
-        check_workflow_errors(workflow_state)
 
         raw_messages = workflow_state.pop("messages", [])
         if raw_messages:

--- a/evals_inspectai/common/api_solver.py
+++ b/evals_inspectai/common/api_solver.py
@@ -12,6 +12,7 @@ from evals_inspectai.common.api_client import (
     upload_and_start_analysis,
 )
 from evals_inspectai.common.converters import messages_from_langchain
+from evals_inspectai.common.errors import check_workflow_errors
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ def api_workflow_agent(
         )
 
         workflow_state = run_detail.get("state") or {}
+        check_workflow_errors(workflow_state)
 
         raw_messages = workflow_state.pop("messages", [])
         if raw_messages:

--- a/evals_inspectai/common/errors.py
+++ b/evals_inspectai/common/errors.py
@@ -1,0 +1,48 @@
+"""Error utilities for Inspect AI eval solvers.
+
+Provides a custom exception and checker to surface workflow-level errors
+(e.g. rate-limit 429s, timeouts) as Inspect AI sample errors rather than
+letting them be silently scored as INCORRECT.
+"""
+
+from typing import Any
+
+
+class WorkflowCompletionError(Exception):
+    """Raised when a completed workflow contains errors in its state.
+
+    When this exception propagates during an Inspect AI eval, the framework
+    records it as ``EvalSample.error`` and excludes the sample from score
+    metrics — making completion errors visually distinct from genuine
+    scoring misses.
+    """
+
+
+def check_workflow_errors(workflow_state: dict[str, Any]) -> None:
+    """Raise if the workflow state contains any errors.
+
+    Inspects the ``errors`` list present on every workflow state (inherited
+    from ``BaseWorkflowState``).  Each entry is a ``WorkflowError`` dict
+    with at least a ``task_name`` and ``error`` field.
+
+    Args:
+        workflow_state: The deserialized workflow state dict.
+
+    Raises:
+        WorkflowCompletionError: If one or more errors are present.
+    """
+    errors = workflow_state.get("errors", [])
+    if not errors:
+        return
+
+    messages = []
+    for entry in errors:
+        if isinstance(entry, dict):
+            task = entry.get("task_name", "unknown")
+            error = entry.get("error", "unknown error")
+            messages.append(f"{task}: {error}")
+
+    raise WorkflowCompletionError(
+        f"Workflow completed with {len(messages)} error(s): "
+        + "; ".join(messages)
+    )

--- a/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
+++ b/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
@@ -15,7 +15,7 @@ from evals_inspectai.common.api_client import (
     start_workflow,
     upload_and_start_analysis,
 )
-from evals_inspectai.common.errors import WorkflowCompletionError, check_workflow_errors
+from evals_inspectai.common.errors import WorkflowCompletionError
 from evals_inspectai.common.scorers import structured_output_scorer
 
 
@@ -99,7 +99,6 @@ def _reference_downloader_api_agent(
         )
 
         workflow_state = run_detail.get("state") or {}
-        check_workflow_errors(workflow_state)
         _check_item_errors(workflow_state)
 
         state.output = ModelOutput(

--- a/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
+++ b/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
@@ -15,6 +15,7 @@ from evals_inspectai.common.api_client import (
     start_workflow,
     upload_and_start_analysis,
 )
+from evals_inspectai.common.errors import WorkflowCompletionError, check_workflow_errors
 from evals_inspectai.common.scorers import structured_output_scorer
 
 
@@ -98,6 +99,8 @@ def _reference_downloader_api_agent(
         )
 
         workflow_state = run_detail.get("state") or {}
+        check_workflow_errors(workflow_state)
+        _check_item_errors(workflow_state)
 
         state.output = ModelOutput(
             completion=json.dumps(workflow_state),
@@ -106,6 +109,16 @@ def _reference_downloader_api_agent(
         return state
 
     return execute
+
+
+def _check_item_errors(workflow_state: dict) -> None:
+    """Raise if any fetched reference has a per-item error."""
+    for item in workflow_state.get("fetched_references", []):
+        if isinstance(item, dict) and item.get("error"):
+            raise WorkflowCompletionError(
+                f"Reference '{item.get('input_reference', '?')}' "
+                f"failed: {item['error']}"
+            )
 
 
 def _compare_final_conclusion(

--- a/evals_inspectai/e2e/reference_validation/reference_validation_e2e.py
+++ b/evals_inspectai/e2e/reference_validation/reference_validation_e2e.py
@@ -8,6 +8,7 @@ from inspect_ai.solver import TaskState
 from pydantic import BaseModel, Field
 
 from evals_inspectai.common.api_solver import api_workflow_agent
+from evals_inspectai.common.errors import WorkflowCompletionError
 from evals_inspectai.common.scorers import model_graded_check, structured_output_scorer
 
 
@@ -85,6 +86,10 @@ def _compare_final_result(output: ReferenceValidationOutput, state: TaskState) -
         return Score(value=INCORRECT, explanation="No reference validations found")
 
     first = output.reference_validations[0]
+    if first.error:
+        raise WorkflowCompletionError(
+            f"Reference '{first.input_reference}' failed: {first.error}"
+        )
     if first.validation_result is None:
         return Score(value=INCORRECT, explanation="No validation result found")
 


### PR DESCRIPTION
## Summary

- When a workflow completes with errors (e.g. 429 rate limits, timeouts), eval solvers now raise `WorkflowCompletionError` so Inspect AI records the sample as an error instead of scoring it as INCORRECT
- This makes completion errors visually distinct from genuine scoring misses in `inspect view`

## Motivation

Feedback from Emily Lathrop: when reviewing Inspect eval results, a failed sample could mean either "the workflow hit a 429 rate limit" or "the completion was scored as incorrect." These were indistinguishable at a glance — you had to open `inspect view` and examine per-sample JSON to tell them apart.

## What's Changed

### Backend

- **`evals_inspectai/common/errors.py`** (new): `WorkflowCompletionError` exception and `check_workflow_errors()` utility that inspects the `errors` list in workflow state (present on all states via `BaseWorkflowState`) and raises if non-empty
- **`evals_inspectai/common/api_solver.py`**: Added `check_workflow_errors()` call after getting workflow state — covers all e2e evals using `api_workflow_agent`
- **`evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py`**: Added top-level and per-item error checks in the custom solver (reference_downloader has its own solver)
- **`evals_inspectai/e2e/reference_validation/reference_validation_e2e.py`**: Added per-item error check in `_compare_final_result` for fan-out item-level errors

### Frontend

No frontend changes.

## Risks and Mitigations

- **Evals now fail on workflow errors by default**: This is intentional — use `--no-fail-on-error` flag to continue running other samples when errors occur. This matches Inspect AI's design for handling sample errors.
- **No changes to workflow source code or scoring logic**: The error information was already present in workflow state; we just detect and surface it now.

Closes [RANDZ-525](https://linear.app/ae-studio/issue/RANDZ-525)

🤖 Generated with [Claude Code](https://claude.com/claude-code)