### PR TITLE
chore(claude): add worktree and preview configuration

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "backend",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": ["run", "dev.py"],
+      "port": 8000,
+      "autoPort": true
+    },
+    {
+      "name": "frontend",
+      "cwd": "frontend",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "port": 3000,
+      "autoPort": true
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,11 @@ rand-personal/
 
 # cursor plans
 .cursor/plans/
-.claude/settings.json
+
+# claude files
+.claude/projects
+.claude/worktrees
+.claude/settings.local.json
 
 # logs
 /logs/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+.env
+frontend/.env

--- a/dev.py
+++ b/dev.py
@@ -1,3 +1,5 @@
+import os
+
 import uvicorn
 from lib.config.logger import setup_logger
 
@@ -7,7 +9,7 @@ if __name__ == "__main__":
     uvicorn.run(
         "lib.api.main:app",
         host="0.0.0.0",
-        port=8000,
+        port=int(os.environ.get("PORT", 8000)),
         reload=True,
         log_level="info",
         log_config=None,


### PR DESCRIPTION
## Summary

- Add `.claude/launch.json` to configure backend and frontend dev server launch with auto port assignment
- Add `.worktreeinclude` to specify env files copied into Claude worktrees
- Update `dev.py` to read `PORT` from environment variable (required for dynamic port assignment in worktrees)
- Update `.gitignore` to exclude Claude worktree/project artifacts and use `settings.local.json` instead of `settings.json`

## Motivation

Enables Claude Code dynamic worktrees with preview environments — each worktree gets its own ports and `.env` files, allowing parallel development sessions without port conflicts.

## What's Changed

### Backend
- `dev.py` — reads `PORT` env var instead of hardcoding `8000`

### Config / Tooling
- `.claude/launch.json` — new file defining backend and frontend launch configurations with `autoPort: true`
- `.worktreeinclude` — new file listing `.env` and `frontend/.env` for worktree inclusion
- `.gitignore` — replaced `.claude/settings.json` ignore with `.claude/projects`, `.claude/worktrees`, and `.claude/settings.local.json`

## Risks and Mitigations

- **Risk**: Existing deployments that rely on hardcoded port 8000 may be unaffected since `PORT` defaults to `8000` when not set.
- **Mitigation**: Default value preserved — no breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)