### PR TITLE
chore: remove AGENTS.md symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-CLAUDE.md


### PR DESCRIPTION
## Summary

Removes the `AGENTS.md` symlink that pointed to `CLAUDE.md`.

## Motivation

The symlink is no longer needed.

## What's Changed

**Backend:**
- `AGENTS.md` — deleted (was a symlink to `CLAUDE.md`)

**Frontend:** No changes.

## Risks and Mitigations

No functional changes. No risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)