### PR TITLE
feat(reference-validator): rewrite prompt as six-step procedure

### DIFF
--- a/lib/agents/reference_validator.py
+++ b/lib/agents/reference_validator.py
@@ -67,56 +67,94 @@ class BibliographyItemValidation(BaseModel):
     )
 
 
-SYSTEM_PROMPT = """Validate a single bibliographic reference by searching for it online and checking its accuracy.
+SYSTEM_PROMPT = """Validate a single bibliographic reference by finding the cited work online and comparing it to the reference. The next message contains the reference to validate — follow the six-step procedure below.
 
-You will receive one reference item from a document's bibliography. Use web search to locate the cited work, then verify each field against the authoritative source you find.
+# Step 1 — Parse the reference
 
-# Validation procedure
+Read the reference and note:
+- What type of work it is (journal article, preprint, book, webpage, press release, government report, briefing slides, etc.).
+- Which fields are present: author, title, publisher/venue, year, identifier (DOI, arXiv ID, ISBN, ISSN), URL.
 
-1. If the reference includes a URL, fetch that exact URL to confirm it resolves to real content. Do not assume a URL is valid just because it has a plausible domain or path structure.
-   - If the URL is live, check whether the page content matches the reference's metadata (title, author, year, etc.) and proceed with field-by-field validation.
-   - If the reference is a bare URL with no bibliographic metadata, apply the "Bare URL references" rules below regardless of whether the URL is reachable.
-   - If the URL is dead (404, error page, etc.) and the reference includes bibliographic metadata (title, authors), search for the exact title to determine whether the cited work exists elsewhere. Only consider it a match if the title and authors are the same — a different work on a similar topic is not a match. If you find the exact work at a different URL, flag the URL as inconsistent. If you cannot find the exact work anywhere, the reference is `not_found`.
-2. Search for the reference online to find a matching legitimate source.
-3. For each field (author, title, publisher, year, identifier), compare the reference's value against what you found online.
-4. Determine whether the reference is valid overall.
+Special case — bare URL: if the reference is only a URL with no bibliographic metadata, skip ahead to Step 6 with final_result `found_with_inconsistencies`. Reconstruct the full citation from the URL's content and populate `updated_reference`. Mark all five field validations as MISSING except `identifier`, which may be the URL itself or MISSING.
 
-# Field validation rules
+# Step 2 — Resolve the URL (if the reference contains one)
 
-- **Author**: Verify all listed authors exist and names are spelled correctly. Both "first last" and "last, F." formats are acceptable. "et al." is valid for truncating author lists.
-- **Title**: Verify the title matches the source **in wording only**. Capitalization and minor punctuation differences are NEVER errors. Example: current value "Webvoyager: Building an end-to-end web agent with large multimodal models." vs. authoritative "WebVoyager: Building an End-to-End Web Agent with Large Multimodal Models" → mark CORRECT because the words are the same. The authoritative title is the one displayed in the **content body** of the page (typically the `<h1>` heading or article headline), NOT the browser tab title (`<title>` tag), social sharing title (`og:title`), or search engine snippet. These metadata titles are often shortened, reworded, or sanitized versions of the real headline. For PDF-linked articles, prefer the title inside the PDF over the webpage title.
-- **Publisher**: Verify the publisher matches. Abbreviations are equivalent to full names (e.g., "ACM" = "Association for Computing Machinery"). Capitalization differences are not errors.
-- **Year**: Verify the publication year is correct.
-- **Identifier**: Verify any persistent identifier such as a DOI, arXiv ID, ISBN, ISSN, or similar. If the reference includes one, check that it resolves to the correct work. If the reference omits an identifier but one exists for the work, mark as MISSING and provide the correct identifier as the suggested value. If no identifier exists for the work, mark as CORRECT with an empty current_value and suggested_value.
+Fetch the URL exactly as given. One of three outcomes:
 
-# Formatting policy
+- URL resolves to real content that appears to match the reference → use that page as your primary authoritative source. Continue to Step 4.
+- URL resolves but the page is clearly unrelated (a different article, a generic landing page) → note the URL as inconsistent. Continue to Step 3 to search.
+- URL returns 404 or error → the URL is inconsistent or fabricated. Continue to Step 3.
 
-Accept any broadly recognizable citation style (APA, Chicago, MLA, IEEE, etc.). Do not flag minor stylistic differences such as capitalization, punctuation choice, field ordering, or comma vs. period usage. Capitalization variants (title case, sentence case, all caps) and minor punctuation differences (trailing periods, commas vs. semicolons, hyphens vs. dashes) must be treated as equivalent. Page ranges (e.g., "pp. 1-10") should be ignored for validation purposes — do not flag them as incorrect or missing. Focus exclusively on content accuracy, not style conformance.
+Do NOT treat a URL as valid just because its domain/path looks plausible — you must confirm the page actually exists and has real content.
 
-# Bare URL references
+# Step 3 — Search the web for the cited work
 
-A reference consisting solely of a URL with no bibliographic metadata is always invalid. Mark all five fields as MISSING and reconstruct the full citation from the URL's content in updated_reference.
+Search using the reference's title (quote distinctive phrases) together with a key author surname and/or year. For references with a DOI or arXiv ID, resolve the identifier first and use the canonical page — BUT if the resolved work's title clearly does not match the reference's title, treat the identifier as incorrect or fabricated and search by title instead. Do NOT accept an unrelated work as your candidate just because an identifier happened to resolve to it; when this happens, flag the identifier as INCORRECT in Step 5 and use the title-based candidate for the other fields.
 
-# Output logic
+Pick the single best candidate that plausibly IS the cited work. If no candidate matches the cited title or authors, stop and go to Step 6 with `not_found`.
 
-- **Capitalization/punctuation check (apply first)**: Before marking any field INCORRECT, ask: "If I ignore uppercase/lowercase differences and minor punctuation (periods, commas, hyphens, colons), do the two values convey the same words?" If yes → the field is CORRECT.
-- Set problem_type to CORRECT when the field's value matches the authoritative source in wording (suggested_value equals current_value ignoring case and punctuation).
-- Set problem_type to MISSING when the field is absent from the reference.
-- Set problem_type to INCORRECT only when the field contains different words, different names, wrong numbers, or factually wrong information.
-- Set final_result to one of: `valid`, `found_with_inconsistencies`, or `not_found`:
-  - `valid`: the reference was found online and any differences are trivial or non-actionable. Use `valid` even when minor fields are technically missing or slightly off, as long as the reference clearly identifies the correct work. Examples of trivial differences that should remain `valid`: a missing DOI when an arXiv ID (or other identifier) is already present, minor author name format variations (initials vs. full first names), a missing publisher when the venue is obvious, or slight title wording differences that don't change meaning.
-  - `found_with_inconsistencies`: the reference was found online but has **substantial** errors that would mislead a reader or make the work hard to locate — e.g., wrong author names, a factually incorrect title, wrong publication year, or a completely missing title/author. Reserve this status for differences that genuinely need to be corrected.
-  - `not_found`: the reference could not be located online, or the identifiers/URLs/authors appear fabricated or point to a different work.
-- When invalid, write a single-sentence suggested_action summarizing what to fix.
-- When invalid and a matching source was found, provide updated_reference with corrections applied, preserving the original citation format. When valid, or when no matching source could be found online, set updated_reference to null.
+ArXiv-specific rules:
+- ArXiv versioning: when the reference cites an arXiv paper WITHOUT a version suffix (e.g., `arXiv:2311.16169` rather than `arXiv:2311.16169v1`), treat the MOST RECENT version on arXiv as authoritative — its title, author list, and most-recent submission year. When the reference explicitly pins a version (e.g., `arxiv.org/abs/2406.01637v1`), treat that version as authoritative instead.
+- ArXiv HTML view: URLs of the form `arxiv.org/html/...` sometimes contain rendering artifacts that produce incorrect-looking titles. Do not take the title from the HTML view. Prefer, in order: (a) the title from the official conference/journal publication if one exists, (b) the arXiv abstract page `arxiv.org/abs/...`, (c) the PDF.
+- ArXiv + official publication: if a paper has both an arXiv preprint and an official conference/journal publication (e.g., IEEE S&P, ACM CSCW, NeurIPS), the official venue is the preferred publisher; the arXiv ID remains a valid identifier.
+
+# Step 4 — Decide whether the candidate is the same work
+
+Before comparing fields, confirm the candidate source IS the cited work. Compare the candidate's title to the reference's title, ignoring case and punctuation:
+
+- Titles match in wording → it is the SAME WORK. Proceed to Step 5. (Any disagreements in author, publisher, or year are attribution errors in the citation, not a mis-match.)
+- Titles clearly differ in wording AND two or more of {author, publisher, year} also differ → the candidate is a DIFFERENT WORK on a related topic. Go to Step 6 with `not_found`. Do not try to "rescue" a bad reference by treating a different work as a match.
+- Titles differ but author, publisher, and year all line up → likely the same work under a retitling or reprinting. Treat as same work and continue to Step 5.
+
+# Step 5 — Compare each field
+
+For each of author, title, publisher, year, identifier, set `problem_type`:
+
+- CORRECT — the reference matches the authoritative source in substance. Apply CORRECT when the only differences are:
+  * Capitalization (title case vs sentence case vs all caps)
+  * Punctuation (commas, periods, hyphens/dashes, colons, quotation marks, trailing separators)
+  * Author name form (full first name vs initial, middle initial present/absent, surname particles like "von"/"de"/"van" present/absent)
+  * Truncated author lists (the reference lists the first N authors, with or without "et al.", while the full work has more authors — this is a valid citation style, not an error)
+  * Organization form (well-known abbreviation vs full name — e.g., "ACM" = "Association for Computing Machinery", "DMDC" = "Defense Manpower Data Center"; current brand vs recent rebrand — e.g., "Raytheon Technologies" = "RTX")
+  * Field ordering
+  * Page ranges (ignore entirely)
+- MISSING — the field is absent from the reference but exists for the work.
+- INCORRECT — the reference contains substantively different content: different words, different people, wrong numbers, wrong dates, historically incorrect names (e.g., a pre-1947 government title used to cite a modern agency).
+
+Field-specific notes:
+- Title: use the title that appears in the main content body of the authoritative page — the `<h1>` heading, the article headline, or the title page of a PDF. Do NOT use the browser tab `<title>` tag, the `og:title` social-sharing title, or a search-engine snippet — these are often shortened or sanitized. For PDF-linked articles, prefer the title inside the PDF.
+- Identifier: a DOI, arXiv ID, ISBN, or ISSN all qualify. If the reference includes one, check it resolves to the correct work. Accept equivalent forms: a URL that resolves to a persistent identifier (e.g., `https://doi.org/10.xxxx/...`, `https://dl.acm.org/doi/pdf/10.xxxx/...`, `https://arxiv.org/abs/...`) is equivalent to the bare identifier — do NOT flag the URL form as INCORRECT just because the bare DOI or arXiv ID is the canonical form. If the reference omits an identifier but one exists, mark MISSING. If no identifier exists at all, mark CORRECT with empty values. A missing DOI when an arXiv ID is already present is NOT an error.
+- Author for institutional works: when the publishing organization is listed as the author (press releases, homepages, government reports, briefing slides, datasets, policy directives), the org name is the author. Do not demand a list of individuals.
+
+# Step 6 — Decide the final result
+
+Apply in order:
+
+1. No candidate found, OR candidate is a different work (per Step 4) → `final_result = "not_found"`. Set `updated_reference = null`.
+2. Same work, zero INCORRECT fields, and no MISSING key fields (title, author) → `final_result = "valid"`. Set `updated_reference = null`.
+3. Same work, at least one INCORRECT field or a MISSING key field → `final_result = "found_with_inconsistencies"`. Populate `updated_reference` with the corrections applied, preserving the reference's original citation style.
+
+When you are on the boundary between `valid` and `found_with_inconsistencies`, default to `valid`. Only escalate to `found_with_inconsistencies` when the errors would mislead a reader or make the work hard to locate. Specifically, these remain `valid`:
+- A missing identifier when the reference has a resolving URL or clear venue
+- Minor name-form variations covered by the CORRECT rules above
+- Slight title wording differences that do not change meaning
+- A missing publisher/venue when it is obvious from the rest of the citation
+
+Reserve `found_with_inconsistencies` for substantive errors: wrong author names, a factually wrong title (different words), wrong year, a DOI or URL that resolves to a different work.
+
+# Output fields
+
+- `original_reference` — the reference as given.
+- `final_result` — `valid` / `found_with_inconsistencies` / `not_found`.
+- `bibliography_field_validations` — one entry per field with `current_value`, `suggested_value`, `problem_type`.
+- `url` — the URL identifying the cited work (from the reference, identifier resolution, or your search). Empty string when `not_found`.
+- `reasoning` — a brief step-by-step summary of how you validated.
+- `suggested_action` — one sentence describing what to fix; `"No changes needed"` when `valid`.
+- `updated_reference` — corrected citation in the reference's original format when `found_with_inconsistencies`; otherwise `null`.
 
 # Response hygiene
 
-Never include internal search tokens (e.g., turn0search0, turn2search3) or raw metadata markers in any output field. All text must be clean and human-readable.
-
----
-
-The reference to validate will be provided in the next message."""
+Never include internal search tokens (e.g., `turn0search0`) or raw metadata markers in any output field. All text must be clean and human-readable."""
 
 
 class ReferenceValidatorAgent(LangChainAgent):


### PR DESCRIPTION
## Summary

Rewrites the reference validator agent's system prompt as a clear six-step procedure and adds targeted rules for common failure modes surfaced by Emily's newly-added eval cases (PR #498) plus previously-failing baseline tests. Lifts `structured_output_scorer` mean on the `reference_validation` internal eval from **0.821 → 0.881** (+0.060).

## Motivation

Emily added 14 new reference_validation eval cases covering known agent failure patterns: arXiv versioning, arXiv HTML rendering artifacts, fabricated blog URLs that were being "rescued" into loosely-similar matches, minor author-name variants, and organization rebrand/abbreviation tolerance. The prior prompt had accumulated patches and implicit rules that the model wasn't applying consistently. Rather than adding another patch, this PR restructures the prompt into an explicit step-by-step procedure and folds in targeted rules for the new failure modes.

## What's Changed

### Backend

- `lib/agents/reference_validator.py` — rewrote the `SYSTEM_PROMPT`:
  - **Structure**: six numbered steps (Parse → Resolve URL → Search → Match check → Field compare → Final result), replacing the prior mix of rules, exceptions, and sub-sections.
  - **Match-vs-different-work test (Step 4)**: before comparing fields, confirm the candidate source is actually the cited work. Title-identity ⇒ same work (even if other fields differ); if title differs AND 2+ of {author, publisher, year} differ, the candidate is a different work → `not_found`. Prevents the agent from "rescuing" fabricated references by matching loosely-similar sources.
  - **ArXiv versioning rule (Step 3)**: for unversioned arXiv citations, use the most recent version as authoritative (title, author list, year). Honors explicit version pins (`arxiv.org/abs/.../v1`).
  - **ArXiv HTML view rule (Step 3)**: `arxiv.org/html/` pages often have rendering artifacts; prefer official publication → arXiv abstract → PDF for title extraction.
  - **ArXiv + official publication (Step 3)**: when a paper has both a preprint and a conference/journal version, the official venue is the preferred publisher (arXiv ID still qualifies as identifier).
  - **Unrelated-ID guard (Step 3)**: if a DOI or arXiv ID resolves to a work whose title clearly doesn't match the reference's title, treat the identifier as fabricated, flag it INCORRECT, and search by title instead.
  - **URL-form identifier equivalence (Step 5)**: a URL that resolves to a persistent identifier (e.g. `https://doi.org/...`, `https://dl.acm.org/doi/pdf/...`, `https://arxiv.org/abs/...`) is equivalent to the bare identifier — don't flag the URL form as INCORRECT.
  - **Expanded CORRECT criteria (Step 5)**: surname particles (von/de/van), organization rebrands/abbreviations (RTX ↔ Raytheon Technologies; DMDC ↔ Defense Manpower Data Center), truncated author lists with or without `et al.`, and institutional-org authorship for government/press-release works.

No other files changed. No frontend changes.

## Tests

Ran `uv run inspect eval evals_inspectai/internal/reference_validation/reference_validation.py --epochs=2` across multiple prompt iterations (gpt-5.4, 67 samples × 2 epochs = 134 runs each):

| Iteration | Description | `structured_output_scorer` | `model_graded_check` | Epoch passes |
|---|---|---|---|---|
| Baseline | Pre-change prompt | 0.821 | 0.918 | 110/134 |
| Iter 1 | First targeted rule | 0.851 | 0.925 | 114/134 |
| Iter 2 | Full rewrite | 0.843 | 0.933 | 113/134 |
| Iter 3 | + URL-form + unrelated-ID fixes | 0.866 | 0.922 | 116/134 |
| Iter 4 | + stricter Step 5/6 (reverted — overshoot) | 0.806 | 0.933 | 108/134 |
| **Final** | Iter 3 + truncated author lists | **0.881** | **0.933** | **118/134** |

**Net vs baseline**: 7 samples improved, 2 stochastic one-epoch regressions (samples 35 Xinhua wire, 40 Bluesky post).

### Emily's 14 new eval cases

| # | Case | Baseline | Final |
|---|---|---|---|
| 52 | Microsoft blog fake URL | 1/2 | **2/2** ✓ |
| 53 | Bass 1969 Management Science | 2/2 | 2/2 |
| 54 | Medium redirect | 2/2 | 2/2 |
| 55 | Frontier Model Forum | 2/2 | 2/2 |
| 56 | Google SAIF fake URL | 0/2 | 0/2 (was 2/2 in iter 3 — likely 2-epoch noise) |
| 57 | Khare arXiv year | 0/2 | **2/2** ✓ |
| 58 | Fang arXiv v2 authors | 1/2 | **2/2** ✓ |
| 59 | Kwa arXiv v3 | 2/2 | 2/2 |
| 61 | Stevens NDSS missing venue | 0/2 | 0/2 (policy conflict — see Next Steps) |
| 63 | "von Stockhausen" | 1/2 | 1/2 (stochastic) |
| 65 | Pearce IEEE S&P year | 2/2 | 2/2 |
| 66 | Tihanyi arXiv HTML view | 1/2 | **2/2** ✓ |

4 of Emily's noted failure cases (52, 57, 58, 66) now reliably pass at epochs=2.

## Risks and Mitigations

- **Longer, more prescriptive prompt could reduce flexibility in edge cases** — iterative evaluation revealed and corrected over-prescriptive cases (see iter 4). Final prompt preserves the "lean valid" defaulting rule to handle ambiguity.
- **Two samples regressed vs baseline by one epoch each** (35, 40) — both are single-epoch stochastic flips, not deterministic failures. Acceptable trade-off given the 7 samples improved.
- **ArXiv + official-publication rule can promote a citation past what the author intended** — Emily's sample 57 specifically tests this and now passes. If this becomes an issue in production, a follow-up rule can exempt references that explicitly self-identify as arXiv-only.

## Next steps (for future iterations)

1. **Government/official-doc over-flagging** (samples 41 Air Force policy directive, 46 briefing slides, 48 embassy press release, 50 DMDC — some now partially fixed). The agent still flags subtle author/publisher/identifier differences on institutional works. Would benefit from per-case triage rather than a broad rule.
2. **Sample 61 (Stevens NDSS)** — target is `found_with_inconsistencies` because publisher/venue is missing, but the current "missing venue when obvious" rule keeps it `valid`. Needs a product decision: should a missing NDSS venue when the DOI contains `ndss.2020.` be called out, or treated as obvious-from-identifier?
3. **Sample 39 (Office of the Under Secretary of War)** — requires the agent to recognize a pre-1947 government title as a substantive error. Inconsistent at epochs=2.
4. **Stochastic samples 56, 63, 66** — rules are pointing the right way but coverage is uneven. Consider a higher-epoch routine eval to distinguish genuine regressions from noise.
5. **Sample 31 (URL-form identifier)** — reached 2/2 in iter 3 and dropped to 1/2 in the final run. Low-cost confirmation: targeted higher-epoch re-run after merge.
6. **Eval determinism** — multiple cases pass 1/2 consistently across iterations. Consider raising default eval epochs or adding a variance column to the eval summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)