### PR TITLE
feat(streaming): stream deep-agent messages to client mid-run

### DIFF
--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -58,27 +58,20 @@ function IssuesList({ result }: { result: AgentCheckResult }) {
 }
 
 export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleDeepAgentResultsProps) {
+  const isRunning = isWorkflowProcessing(workflowDetail);
+  const isCancelled = isWorkflowCancelled(workflowDetail);
+
   const messages = workflowDetail.state?.messages ?? [];
   const displayedMessages = messages.filter((message) => message.type !== 'tool');
 
   const runtime = useExternalStoreRuntime({
     messages: displayedMessages,
     convertMessage: (message) => convertLangChainMessages(message as LangChainMessage, {}) as ThreadMessageLike,
-    isRunning: false,
+    isRunning,
     onNew: async () => {},
   });
 
-  if (isWorkflowProcessing(workflowDetail)) {
-    return (
-      <EmptyState
-        icon={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />}
-        message={`Analyzing Document…`}
-        description={`The ${workflowName} analysis is currently running. Results will appear here once complete.`}
-      />
-    );
-  }
-
-  if (isWorkflowCancelled(workflowDetail)) {
+  if (isCancelled) {
     return (
       <EmptyState
         icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
@@ -89,15 +82,16 @@ export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleD
   }
 
   const state = workflowDetail.state as SimpleDeepAgentState | undefined;
+  const result = state?.result;
 
-  if (!state?.result) {
-    return <EmptyState message="No results available for this workflow run." />;
-  }
-
-  const { result } = state;
+  // While running, default to the Messages tab so users see live agent
+  // activity immediately. The backend appends messages to state.messages
+  // mid-run, and the existing 3s polling on useProjectDetails re-renders
+  // this component with the growing list.
+  const defaultTab = isRunning || !result ? 'messages' : 'results';
 
   return (
-    <Tabs defaultValue="results">
+    <Tabs defaultValue={defaultTab}>
       <TabsList>
         <TabsTrigger value="results" className="gap-1.5">
           <ClipboardList className="h-3.5 w-3.5" />
@@ -106,28 +100,48 @@ export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleD
         <TabsTrigger value="messages" className="gap-1.5">
           <MessageSquare className="h-3.5 w-3.5" />
           Messages
+          {isRunning && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
         </TabsTrigger>
       </TabsList>
 
       <TabsContent value="results" className="space-y-4">
-        <IssuesList result={result} />
-
-        {result.report_markdown && (
-          <Card className="gap-2">
-            <CardHeader>
-              <CardTitle className="text-sm">Report</CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm">
-              <Markdown>{result.report_markdown}</Markdown>
-            </CardContent>
-          </Card>
+        {result ? (
+          <>
+            <IssuesList result={result} />
+            {result.report_markdown && (
+              <Card className="gap-2">
+                <CardHeader>
+                  <CardTitle className="text-sm">Report</CardTitle>
+                </CardHeader>
+                <CardContent className="text-sm">
+                  <Markdown>{result.report_markdown}</Markdown>
+                </CardContent>
+              </Card>
+            )}
+          </>
+        ) : isRunning ? (
+          <EmptyState
+            icon={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />}
+            message="Analyzing Document…"
+            description={`The ${workflowName} analysis is currently running. Switch to Messages to see the agent's progress, or wait for results here.`}
+          />
+        ) : (
+          <EmptyState message="No results available for this workflow run." />
         )}
       </TabsContent>
 
       <TabsContent value="messages" className="mt-4">
-        <AssistantRuntimeProvider runtime={runtime}>
-          <ReadonlyThread />
-        </AssistantRuntimeProvider>
+        {displayedMessages.length === 0 && isRunning ? (
+          <EmptyState
+            icon={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />}
+            message="Starting analysis…"
+            description="The agent is warming up. Messages will appear here as the analysis progresses."
+          />
+        ) : (
+          <AssistantRuntimeProvider runtime={runtime}>
+            <ReadonlyThread />
+          </AssistantRuntimeProvider>
+        )}
       </TabsContent>
     </Tabs>
   );

--- a/lib/services/live_message_writer.py
+++ b/lib/services/live_message_writer.py
@@ -1,0 +1,110 @@
+"""Appends deep-agent messages to a running workflow's state.
+
+The writer is built in the runner (`lib/workflows/runner.py`) and attached to
+`ContextSchema.live_message_writer` for workflows whose manifest opts in via
+`supports_live_messages`. Inside the workflow node, the agent calls
+`append(message)` each time an LLM response or tool result completes, which:
+
+1. Redacts the message (API-key scrubbing + tool-output truncation).
+2. Writes a LangGraph checkpoint appending the message to `state.messages`
+   via `add_messages`, so the existing GET /api/workflows/{id} polling
+   endpoint sees the growing conversation on its next tick.
+
+Single-node simple-deep-agent graphs are the only current caller, so there's
+no contention with concurrent node writers on the same thread.
+"""
+
+import copy
+import logging
+import re
+from typing import Any
+
+from langchain_core.messages import BaseMessage, ToolMessage
+from langgraph.graph.state import CompiledStateGraph
+
+logger = logging.getLogger(__name__)
+
+# OpenAI-style API key pattern. Defense in depth — keys should never make it
+# into messages, but redact on the off-chance they do.
+_API_KEY_PATTERN = re.compile(r"sk-[A-Za-z0-9_-]{20,}")
+_REDACTED_PLACEHOLDER = "[REDACTED_API_KEY]"
+
+# Tool outputs can be very large (full document snippets, search results).
+# Cap what we append to state so checkpoints stay a reasonable size. The
+# final state still reflects what the agent saw — only the persisted copy
+# is truncated.
+_MAX_TOOL_CONTENT_CHARS = 10_000
+_TRUNCATION_MARKER = "\n…[truncated]"
+
+
+def _redact_str(value: str) -> str:
+    return _API_KEY_PATTERN.sub(_REDACTED_PLACEHOLDER, value)
+
+
+def _redact_content(content: Any) -> Any:
+    """Redact API keys anywhere in a string or nested content block list."""
+    if isinstance(content, str):
+        return _redact_str(content)
+    if isinstance(content, list):
+        return [_redact_content(item) for item in content]
+    if isinstance(content, dict):
+        return {k: _redact_content(v) for k, v in content.items()}
+    return content
+
+
+def _truncate_tool_content(content: Any) -> Any:
+    """Cap ToolMessage content at `_MAX_TOOL_CONTENT_CHARS`."""
+    if isinstance(content, str) and len(content) > _MAX_TOOL_CONTENT_CHARS:
+        return content[:_MAX_TOOL_CONTENT_CHARS] + _TRUNCATION_MARKER
+    if isinstance(content, list):
+        return [_truncate_tool_content(item) for item in content]
+    return content
+
+
+def _redact(message: BaseMessage) -> BaseMessage:
+    """Return a copy of the message with API keys scrubbed and tool outputs bounded."""
+    redacted = copy.deepcopy(message)
+    redacted.content = _redact_content(redacted.content)
+    if isinstance(redacted, ToolMessage):
+        redacted.content = _truncate_tool_content(redacted.content)
+    return redacted
+
+
+class LiveMessageWriter:
+    """Appends messages to the running workflow's state mid-node.
+
+    Built by `lib.workflows.runner.run_workflow` after graph compilation and
+    attached to the per-run `ContextSchema`. The workflow node pulls it off
+    the context and calls `append()` as each completed message arrives from
+    the deep agent's event stream.
+    """
+
+    def __init__(
+        self,
+        app: CompiledStateGraph,
+        thread_config: dict,
+        node_name: str,
+    ) -> None:
+        self._app = app
+        self._thread_config = thread_config
+        self._node_name = node_name
+
+    async def append(self, message: BaseMessage) -> None:
+        """Redact, then checkpoint a single new message onto `state.messages`."""
+        redacted = _redact(message)
+        try:
+            await self._app.aupdate_state(
+                self._thread_config,
+                {"messages": [redacted]},
+                as_node=self._node_name,
+            )
+        except Exception as e:
+            # Never let a streaming-persistence failure abort the workflow.
+            # The final node return still includes the full messages list, so
+            # the end result is unaffected — we just lose the live update for
+            # this single message. Logged at warning so it's visible in logs
+            # without being mistaken for a workflow-level error.
+            logger.warning(
+                f"LiveMessageWriter.append failed for node {self._node_name}: {e}",
+                exc_info=True,
+            )

--- a/lib/workflows/context.py
+++ b/lib/workflows/context.py
@@ -5,6 +5,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 from lib.services.file_artifacts_service.file_artifacts_service_type import FileArtifactsServiceType
+from lib.services.live_message_writer import LiveMessageWriter
 from lib.services.vector_store import VectorStoreService
 
 
@@ -36,6 +37,15 @@ class ContextSchema(BaseModel):
     revision: int = Field(
         default=1,
         description="The project revision this workflow execution belongs to.",
+    )
+    live_message_writer: Optional[LiveMessageWriter] = Field(
+        default=None,
+        exclude=True,
+        description=(
+            "Optional helper for appending deep-agent messages to `state.messages` "
+            "mid-run. Populated by the runner only for workflows whose manifest "
+            "sets `supports_live_messages = True`."
+        ),
     )
 
 

--- a/lib/workflows/manifest.py
+++ b/lib/workflows/manifest.py
@@ -50,6 +50,17 @@ class WorkflowManifest[WorkflowStateType, WorkflowConfigType](ABC):
     # The workflows needs to be idempotent, meaning it can be run multiple times without changing the result and typical execute only "new" content that was not processed in a previous run, reusing cached results from previous runs, like summarization, document conversion, etc (should process only new files in subsequent runs).
     always_run: bool = False
 
+    # If True, the runner builds a LiveMessageWriter and attaches it to the
+    # context so the workflow node can append deep-agent messages to state
+    # mid-run. Requires that the workflow's state has a `messages` field with
+    # the `add_messages` reducer, and that the opted-in node is named
+    # consistently so `aupdate_state(..., as_node=...)` can target it.
+    supports_live_messages: bool = False
+
+    # Node name that LiveMessageWriter passes to `aupdate_state(as_node=...)`
+    # when `supports_live_messages` is True.
+    live_messages_node_name: str = "run_agent"
+
     @property
     def is_qa_screener(self) -> bool:
         """Whether the workflow is part of the QA Screener tool."""

--- a/lib/workflows/runner.py
+++ b/lib/workflows/runner.py
@@ -15,6 +15,7 @@ from lib.services.file_artifacts_service.file_artifacts_service import (
     FileArtifactsService,
 )
 from lib.services.issue_persistence import persist_workflow_issues
+from lib.services.live_message_writer import LiveMessageWriter
 from lib.services.users import get_user_decrypted_api_key
 from lib.services.vector_store import VectorStoreService
 from lib.services.workflow_runs import update_workflow_run_status
@@ -155,6 +156,23 @@ async def run_workflow(
         checkpoint_id = None
         updated_state = state.model_copy(deep=True, update={"errors": []})
         thread_config = {"configurable": {"thread_id": thread_id}}
+
+        # Opt-in workflows (e.g. SimpleDeepAgentManifest subclasses) get a
+        # LiveMessageWriter so their node can append deep-agent messages to
+        # `state.messages` mid-run. The existing polling on
+        # GET /api/workflows/{id} then surfaces the growing list without
+        # needing a new transport.
+        manifest = get_workflow_manifest(workflow_type, raise_exception=False)
+        if manifest and manifest.supports_live_messages:
+            context = context.model_copy(
+                update={
+                    "live_message_writer": LiveMessageWriter(
+                        app=app,
+                        thread_config=thread_config,
+                        node_name=manifest.live_messages_node_name,
+                    )
+                }
+            )
 
         try:
             async for values in app.astream(

--- a/lib/workflows/simple_deep_agent/agent.py
+++ b/lib/workflows/simple_deep_agent/agent.py
@@ -5,6 +5,7 @@ Callers supply the user prompt (specific rules/criteria) and may optionally
 override the system prompt when the default is not appropriate.
 """
 
+import logging
 from typing import List, Optional
 
 from deepagents import create_deep_agent
@@ -16,6 +17,8 @@ from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 from lib.workflows.simple_deep_agent.types import AgentCheckResult
+
+logger = logging.getLogger(__name__)
 
 _SYSTEM_PROMPT = """\
 You are a specialist document reviewer. Your task is to review a document \
@@ -71,18 +74,51 @@ class SimpleDeepAgent(LangChainAgent):
             skills=["/skills/"],
         )
 
-        result = await deep_agent.ainvoke(
-            {
-                "files": await self.context.file_artifacts_service.get_deepagent_backend_files(
-                    include_supporting_files=self._include_supporting_files,
-                    include_skills=True,
-                ),
-                "messages": [
-                    SystemMessage(content=self._system_prompt),
-                    HumanMessage(content=self._user_prompt),
-                ],
-            },
-            config={"recursion_limit": 100, **(config or {})},
-        )
+        inputs = {
+            "files": await self.context.file_artifacts_service.get_deepagent_backend_files(
+                include_supporting_files=self._include_supporting_files,
+                include_skills=True,
+            ),
+            "messages": [
+                SystemMessage(content=self._system_prompt),
+                HumanMessage(content=self._user_prompt),
+            ],
+        }
+        run_config = {"recursion_limit": 100, **(config or {})}
 
-        return result["structured_response"], result["messages"]
+        writer = self.context.live_message_writer
+        if writer is None:
+            # No live streaming requested — behave exactly like before.
+            result = await deep_agent.ainvoke(inputs, config=run_config)
+            return result["structured_response"], result["messages"]
+
+        # Stream the deep agent's internal state and append each newly-produced
+        # message to the outer workflow's state via the writer. Using
+        # stream_mode="values" yields the full inner state after each step; we
+        # diff against the count seen so far to isolate new messages.
+        final_state: Optional[dict] = None
+        seen_count = 0
+        async for values in deep_agent.astream(
+            inputs, config=run_config, stream_mode="values"
+        ):
+            final_state = values
+            current_messages = values.get("messages", []) or []
+            for msg in current_messages[seen_count:]:
+                await writer.append(msg)
+            seen_count = len(current_messages)
+
+        if final_state is None:
+            # Defensive: astream yielded nothing. Fall back to a blocking call
+            # so we still produce a result rather than returning empty state.
+            logger.warning(
+                "deep_agent.astream yielded no values; falling back to ainvoke"
+            )
+            result = await deep_agent.ainvoke(inputs, config=run_config)
+            return result["structured_response"], result["messages"]
+
+        # Return the full messages list. The add_messages reducer on
+        # SimpleDeepAgentState.messages de-duplicates by message ID, so
+        # messages already written mid-run via `writer.append` are overwritten
+        # rather than duplicated; any message that failed to stream still lands
+        # in state via this final return.
+        return final_state["structured_response"], final_state["messages"]

--- a/lib/workflows/simple_deep_agent/manifest_base.py
+++ b/lib/workflows/simple_deep_agent/manifest_base.py
@@ -48,6 +48,11 @@ class SimpleDeepAgentManifest(
     system_prompt: ClassVar[Optional[str]] = None
     include_supporting_files: ClassVar[bool] = False
 
+    # All simple-deep-agent workflows run under a single "run_agent" node and
+    # use the add_messages reducer on their state, so they can safely stream
+    # deep-agent messages back to the client mid-run.
+    supports_live_messages: ClassVar[bool] = True
+
     def get_state_type(self) -> Type[SimpleDeepAgentState]:
         return SimpleDeepAgentState
 

--- a/lib/workflows/simple_deep_agent/state.py
+++ b/lib/workflows/simple_deep_agent/state.py
@@ -6,9 +6,10 @@ because deserialization always goes through the manifest's get_state_type(),
 not Pydantic union dispatch.
 """
 
-from typing import List, Optional
+from typing import Annotated, List, Optional
 
 from langchain_core.messages import BaseMessage
+from langgraph.graph.message import add_messages
 from pydantic import Field, field_serializer
 
 from lib.workflows.models import BaseWorkflowConfig, BaseWorkflowState, WorkflowRunType
@@ -34,7 +35,9 @@ class SimpleDeepAgentState(BaseWorkflowState):
         default=None,
         description="Result from the deep agent validation pass",
     )
-    messages: List[BaseMessage] = Field(
+    # `add_messages` reducer so mid-run appends (from LiveMessageWriter) and
+    # the final node return both accumulate rather than replace.
+    messages: Annotated[List[BaseMessage], add_messages] = Field(
         default_factory=list,
         description="LLM conversation messages from the agent invocation.",
     )

--- a/tests/unit/services/test_live_message_writer.py
+++ b/tests/unit/services/test_live_message_writer.py
@@ -1,0 +1,140 @@
+"""Unit tests for LiveMessageWriter — redaction and aupdate_state wiring."""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from lib.services.live_message_writer import (
+    _MAX_TOOL_CONTENT_CHARS,
+    _REDACTED_PLACEHOLDER,
+    _TRUNCATION_MARKER,
+    LiveMessageWriter,
+)
+
+
+def _make_writer() -> tuple[LiveMessageWriter, AsyncMock]:
+    app = Mock()
+    app.aupdate_state = AsyncMock()
+    writer = LiveMessageWriter(
+        app=app,
+        thread_config={"configurable": {"thread_id": "thread-123"}},
+        node_name="run_agent",
+    )
+    return writer, app.aupdate_state
+
+
+class TestRedaction:
+    @pytest.mark.asyncio
+    async def test_openai_api_key_is_scrubbed_from_content(self):
+        """Any substring matching the sk-... pattern gets replaced with the placeholder."""
+        writer, update = _make_writer()
+        leaked = (
+            "Here is my key: sk-proj-ABCDEFG1234567890_abcdefghij please keep it safe"
+        )
+
+        await writer.append(AIMessage(content=leaked))
+
+        assert update.await_count == 1
+        persisted = update.await_args.args[1]["messages"][0]
+        assert "sk-proj-" not in persisted.content
+        assert _REDACTED_PLACEHOLDER in persisted.content
+        assert "please keep it safe" in persisted.content
+
+    @pytest.mark.asyncio
+    async def test_redaction_walks_structured_content_blocks(self):
+        """List-shaped content (LangChain content blocks) is redacted recursively."""
+        writer, update = _make_writer()
+        blocks = [
+            {"type": "text", "text": "leaking sk-abcdefghij1234567890klmnop now"},
+            {"type": "text", "text": "harmless"},
+        ]
+
+        await writer.append(AIMessage(content=blocks))
+
+        persisted = update.await_args.args[1]["messages"][0]
+        assert _REDACTED_PLACEHOLDER in persisted.content[0]["text"]
+        assert persisted.content[1]["text"] == "harmless"
+
+    @pytest.mark.asyncio
+    async def test_short_strings_without_api_keys_are_passed_through(self):
+        """No accidental mangling of plain content."""
+        writer, update = _make_writer()
+
+        await writer.append(AIMessage(content="plain response with no secrets"))
+
+        persisted = update.await_args.args[1]["messages"][0]
+        assert persisted.content == "plain response with no secrets"
+
+
+class TestToolTruncation:
+    @pytest.mark.asyncio
+    async def test_large_tool_content_is_truncated(self):
+        """ToolMessage content exceeding the cap is truncated with a marker."""
+        writer, update = _make_writer()
+        huge = "x" * (_MAX_TOOL_CONTENT_CHARS + 5_000)
+
+        await writer.append(ToolMessage(content=huge, tool_call_id="t1"))
+
+        persisted = update.await_args.args[1]["messages"][0]
+        assert len(persisted.content) == _MAX_TOOL_CONTENT_CHARS + len(_TRUNCATION_MARKER)
+        assert persisted.content.endswith(_TRUNCATION_MARKER)
+
+    @pytest.mark.asyncio
+    async def test_small_tool_content_is_not_touched(self):
+        writer, update = _make_writer()
+
+        await writer.append(ToolMessage(content="tiny result", tool_call_id="t1"))
+
+        persisted = update.await_args.args[1]["messages"][0]
+        assert persisted.content == "tiny result"
+
+    @pytest.mark.asyncio
+    async def test_truncation_only_applies_to_tool_messages(self):
+        """AIMessage and HumanMessage are not capped — they're generally small,
+        and the LLM's own output shouldn't be silently chopped."""
+        writer, update = _make_writer()
+        huge = "y" * (_MAX_TOOL_CONTENT_CHARS + 1_000)
+
+        await writer.append(AIMessage(content=huge))
+
+        persisted = update.await_args.args[1]["messages"][0]
+        assert persisted.content == huge
+
+
+class TestAupdateStateWiring:
+    @pytest.mark.asyncio
+    async def test_passes_correct_thread_config_and_node_name(self):
+        writer, update = _make_writer()
+
+        await writer.append(AIMessage(content="hello"))
+
+        assert update.await_count == 1
+        args, kwargs = update.await_args
+        assert args[0] == {"configurable": {"thread_id": "thread-123"}}
+        assert args[1]["messages"][0].content == "hello"
+        assert kwargs["as_node"] == "run_agent"
+
+    @pytest.mark.asyncio
+    async def test_append_does_not_mutate_caller_message(self):
+        """The original BaseMessage passed in by the caller must stay intact —
+        redaction operates on a copy so the agent's own references are safe."""
+        writer, _ = _make_writer()
+        original = AIMessage(content="key: sk-abcdefghij1234567890klmnop")
+
+        await writer.append(original)
+
+        assert "sk-" in original.content  # caller's copy still has the secret
+        assert _REDACTED_PLACEHOLDER not in original.content
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_failure_does_not_raise(self):
+        """aupdate_state errors are logged, not re-raised — we never want a
+        streaming-persistence hiccup to abort the workflow."""
+        writer, update = _make_writer()
+        update.side_effect = RuntimeError("checkpoint table busy")
+
+        # Should not raise
+        await writer.append(HumanMessage(content="ok"))
+
+        assert update.await_count == 1

--- a/tests/unit/workflows/test_simple_deep_agent_streaming.py
+++ b/tests/unit/workflows/test_simple_deep_agent_streaming.py
@@ -1,0 +1,177 @@
+"""Unit tests for SimpleDeepAgent's streaming branch.
+
+Covers the two paths in `SimpleDeepAgent.ainvoke`:
+- `live_message_writer is None` → blocking `deep_agent.ainvoke` (unchanged legacy behavior)
+- `live_message_writer is set`  → iterate `deep_agent.astream` and call
+  `writer.append` once per newly-produced message, returning the final
+  accumulated state.
+"""
+
+from typing import AsyncIterator
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, ToolMessage
+
+from lib.services.file_artifacts_service.file_artifacts_service_type import (
+    FileArtifactsServiceType,
+)
+from lib.services.live_message_writer import LiveMessageWriter
+from lib.workflows.context import ContextSchema
+from lib.workflows.simple_deep_agent.agent import SimpleDeepAgent
+from lib.workflows.simple_deep_agent.types import AgentCheckResult
+
+
+def _make_context(writer=None) -> ContextSchema:
+    # The agent only reads `file_artifacts_service.get_deepagent_backend_files`
+    # during ainvoke and hands the result straight to the (mocked) deep_agent,
+    # so a spec'd Mock with one async method is enough.
+    fake_file_service = Mock(spec=FileArtifactsServiceType)
+    fake_file_service.get_deepagent_backend_files = AsyncMock(return_value={})
+    return ContextSchema(
+        project_id="p1",
+        file_artifacts_service=fake_file_service,
+        live_message_writer=writer,
+        openai_api_key="sk-test",
+    )
+
+
+def _make_writer_mock() -> Mock:
+    writer = Mock(spec=LiveMessageWriter)
+    writer.append = AsyncMock()
+    return writer
+
+
+def _make_agent(writer=None) -> SimpleDeepAgent:
+    # LangChainAgent.__init__ may try to construct an LLM client. We only
+    # exercise ainvoke's streaming logic, and ainvoke constructs its own
+    # deep_agent (which we mock out), so the llm attribute is never actually
+    # used during these tests.
+    with patch.object(SimpleDeepAgent, "llm", Mock(), create=True):
+        return SimpleDeepAgent(context=_make_context(writer=writer), user_prompt="check X")
+
+
+class _StreamingAgent:
+    """Stand-in for a compiled deep_agent whose astream yields `values`-mode
+    state snapshots with a growing `messages` list."""
+
+    def __init__(self, yields: list[dict]):
+        self._yields = yields
+
+    async def astream(self, inputs, config, stream_mode):
+        assert stream_mode == "values"
+        for chunk in self._yields:
+            yield chunk
+
+    async def ainvoke(self, inputs, config):
+        # Final state = last yield
+        return self._yields[-1]
+
+
+class TestLegacyPath:
+    @pytest.mark.asyncio
+    async def test_no_writer_calls_ainvoke_and_returns_final(self):
+        final_result = AgentCheckResult(issues=[], report_markdown="done")
+        messages = [AIMessage(content="hello", id="a1")]
+
+        agent = _make_agent(writer=None)
+        stub = _StreamingAgent([{"structured_response": final_result, "messages": messages}])
+
+        with patch(
+            "lib.workflows.simple_deep_agent.agent.create_deep_agent",
+            return_value=stub,
+        ):
+            result, out_messages = await agent.ainvoke({})
+
+        assert result is final_result
+        assert out_messages == messages
+
+
+class TestStreamingPath:
+    @pytest.mark.asyncio
+    async def test_writer_called_once_per_new_message(self):
+        """Streaming should call writer.append exactly once per new message,
+        using the diff between successive state snapshots."""
+        writer = _make_writer_mock()
+
+        msg_a = AIMessage(content="thinking…", id="a")
+        msg_b = ToolMessage(content="tool result", tool_call_id="t1", id="b")
+        msg_c = AIMessage(content="final", id="c")
+        final_result = AgentCheckResult(issues=[], report_markdown="done")
+
+        stub = _StreamingAgent([
+            # step 1: just the first LLM message
+            {"structured_response": None, "messages": [msg_a]},
+            # step 2: adds a tool result
+            {"structured_response": None, "messages": [msg_a, msg_b]},
+            # step 3: final LLM message + structured output
+            {"structured_response": final_result, "messages": [msg_a, msg_b, msg_c]},
+        ])
+
+        agent = _make_agent(writer=writer)
+        with patch(
+            "lib.workflows.simple_deep_agent.agent.create_deep_agent",
+            return_value=stub,
+        ):
+            result, messages = await agent.ainvoke({})
+
+        assert result is final_result
+        assert messages == [msg_a, msg_b, msg_c]
+        # Exactly 3 appends, in order
+        assert writer.append.await_count == 3
+        appended = [call.args[0] for call in writer.append.await_args_list]
+        assert appended == [msg_a, msg_b, msg_c]
+
+    @pytest.mark.asyncio
+    async def test_identical_snapshots_do_not_trigger_duplicate_appends(self):
+        """If the deep agent yields the same state snapshot twice (no new
+        messages), the writer must not be called again for the same messages."""
+        writer = _make_writer_mock()
+
+        msg = AIMessage(content="only", id="only")
+        stub = _StreamingAgent([
+            {"structured_response": None, "messages": [msg]},
+            {"structured_response": None, "messages": [msg]},  # no new messages
+            {"structured_response": AgentCheckResult(), "messages": [msg]},
+        ])
+
+        agent = _make_agent(writer=writer)
+        with patch(
+            "lib.workflows.simple_deep_agent.agent.create_deep_agent",
+            return_value=stub,
+        ):
+            await agent.ainvoke({})
+
+        assert writer.append.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_stream_falls_back_to_ainvoke(self):
+        """Defensive: if astream yields nothing at all, ainvoke is used so the
+        workflow still gets a structured result."""
+        writer = _make_writer_mock()
+
+        fallback_result = AgentCheckResult(issues=[], report_markdown="from fallback")
+
+        stub = Mock()
+        stub.astream = Mock(return_value=_empty_async_iter())
+        stub.ainvoke = AsyncMock(
+            return_value={"structured_response": fallback_result, "messages": []}
+        )
+
+        agent = _make_agent(writer=writer)
+        with patch(
+            "lib.workflows.simple_deep_agent.agent.create_deep_agent",
+            return_value=stub,
+        ):
+            result, messages = await agent.ainvoke({})
+
+        assert result is fallback_result
+        assert messages == []
+        # No messages produced → writer must not have been called.
+        assert writer.append.await_count == 0
+        stub.ainvoke.assert_awaited_once()
+
+
+async def _empty_async_iter() -> AsyncIterator[dict]:
+    if False:  # pragma: no cover - generator that yields nothing
+        yield {}


### PR DESCRIPTION
## Summary

- Adds `LiveMessageWriter` service that appends deep-agent messages to workflow state mid-run via LangGraph checkpoints
- Opts all `SimpleDeepAgentManifest` subclasses into live streaming via a new `supports_live_messages` flag
- Updates the frontend to show live agent messages in a Messages tab while the workflow is running, instead of a static loading spinner

Linear: https://linear.app/ae-studio/issue/RANDZ-528/stream-deep-agent-messages-back-to-user

## Motivation

Previously, simple-deep-agent workflows showed only a spinner while running. Users had no visibility into agent progress. This change streams messages back as they are produced, leveraging the existing 3s polling on `GET /api/workflows/{id}` — no new transport needed.

## What's Changed

### Backend

- **`lib/services/live_message_writer.py`** _(new)_ — `LiveMessageWriter` class: redacts API keys, truncates large tool outputs, and calls `app.aupdate_state(as_node=...)` to persist each message to the LangGraph checkpoint mid-run.
- **`lib/workflows/context.py`** — Added optional `live_message_writer: LiveMessageWriter` field to `ContextSchema` (excluded from serialization).
- **`lib/workflows/manifest.py`** — Added `supports_live_messages: bool` and `live_messages_node_name: str` class vars to `WorkflowManifest`.
- **`lib/workflows/runner.py`** — When a manifest opts in, builds a `LiveMessageWriter` and attaches it to the context before the graph runs.
- **`lib/workflows/simple_deep_agent/agent.py`** — When a writer is present, switches from `ainvoke` to `astream` and calls `writer.append(msg)` for each new message. Falls back to `ainvoke` if the stream yields nothing.
- **`lib/workflows/simple_deep_agent/manifest_base.py`** — Sets `supports_live_messages = True` for all simple-deep-agent workflows.
- **`lib/workflows/simple_deep_agent/state.py`** — Changed `messages` field to use `Annotated[List[BaseMessage], add_messages]` reducer so mid-run appends accumulate rather than replace.

### Tests

- **`tests/unit/services/test_live_message_writer.py`** _(new)_ — Unit tests for `LiveMessageWriter` covering redaction, truncation, and failure resilience.
- **`tests/unit/workflows/test_simple_deep_agent_streaming.py`** _(new)_ — Tests for the streaming path in `SimpleDeepAgent`.

### Frontend

- **`frontend/components/workflows/results/simple-deep-agent-results.tsx`** — Removes the loading-only render path; instead defaults to the Messages tab while running and shows a spinner inline. The Results tab shows a running-state empty state when results aren't yet available.

## Risks and Mitigations

- **Checkpoint contention**: `aupdate_state` is called from within a running node. This is safe for single-node graphs (all simple-deep-agent workflows) since there's no concurrent writer. Multi-node graphs would need a different approach.
- **Streaming failures**: `LiveMessageWriter.append` catches all exceptions and logs a warning rather than propagating. The final node return includes the full message list, so no data is lost if a mid-run write fails.
- **Duplicate messages**: The `add_messages` reducer deduplicates by message ID, so messages written mid-run and again in the final return are not duplicated.