### PR TITLE
feat(config): per-model API key support (RANDZ-522)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,9 @@
 # OpenAI
 OPENAI_API_KEY=
+# Per-model API key overrides — JSON dict mapping model name to API key.
+# Use this to assign a separate key (and thus separate rate-limit bucket) per model.
+# Example: MODEL_API_KEYS={"gpt-5-mini-2025-08-07": "sk-xxx", "gpt-4.1-2025-04-14": "sk-yyy"}
+# MODEL_API_KEYS={}
 
 # Logging Configuration
 LOG_RICH_HANDLER=true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,10 @@ uv run inspect view
 
 ## Git Conventions
 
+### Commits and Pull Requests
+
+Never create commits or open pull requests unless the user explicitly asks. Finish the implementation, confirm it works, then wait for instruction before touching git.
+
 ### Commit Messages
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages. The format is:

--- a/lib/config/env.py
+++ b/lib/config/env.py
@@ -1,3 +1,4 @@
+import json
 import os
 from typing import Optional
 
@@ -75,6 +76,13 @@ class Config(BaseModel):
         description="Base URL for the frontend application (used for share links)",
     )
 
+    # Per-model API key overrides (JSON dict mapping model name → API key)
+    # Example: {"gpt-5-mini-2025-08-07": "sk-xxx", "gpt-4.1-2025-04-14": "sk-yyy"}
+    MODEL_API_KEYS: dict[str, str] = Field(
+        default_factory=dict,
+        description="Per-model API key overrides. Keys are model names (e.g. Azure deployment IDs).",
+    )
+
     # Rate limiter configuration (shared across workers via Postgres)
     RATE_LIMITER_REQUESTS_PER_SECOND: float = Field(
         default=2,
@@ -123,4 +131,10 @@ config = Config(
     RATE_LIMITER_CHECK_EVERY_N_SECONDS=float(
         os.getenv("RATE_LIMITER_CHECK_EVERY_N_SECONDS", "0.2")
     ),
+    MODEL_API_KEYS=json.loads(os.getenv("MODEL_API_KEYS", "{}")),
 )
+
+
+def get_model_api_key(model_name: str) -> str | None:
+    """Return the API key configured for a specific model name, or None."""
+    return config.MODEL_API_KEYS.get(model_name)

--- a/lib/models/agent.py
+++ b/lib/models/agent.py
@@ -7,6 +7,7 @@ from langchain_core.rate_limiters import BaseRateLimiter
 from langchain_core.runnables.config import RunnableConfig
 from pydantic import BaseModel
 
+from lib.config.env import get_model_api_key
 from lib.config.llm_models import LLMModel
 from lib.config.rate_limiter import get_rate_limiter, hash_api_key
 from lib.workflows.context import ContextSchema
@@ -59,7 +60,11 @@ class LangChainAgent(BaseAgent):
         self.context = context
 
     def get_rate_limiter(self) -> BaseRateLimiter:
-        api_key = self.context.openai_api_key or "default"
+        api_key = (
+            get_model_api_key(self.model.name)
+            or self.context.openai_api_key
+            or "default"
+        )
         return get_rate_limiter(hash_api_key(api_key))
 
     def get_init_chat_model_kwargs(self) -> dict:
@@ -74,10 +79,13 @@ class LangChainAgent(BaseAgent):
         if self.reasoning:
             init_kwargs["reasoning"] = self.reasoning
 
-        # For OpenAI models: use context API key if provided, otherwise fall back to env var
-        # For other providers (Anthropic, Google): always use environment variables
-        if self.model.provider == "openai" and self.context.openai_api_key:
-            init_kwargs["api_key"] = self.context.openai_api_key
+        # Resolve API key: per-model override takes priority, then context key (OpenAI only)
+        model_api_key = get_model_api_key(self.model.name)
+        effective_api_key = model_api_key or (
+            self.context.openai_api_key if self.model.provider == "openai" else None
+        )
+        if effective_api_key:
+            init_kwargs["api_key"] = effective_api_key
 
         return init_kwargs
 

--- a/lib/models/agent.py
+++ b/lib/models/agent.py
@@ -59,13 +59,14 @@ class LangChainAgent(BaseAgent):
     def __init__(self, context: ContextSchema):
         self.context = context
 
+    def _resolve_api_key(self) -> str | None:
+        """User context key wins; falls back to per-model override. OpenAI only."""
+        if self.model.provider != "openai":
+            return None
+        return self.context.openai_api_key or get_model_api_key(self.model.name)
+
     def get_rate_limiter(self) -> BaseRateLimiter:
-        openai_key = (
-            self.context.openai_api_key or get_model_api_key(self.model.name)
-            if self.model.provider == "openai"
-            else None
-        )
-        return get_rate_limiter(hash_api_key(openai_key or "default"))
+        return get_rate_limiter(hash_api_key(self._resolve_api_key() or "default"))
 
     def get_init_chat_model_kwargs(self) -> dict:
         init_kwargs = {
@@ -79,13 +80,9 @@ class LangChainAgent(BaseAgent):
         if self.reasoning:
             init_kwargs["reasoning"] = self.reasoning
 
-        # Resolve API key: user context key takes priority, then per-model override (OpenAI only)
-        if self.model.provider == "openai":
-            effective_api_key = (
-                self.context.openai_api_key or get_model_api_key(self.model.name)
-            )
-            if effective_api_key:
-                init_kwargs["api_key"] = effective_api_key
+        api_key = self._resolve_api_key()
+        if api_key:
+            init_kwargs["api_key"] = api_key
 
         return init_kwargs
 

--- a/lib/models/agent.py
+++ b/lib/models/agent.py
@@ -60,12 +60,12 @@ class LangChainAgent(BaseAgent):
         self.context = context
 
     def get_rate_limiter(self) -> BaseRateLimiter:
-        api_key = (
-            self.context.openai_api_key
-            or get_model_api_key(self.model.name)
-            or "default"
+        openai_key = (
+            self.context.openai_api_key or get_model_api_key(self.model.name)
+            if self.model.provider == "openai"
+            else None
         )
-        return get_rate_limiter(hash_api_key(api_key))
+        return get_rate_limiter(hash_api_key(openai_key or "default"))
 
     def get_init_chat_model_kwargs(self) -> dict:
         init_kwargs = {

--- a/lib/models/agent.py
+++ b/lib/models/agent.py
@@ -61,8 +61,8 @@ class LangChainAgent(BaseAgent):
 
     def get_rate_limiter(self) -> BaseRateLimiter:
         api_key = (
-            get_model_api_key(self.model.name)
-            or self.context.openai_api_key
+            self.context.openai_api_key
+            or get_model_api_key(self.model.name)
             or "default"
         )
         return get_rate_limiter(hash_api_key(api_key))
@@ -79,13 +79,13 @@ class LangChainAgent(BaseAgent):
         if self.reasoning:
             init_kwargs["reasoning"] = self.reasoning
 
-        # Resolve API key: per-model override takes priority, then context key (OpenAI only)
-        model_api_key = get_model_api_key(self.model.name)
-        effective_api_key = model_api_key or (
-            self.context.openai_api_key if self.model.provider == "openai" else None
-        )
-        if effective_api_key:
-            init_kwargs["api_key"] = effective_api_key
+        # Resolve API key: user context key takes priority, then per-model override (OpenAI only)
+        if self.model.provider == "openai":
+            effective_api_key = (
+                self.context.openai_api_key or get_model_api_key(self.model.name)
+            )
+            if effective_api_key:
+                init_kwargs["api_key"] = effective_api_key
 
         return init_kwargs
 

--- a/tests/unit/test_model_api_keys.py
+++ b/tests/unit/test_model_api_keys.py
@@ -16,8 +16,11 @@ def _make_context(openai_api_key: str | None = None) -> ContextSchema:
     )
 
 
-class _TestAgent:
-    """Minimal LangChainAgent-like object for testing get_init_chat_model_kwargs / get_rate_limiter."""
+from lib.models.agent import LangChainAgent
+
+
+class _TestAgent(LangChainAgent):
+    """Minimal LangChainAgent subclass for testing API key resolution."""
 
     name = "Test Agent"
     description = "Test"
@@ -27,14 +30,8 @@ class _TestAgent:
     output_schema = None
     model = LLMModel(provider="openai", name="gpt-5-mini-2025-08-07")
 
-    def __init__(self, context: ContextSchema):
-        self.context = context
-        self._llm = None
-
-    from lib.models.agent import LangChainAgent
-
-    get_rate_limiter = LangChainAgent.get_rate_limiter
-    get_init_chat_model_kwargs = LangChainAgent.get_init_chat_model_kwargs
+    async def ainvoke(self, prompt_kwargs, config=None):  # type: ignore[override]
+        raise NotImplementedError
 
 
 def test_model_api_key_used_in_init_kwargs():

--- a/tests/unit/test_model_api_keys.py
+++ b/tests/unit/test_model_api_keys.py
@@ -45,12 +45,12 @@ def test_model_api_key_used_in_init_kwargs():
     assert kwargs["api_key"] == "sk-model-specific"
 
 
-def test_model_api_key_takes_priority_over_context_key():
+def test_context_key_takes_priority_over_model_key():
     agent = _TestAgent(_make_context(openai_api_key="sk-context-key"))
     with patch("lib.config.env.config") as mock_config:
         mock_config.MODEL_API_KEYS = {"gpt-5-mini-2025-08-07": "sk-model-specific"}
         kwargs = agent.get_init_chat_model_kwargs()
-    assert kwargs["api_key"] == "sk-model-specific"
+    assert kwargs["api_key"] == "sk-context-key"
 
 
 def test_context_key_used_when_no_model_key():
@@ -69,14 +69,25 @@ def test_no_api_key_in_kwargs_when_neither_set():
     assert "api_key" not in kwargs
 
 
-def test_rate_limiter_bucketed_by_model_key():
-    agent = _TestAgent(_make_context(openai_api_key="sk-context-key"))
+def test_rate_limiter_uses_model_key_when_no_context_key():
+    agent = _TestAgent(_make_context())
     with patch("lib.config.env.config") as mock_config:
         mock_config.MODEL_API_KEYS = {"gpt-5-mini-2025-08-07": "sk-model-specific"}
         limiter = agent.get_rate_limiter()
 
     from lib.config.rate_limiter import get_rate_limiter as get_rl
     expected = get_rl(hash_api_key("sk-model-specific"))
+    assert limiter is expected
+
+
+def test_rate_limiter_prefers_context_key_over_model_key():
+    agent = _TestAgent(_make_context(openai_api_key="sk-context-key"))
+    with patch("lib.config.env.config") as mock_config:
+        mock_config.MODEL_API_KEYS = {"gpt-5-mini-2025-08-07": "sk-model-specific"}
+        limiter = agent.get_rate_limiter()
+
+    from lib.config.rate_limiter import get_rate_limiter as get_rl
+    expected = get_rl(hash_api_key("sk-context-key"))
     assert limiter is expected
 
 

--- a/tests/unit/test_model_api_keys.py
+++ b/tests/unit/test_model_api_keys.py
@@ -1,0 +1,91 @@
+"""Unit tests for per-model API key support."""
+
+from unittest.mock import MagicMock, patch
+
+from lib.config.llm_models import LLMModel
+from lib.config.rate_limiter import hash_api_key
+from lib.services.file_artifacts_service.file_artifacts_service_type import FileArtifactsServiceType
+from lib.workflows.context import ContextSchema
+
+
+def _make_context(openai_api_key: str | None = None) -> ContextSchema:
+    return ContextSchema(
+        openai_api_key=openai_api_key,
+        file_artifacts_service=MagicMock(spec=FileArtifactsServiceType),
+        project_id="test-project",
+    )
+
+
+class _TestAgent:
+    """Minimal LangChainAgent-like object for testing get_init_chat_model_kwargs / get_rate_limiter."""
+
+    name = "Test Agent"
+    description = "Test"
+    temperature = 0.0
+    timeout = 60
+    reasoning = None
+    output_schema = None
+    model = LLMModel(provider="openai", name="gpt-5-mini-2025-08-07")
+
+    def __init__(self, context: ContextSchema):
+        self.context = context
+        self._llm = None
+
+    from lib.models.agent import LangChainAgent
+
+    get_rate_limiter = LangChainAgent.get_rate_limiter
+    get_init_chat_model_kwargs = LangChainAgent.get_init_chat_model_kwargs
+
+
+def test_model_api_key_used_in_init_kwargs():
+    agent = _TestAgent(_make_context())
+    with patch("lib.config.env.config") as mock_config:
+        mock_config.MODEL_API_KEYS = {"gpt-5-mini-2025-08-07": "sk-model-specific"}
+        kwargs = agent.get_init_chat_model_kwargs()
+    assert kwargs["api_key"] == "sk-model-specific"
+
+
+def test_model_api_key_takes_priority_over_context_key():
+    agent = _TestAgent(_make_context(openai_api_key="sk-context-key"))
+    with patch("lib.config.env.config") as mock_config:
+        mock_config.MODEL_API_KEYS = {"gpt-5-mini-2025-08-07": "sk-model-specific"}
+        kwargs = agent.get_init_chat_model_kwargs()
+    assert kwargs["api_key"] == "sk-model-specific"
+
+
+def test_context_key_used_when_no_model_key():
+    agent = _TestAgent(_make_context(openai_api_key="sk-context-key"))
+    with patch("lib.config.env.config") as mock_config:
+        mock_config.MODEL_API_KEYS = {}
+        kwargs = agent.get_init_chat_model_kwargs()
+    assert kwargs["api_key"] == "sk-context-key"
+
+
+def test_no_api_key_in_kwargs_when_neither_set():
+    agent = _TestAgent(_make_context())
+    with patch("lib.config.env.config") as mock_config:
+        mock_config.MODEL_API_KEYS = {}
+        kwargs = agent.get_init_chat_model_kwargs()
+    assert "api_key" not in kwargs
+
+
+def test_rate_limiter_bucketed_by_model_key():
+    agent = _TestAgent(_make_context(openai_api_key="sk-context-key"))
+    with patch("lib.config.env.config") as mock_config:
+        mock_config.MODEL_API_KEYS = {"gpt-5-mini-2025-08-07": "sk-model-specific"}
+        limiter = agent.get_rate_limiter()
+
+    from lib.config.rate_limiter import get_rate_limiter as get_rl
+    expected = get_rl(hash_api_key("sk-model-specific"))
+    assert limiter is expected
+
+
+def test_rate_limiter_falls_back_to_context_key():
+    agent = _TestAgent(_make_context(openai_api_key="sk-context-key"))
+    with patch("lib.config.env.config") as mock_config:
+        mock_config.MODEL_API_KEYS = {}
+        limiter = agent.get_rate_limiter()
+
+    from lib.config.rate_limiter import get_rate_limiter as get_rl
+    expected = get_rl(hash_api_key("sk-context-key"))
+    assert limiter is expected


### PR DESCRIPTION
## Summary

- Add `MODEL_API_KEYS` env var (JSON dict) to assign a specific API key per model name
- Per-model key is used as a fallback when no user-provided key exists, giving each model its own rate-limit bucket
- Add `get_model_api_key()` helper and 7 unit tests

## Motivation

The RAND fork routes all calls through Azure OpenAI, where models are identified by deployment IDs (e.g. `gpt-5-mini-2025-08-07`). Each deployment can have its own subscription/API key with its own rate limits. Without per-model key support, all models share one rate-limit bucket, making it impossible to distribute load across separate Azure subscriptions.

## Usage

Set `MODEL_API_KEYS` to a JSON object mapping model names (use the actual deployment ID, not the generic alias) to API keys:

```bash
# .env or k8s Secret
MODEL_API_KEYS={"gpt-5-mini-2025-08-07": "sk-key-for-mini", "gpt-4.1-2025-04-14": "sk-key-for-4-1"}
```

Key resolution order per agent call:
1. `context.openai_api_key` — per-request key supplied by the user/frontend (always wins)
2. `MODEL_API_KEYS[model.name]` — per-model override (used when no user key is present)
3. `OPENAI_API_KEY` — global env fallback (LangChain reads this automatically)

Rate limiting is bucketed by whichever key is resolved, so models with separate keys get independent rate-limit buckets.

Models not listed in `MODEL_API_KEYS` continue to behave exactly as before.

## What's Changed

### Backend

- **`lib/config/env.py`** — Added `MODEL_API_KEYS: dict[str, str]` field to `Config` (parsed from `MODEL_API_KEYS` env var as JSON) and `get_model_api_key(model_name)` helper function
- **`lib/models/agent.py`** — `get_rate_limiter()` and `get_init_chat_model_kwargs()` now resolve the API key using user context key → per-model override → env fallback chain
- **`.env.template`** — Documented the new `MODEL_API_KEYS` env var with example
- **`tests/unit/test_model_api_keys.py`** — 7 unit tests covering all key resolution cases

### Frontend

No changes.

## Risks and Mitigations

- **Backwards compatible** — `MODEL_API_KEYS` defaults to `{}`, so existing deployments are unaffected
- **User key always wins** — per-model keys only apply when the user hasn't provided their own key, preserving existing per-user key behaviour