### PR TITLE
fix(rate-limiter): cap DB pool pressure with per-bucket asyncio.Lock

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -55,4 +55,4 @@ FRONTEND_URL=http://localhost:3000
 # Rate limiter (shared across workers via Postgres)
 # RATE_LIMITER_REQUESTS_PER_SECOND=2     # Average LLM rps cap (default: 2)
 # RATE_LIMITER_MAX_BUCKET_SIZE=1         # Max burst size, must be >= 1 (default: 1)
-# RATE_LIMITER_CHECK_EVERY_N_SECONDS=0.2 # Poll interval while blocking (default: 0.2)
+# RATE_LIMITER_CHECK_EVERY_N_SECONDS=0.25 # Poll interval while blocking (default: 0.25)

--- a/lib/config/env.py
+++ b/lib/config/env.py
@@ -93,7 +93,7 @@ class Config(BaseModel):
         description="Maximum burst size (token bucket ceiling); must be >= 1",
     )
     RATE_LIMITER_CHECK_EVERY_N_SECONDS: float = Field(
-        default=0.2,
+        default=0.25,
         description="Polling interval when the bucket is empty and the caller is blocking",
     )
 
@@ -129,7 +129,7 @@ config = Config(
     ),
     RATE_LIMITER_MAX_BUCKET_SIZE=float(os.getenv("RATE_LIMITER_MAX_BUCKET_SIZE", "1")),
     RATE_LIMITER_CHECK_EVERY_N_SECONDS=float(
-        os.getenv("RATE_LIMITER_CHECK_EVERY_N_SECONDS", "0.2")
+        os.getenv("RATE_LIMITER_CHECK_EVERY_N_SECONDS", "0.25")
     ),
     MODEL_API_KEYS=json.loads(os.getenv("MODEL_API_KEYS", "{}")),
 )

--- a/lib/services/postgres_rate_limiter.py
+++ b/lib/services/postgres_rate_limiter.py
@@ -9,6 +9,12 @@ Concurrency control: each acquire attempt runs one short transaction that
 new state, and commits. The row lock serialises concurrent acquires across
 workers; the lock window is a single ``UPDATE``, so contention is bounded.
 
+An in-process ``asyncio.Lock`` per ``bucket_key`` also serialises callers
+within a single process, so only one coroutine at a time checks out a DB
+connection for a given bucket. This bounds pool pressure to ``O(num_buckets)``
+per process instead of ``O(concurrent_callers)``; cross-process serialisation
+still relies on the Postgres row lock.
+
 Fallback policy: fail closed. Any backend error is wrapped in
 ``RateLimiterBackendError`` and propagated so the awaiting LLM call fails
 loudly instead of silently bypassing the limiter.
@@ -36,6 +42,23 @@ class RateLimiterBackendError(RuntimeError):
     Propagated (not swallowed) so that callers fail closed rather than
     silently bypassing rate limiting when the shared store misbehaves.
     """
+
+
+_bucket_locks: dict[str, asyncio.Lock] = {}
+_bucket_locks_guard = asyncio.Lock()
+
+
+async def _get_bucket_lock(bucket_key: str) -> asyncio.Lock:
+    """Return a process-wide ``asyncio.Lock`` dedicated to ``bucket_key``."""
+    lock = _bucket_locks.get(bucket_key)
+    if lock is not None:
+        return lock
+    async with _bucket_locks_guard:
+        lock = _bucket_locks.get(bucket_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _bucket_locks[bucket_key] = lock
+        return lock
 
 
 class PostgresRateLimiter(BaseRateLimiter):
@@ -75,7 +98,11 @@ class PostgresRateLimiter(BaseRateLimiter):
         on any backend failure (fail-closed policy).
         """
         try:
-            async with AsyncSessionLocal() as session:
+            # Serialise callers within this process so only one coroutine per
+            # bucket checks out a DB connection at a time. Cross-process
+            # serialisation still relies on the Postgres row lock below.
+            bucket_lock = await _get_bucket_lock(self.bucket_key)
+            async with bucket_lock, AsyncSessionLocal() as session:
                 async with session.begin():
                     # Ensure the row exists. A fresh bucket starts full so the
                     # first caller can burst up to max_bucket_size.


### PR DESCRIPTION
## Summary
- Adds a per-`bucket_key` in-process `asyncio.Lock` around `PostgresRateLimiter._aconsume`, bounding DB pool pressure to one connection per bucket per process.
- Bumps default `RATE_LIMITER_CHECK_EVERY_N_SECONDS` from `0.2` to `0.25`.

## Motivation
Under high-concurrency nodes (e.g. `split_into_chunks` firing ~20 parallel `SentenceTokenizerAgent.ainvoke` calls), every LangChain LLM call routes through `PostgresRateLimiter.aacquire`, which opened its own `AsyncSessionLocal()` and blocked inside a `SELECT ... FOR UPDATE` row lock while waiting its turn. With `MAX_CONCURRENT_TASKS=20` and an engine pool of `pool_size=8, max_overflow=3`, concurrent pollers exhausted the pool and surfaced as:

```
TimeoutError: QueuePool limit of size 8 overflow 3 reached, connection timed out
→ RateLimiterBackendError: Rate limiter backend failure for bucket_key=...
```

The rate limiter fails closed, so the whole workflow node died.

## What's Changed

### Backend
- `lib/services/postgres_rate_limiter.py`
  - New module-level `_bucket_locks` registry plus `_get_bucket_lock(bucket_key)` helper that returns a process-wide `asyncio.Lock` per bucket (double-checked init guarded by `_bucket_locks_guard`).
  - `_aconsume()` now acquires that lock before opening the session, so only one coroutine per bucket per process holds a DB connection at a time. Cross-process serialisation still relies on the existing `SELECT ... FOR UPDATE` row lock.
  - Module docstring updated to describe the two-layer concurrency model.
- `lib/config/env.py`, `.env.template`
  - Default `RATE_LIMITER_CHECK_EVERY_N_SECONDS` bumped from `0.2` to `0.25` to further reduce poll churn (waiters now queue on the in-process lock, so a slightly longer interval is fine).

## Risks and Mitigations
- **Risk:** the in-process lock adds a serial point per bucket. **Mitigation:** the critical section is a single short DB transaction (already the case), so latency impact is minimal; the lock only queues callers that would otherwise contend on the Postgres row lock anyway.
- **Risk:** a stuck acquire would now also block other callers in the same process. **Mitigation:** the transaction is bounded and errors are re-raised — the lock is released on exception via `async with`.
- **Risk:** `_bucket_locks` grows unbounded over process lifetime. **Mitigation:** bucket keys are a small, bounded set (hashed API keys); memory impact is negligible.
- **Scope:** this is Layer 1 of the fix. For multi-pod production scale, we'll likely follow up with `pg_try_advisory_xact_lock` to also bound cross-pod pool pressure, but that's not part of this PR.

## Test plan
- [x] `uv run pytest` — 544 passed, 3 skipped
- [ ] Manually exercise a workflow run that previously triggered the `QueuePool` timeout under high concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)