### PR TITLE
feat(ui): rename analysis→assessment and experimental→beta across frontend

### DIFF
--- a/frontend/app/(authenticated)/new/page.tsx
+++ b/frontend/app/(authenticated)/new/page.tsx
@@ -26,7 +26,7 @@ function WizardContent() {
     const apiKeyStep = REQUIRE_API_KEY_CONFIG ? [{ label: 'API Key Setup', completed: apiKeyConfigured }] : [];
     const wizardSteps = [
       { label: 'Your Document', completed: wizard.currentStep > 1 },
-      { label: 'Choose Analyses', completed: wizard.currentStep > 2 },
+      { label: 'Choose Assessments', completed: wizard.currentStep > 2 },
     ];
     return [...apiKeyStep, ...wizardSteps];
   }, [apiKeyConfigured, wizard.currentStep]);

--- a/frontend/app/addin/layout.tsx
+++ b/frontend/app/addin/layout.tsx
@@ -2,8 +2,8 @@ import Script from 'next/script';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'AI Reviewer Add-in',
-  description: 'Word Add-in for AI Reviewer',
+  title: 'Draft Detective Add-in',
+  description: 'Word Add-in for Draft Detective',
 };
 
 export default function AddinLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -24,7 +24,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: 'AI Reviewer',
   description:
-    'AI-powered document review and analysis platform for accurate citations, fact-checking, and quality assessment',
+    'AI-powered document review and assessment platform for accurate citations, fact-checking, and quality assessment',
 };
 
 export default async function RootLayout({

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -22,7 +22,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: 'AI Reviewer',
+  title: 'Draft Detective',
   description:
     'AI-powered document review and assessment platform for accurate citations, fact-checking, and quality assessment',
 };

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -14,11 +14,12 @@ export default function Home() {
             AI-Powered Peer Review
           </Badge>
           <h1 className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
-            AI Reviewer
+            Draft Detective
           </h1>
           <p className="text-lg text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-            Transform your document review process with AI-powered claim extraction, citation analysis, and evidence
-            substantiation. Built for researchers, analysts, and content reviewers who demand accuracy and thoroughness.
+            Transform your document review process with Draft Detective. Run pre-peer review checks on your manuscript
+            and get a prioritized list of flagged issues. Built for researchers, analysts, and content reviewers who
+            want to catch problems before reviewers do.
           </p>
         </div>
 

--- a/frontend/app/share/[token]/page.tsx
+++ b/frontend/app/share/[token]/page.tsx
@@ -28,7 +28,7 @@ export default function SharedProjectPage() {
       <div className="flex items-center justify-center py-20">
         <div className="text-center">
           <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4"></div>
-          <p className="text-muted-foreground">Loading shared analysis...</p>
+          <p className="text-muted-foreground">Loading shared assessment...</p>
         </div>
       </div>
     );

--- a/frontend/components/admin/feedbacks-list.tsx
+++ b/frontend/components/admin/feedbacks-list.tsx
@@ -252,10 +252,10 @@ export function FeedbacksList() {
 
             <Select value={selectedWorkflowType} onValueChange={setSelectedWorkflowType}>
               <SelectTrigger className="w-[220px]">
-                <SelectValue placeholder="All analysis types" />
+                <SelectValue placeholder="All assessment types" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={ALL_VALUE}>All analysis types</SelectItem>
+                <SelectItem value={ALL_VALUE}>All assessment types</SelectItem>
                 {[...workflowTypes]
                   .sort((a, b) => a.name.localeCompare(b.name))
                   .map((wt) => (

--- a/frontend/components/analysis-form/index.tsx
+++ b/frontend/components/analysis-form/index.tsx
@@ -81,7 +81,7 @@ export function AnalysisForm({ onSubmit, isPending = false, error }: AnalysisFor
         <div className="p-4 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start gap-3">
           <AlertCircle className="h-5 w-5 text-destructive shrink-0 mt-0.5" />
           <div className="space-y-1">
-            <p className="font-medium text-destructive">Failed to start analysis</p>
+            <p className="font-medium text-destructive">Failed to start assessment</p>
             <p className="text-sm text-destructive/90 whitespace-pre-line">{error}</p>
           </div>
         </div>
@@ -93,7 +93,7 @@ export function AnalysisForm({ onSubmit, isPending = false, error }: AnalysisFor
           <div className="space-y-2">
             <UploadSection
               title="Main Document"
-              description="Primary document for analysis. Word documents are preferred (less LLM conversion errors) but PDFs are also supported."
+              description="Primary document for assessment. Word documents are preferred (less LLM conversion errors) but PDFs are also supported."
               required={true}
               onFilesChange={(files) => field.handleChange(files[0] || null)}
               multiple={false}
@@ -125,7 +125,7 @@ export function AnalysisForm({ onSubmit, isPending = false, error }: AnalysisFor
             selectedTypes={field.state.value}
             onSelectionChange={field.handleChange}
             disabled={isPending}
-            headerDescription="Select which types of analyses to perform"
+            headerDescription="Select which assessments to perform"
             error={
               !field.state.meta.isValid && field.state.meta.errors.length > 0
                 ? field.state.meta.errors.join(', ')
@@ -198,7 +198,7 @@ export function AnalysisForm({ onSubmit, isPending = false, error }: AnalysisFor
       <div className="space-y-4">
         <div className="space-y-1">
           <h2 className="text-xl font-semibold">Additional Context</h2>
-          <p className="text-sm text-muted-foreground">Provide context for more accurate analysis</p>
+          <p className="text-sm text-muted-foreground">Provide context for more accurate assessment</p>
         </div>
         <div className="space-y-4">
           {/*
@@ -301,7 +301,7 @@ export function AnalysisForm({ onSubmit, isPending = false, error }: AnalysisFor
               ) : (
                 <>
                   <Play className="w-4 h-4" />
-                  {error ? 'Retry Analysis' : 'Start Analysis'}
+                  {error ? 'Retry Assessment' : 'Start Assessment'}
                 </>
               )}
             </Button>

--- a/frontend/components/analysis-wizard/step-analyses.tsx
+++ b/frontend/components/analysis-wizard/step-analyses.tsx
@@ -62,11 +62,11 @@ export function StepAnalyses() {
       });
     },
     onSuccess: () => {
-      toast.success('Analysis started! Redirecting to your project...');
+      toast.success('Assessment started! Redirecting to your project...');
       router.push(`/projects/${wizard.projectId}?fromWizard=true`);
     },
     onError: (error) => {
-      toast.error(getErrorMessage(error, 'Failed to start analysis'));
+      toast.error(getErrorMessage(error, 'Failed to start assessment'));
     },
   });
 
@@ -85,7 +85,7 @@ export function StepAnalyses() {
           <div className="flex flex-col items-center justify-center space-y-4">
             <Loader2 className="w-12 h-12 animate-spin text-primary" />
             <div className="text-center space-y-2">
-              <h2 className="text-xl font-semibold">Starting Analysis</h2>
+              <h2 className="text-xl font-semibold">Starting Assessment</h2>
               <p className="text-sm text-muted-foreground">Starting workflows...</p>
             </div>
           </div>
@@ -99,8 +99,9 @@ export function StepAnalyses() {
       <div className="space-y-2">
         <h1 className="text-2xl font-bold">What would you like to check?</h1>
         <p className="text-muted-foreground">
-          Select the analyses that matter most for your document. <strong>You can also trigger analyses later</strong>,
-          after project is created, so you can skip this step for now if you want.
+          Select the assessments that matter most for your document.{' '}
+          <strong>You can also trigger assessments later</strong>, after project is created, so you can skip this step
+          for now if you want.
         </p>
       </div>
 
@@ -112,7 +113,7 @@ export function StepAnalyses() {
 
       {needsSupportingDocs && (
         <Callout variant="info" icon={AlertCircle} title="Source documents required">
-          Some selected analyses need reference documents to verify claims. After the project is created, go to the{' '}
+          Some selected assessments need reference documents to verify claims. After the project is created, go to the{' '}
           <strong>References tab</strong> to upload sources or fetch them from the web, then approve to start the
           analysis.
         </Callout>
@@ -123,7 +124,7 @@ export function StepAnalyses() {
       <div className="space-y-4">
         <div>
           <h3 className="text-lg font-semibold">Help us understand your context</h3>
-          <p className="text-sm text-muted-foreground">Optional, but helps tailor the analysis.</p>
+          <p className="text-sm text-muted-foreground">Optional, but helps tailor the assessment.</p>
         </div>
         <div className="space-y-2">
           <Label htmlFor="domain">What field is this document about?</Label>
@@ -147,7 +148,7 @@ export function StepAnalyses() {
 
       <div className="flex flex-col gap-3">
         <Button onClick={handleStartAnalysis} disabled={!canContinue} size="lg" className="w-full">
-          Start Analysis
+          Start Assessment
         </Button>
         <Button
           variant="outline"

--- a/frontend/components/analysis-wizard/step-api-key-config.tsx
+++ b/frontend/components/analysis-wizard/step-api-key-config.tsx
@@ -41,8 +41,8 @@ export function StepApiKeyConfig() {
       <div className="space-y-2">
         <h1 className="text-2xl font-bold">Set up your OpenAI API Key</h1>
         <p className="text-muted-foreground">
-          This deployment requires an OpenAI API key to run analyses. Your key is encrypted at rest and never exposed in
-          API responses. You can update or remove it at any time from your account settings.
+          This deployment requires an OpenAI API key to run assessments. Your key is encrypted at rest and never exposed
+          in API responses. You can update or remove it at any time from your account settings.
         </p>
       </div>
 

--- a/frontend/components/analysis-wizard/step-upload.tsx
+++ b/frontend/components/analysis-wizard/step-upload.tsx
@@ -78,7 +78,7 @@ export function StepUpload({ onComplete }: StepUploadProps) {
               {stageMessage || 'Setting up your project...'}
             </>
           ) : (
-            'Next: Choose your analyses →'
+            'Next: Choose your assessments →'
           )}
         </Button>
       </div>

--- a/frontend/components/layout/application-shell.tsx
+++ b/frontend/components/layout/application-shell.tsx
@@ -41,7 +41,7 @@ export function ApplicationShell({ children }: ApplicationShellProps) {
             <div className="flex">
               <div className="flex shrink-0 items-center">
                 <Link href="/" className="text-xl font-bold text-primary">
-                  AI Reviewer
+                  Draft Detective
                 </Link>
               </div>
               <div className="hidden sm:-my-px sm:ml-6 sm:flex sm:space-x-8">

--- a/frontend/components/layout/profile-dropdown.tsx
+++ b/frontend/components/layout/profile-dropdown.tsx
@@ -58,7 +58,7 @@ export function ProfileDropdown({ user }: ProfileDropdownProps) {
             <TooltipTrigger asChild>
               <MenuItem>
                 <label className="flex items-center justify-between px-4 py-2 text-sm text-gray-700 cursor-pointer data-focus:bg-gray-100 data-focus:outline-hidden">
-                  <span>Experimental features</span>
+                  <span>Beta features</span>
                   <Switch
                     checked={showExperimentalFeatures}
                     onCheckedChange={setShowExperimentalFeatures}
@@ -138,7 +138,7 @@ export function MobileProfileMenu({ user }: MobileProfileMenuProps) {
           <Tooltip>
             <TooltipTrigger asChild>
               <label className="flex items-center justify-between px-4 py-2 text-base font-medium text-gray-500 cursor-pointer">
-                <span>Experimental features</span>
+                <span>Beta features</span>
                 <Switch
                   checked={showExperimentalFeatures}
                   onCheckedChange={setShowExperimentalFeatures}

--- a/frontend/components/projects/edit-project-dialog.tsx
+++ b/frontend/components/projects/edit-project-dialog.tsx
@@ -206,8 +206,8 @@ export function EditProjectDialog({
         </form.Field>
 
         <Callout variant="info" icon={InfoIcon} title="Note">
-          Only subsequent analyses (new or re-triggered) will use the updated project details. Existing or running
-          analyses will keep their original configuration and results.
+          Only subsequent assessments (new or re-triggered) will use the updated project details. Existing or running
+          assessments will keep their original configuration and results.
         </Callout>
 
         <form.Subscribe selector={(state) => [state.canSubmit, state.isSubmitting]}>

--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -184,7 +184,7 @@ export function AnalysisOptionsMenu({ project, results, readOnly }: AnalysisOpti
                 <MenuItemWithTooltip
                   icon={RefreshCw}
                   onClick={() => setIsReplaceDialogOpen(true)}
-                  tooltip="Upload a new version of the main document and re-run analyses"
+                  tooltip="Upload a new version of the main document and re-run assessments"
                 >
                   Replace main document
                 </MenuItemWithTooltip>
@@ -194,7 +194,7 @@ export function AnalysisOptionsMenu({ project, results, readOnly }: AnalysisOpti
                   onClick={() => share.setIsDialogOpen(true)}
                   tooltip={share.isEnabled ? 'View or copy the share link' : 'Create a public link'}
                 >
-                  {share.isEnabled ? 'Manage share link' : 'Share this analysis'}
+                  {share.isEnabled ? 'Manage share link' : 'Share this assessment'}
                 </MenuItemWithTooltip>
               </>
             )}

--- a/frontend/components/results/components/document-explorer-sidebar.tsx
+++ b/frontend/components/results/components/document-explorer-sidebar.tsx
@@ -97,7 +97,7 @@ export function DocumentExplorerSidebar({
         {visibleIssues.length === 0 && !isAnyProcessing && (
           <div className="text-sm text-muted-foreground py-4 space-y-2">
             <p>No issues found for this document.</p>
-            <p>You can still view detailed analysis for each chunk by selecting a chunk from the document.</p>
+            <p>You can still view detailed assessment for each chunk by selecting a chunk from the document.</p>
           </div>
         )}
 

--- a/frontend/components/results/components/health-monitor/health-monitor-dashboard.tsx
+++ b/frontend/components/results/components/health-monitor/health-monitor-dashboard.tsx
@@ -67,8 +67,8 @@ export function HealthMonitorDashboard({
   if (sortedHealthData.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
-        <p className="text-muted-foreground">No analyses have been run yet.</p>
-        <p className="text-sm text-muted-foreground mt-1">Start an analysis to see the project health dashboard.</p>
+        <p className="text-muted-foreground">No assessments have been run yet.</p>
+        <p className="text-sm text-muted-foreground mt-1">Start an assessment to see the project health dashboard.</p>
       </div>
     );
   }
@@ -87,7 +87,7 @@ export function HealthMonitorDashboard({
 
       {/* Workflow Widgets Grid */}
       <div>
-        <h3 className="text-lg font-semibold mb-4">Analysis Health by Workflow</h3>
+        <h3 className="text-lg font-semibold mb-4">Results Overview by Assessment Type</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {sortedHealthData.map((data) => (
             <WorkflowHealthWidget

--- a/frontend/components/results/components/health-monitor/health-status-indicator.tsx
+++ b/frontend/components/results/components/health-monitor/health-status-indicator.tsx
@@ -35,7 +35,7 @@ const statusBadgeConfig: Record<
   },
   error: {
     icon: XCircle,
-    label: 'Analysis failed',
+    label: 'Assessment failed',
     className: 'border-transparent bg-red-600 text-white',
   },
 };

--- a/frontend/components/results/components/health-monitor/overall-health-card.tsx
+++ b/frontend/components/results/components/health-monitor/overall-health-card.tsx
@@ -46,7 +46,7 @@ export function OverallHealthCard({
           <div className="flex items-center gap-8">
             <div className="text-center">
               <div className="text-3xl font-bold">{totalWorkflows}</div>
-              <div className="text-sm text-muted-foreground">Analyses</div>
+              <div className="text-sm text-muted-foreground">Assessments</div>
             </div>
             <div className="text-center">
               <div className={cn('text-3xl font-bold', totalIssues > 0 ? 'text-amber-600' : 'text-emerald-600')}>

--- a/frontend/components/results/components/replace-main-document-dialog.tsx
+++ b/frontend/components/results/components/replace-main-document-dialog.tsx
@@ -105,7 +105,7 @@ export function ReplaceMainDocumentDialog({ isOpen, projectId, onClose }: Replac
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['project', projectId] });
-      toast.success('Main document replaced. Analysis started.');
+      toast.success('Main document replaced. Assessment started.');
       onClose();
     },
     onError: (error) => {
@@ -138,7 +138,7 @@ export function ReplaceMainDocumentDialog({ isOpen, projectId, onClose }: Replac
         }
         return 'Uploading document...';
       case 'starting-workflows':
-        return 'Starting analysis workflows...';
+        return 'Starting assessment workflows...';
       default:
         return '';
     }
@@ -150,7 +150,7 @@ export function ReplaceMainDocumentDialog({ isOpen, projectId, onClose }: Replac
         <DialogHeader>
           <DialogTitle>Replace main document</DialogTitle>
           <DialogDescription>
-            Upload a new version of the main document. Previous analysis results will be archived (not deleted).
+            Upload a new version of the main document. Previous assessment results will be archived (not deleted).
             Supporting documents will be preserved.
           </DialogDescription>
         </DialogHeader>
@@ -189,12 +189,12 @@ export function ReplaceMainDocumentDialog({ isOpen, projectId, onClose }: Replac
                   onCheckedChange={(checked) => setRerunAnalyses(checked === true)}
                 />
                 <Label htmlFor="rerun-analyses" className="text-sm font-normal cursor-pointer">
-                  Re-run previous analyses
+                  Re-run previous assessments
                 </Label>
               </div>
               <p className="text-xs text-muted-foreground pl-6">
-                Automatically run the same analysis workflows that were previously executed on the old document. If
-                unchecked, only document processing will run and you can manually start analyses later.
+                Automatically run the same assessment workflows that were previously executed on the old document. If
+                unchecked, only document processing will run and you can manually start assessments later.
               </p>
             </div>
           </div>

--- a/frontend/components/results/components/use-download-docx.ts
+++ b/frontend/components/results/components/use-download-docx.ts
@@ -64,7 +64,7 @@ export function useDownloadDocx({
     const dType = docxType ?? initialDocxType ?? 'original';
     const loadingMessage =
       dType === 'add-in'
-        ? 'Preparing DOCX for AI Reviewer Add-In...'
+        ? 'Preparing DOCX for Draft Detective Add-In...'
         : dType === 'comments-with-links'
           ? 'Preparing DOCX with share links...'
           : 'Preparing DOCX for download...';

--- a/frontend/components/results/components/workflow-type-filter.tsx
+++ b/frontend/components/results/components/workflow-type-filter.tsx
@@ -72,7 +72,7 @@ export function WorkflowTypeFilter({
         <Button
           variant="outline"
           size="sm"
-          title="Filter by analysis type"
+          title="Filter by assessment type"
           className="h-6 px-2 text-xs gap-1 flex items-center"
         >
           <FilterIcon className="size-3.5" />
@@ -86,7 +86,7 @@ export function WorkflowTypeFilter({
       </PopoverTrigger>
       <PopoverContent className="w-64 p-2" align="end">
         <div className="space-y-1">
-          <p className="text-xs font-medium text-muted-foreground px-2 pb-1">Analysis type</p>
+          <p className="text-xs font-medium text-muted-foreground px-2 pb-1">Assessment type</p>
           {workflowTypeOptions.map((option) => (
             <label
               key={option.value}

--- a/frontend/components/results/results-visualization.tsx
+++ b/frontend/components/results/results-visualization.tsx
@@ -141,7 +141,7 @@ export function ResultsVisualization({
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm min-w-0">
                 Go to the <strong>References tab</strong> to upload source documents or fetch them from the web. When
-                you&apos;re ready, use <strong>Approve and start analysis</strong> here or at the bottom of that tab.
+                you&apos;re ready, use <strong>Approve and start assessment</strong> here or at the bottom of that tab.
               </p>
               <div className="flex shrink-0 flex-wrap items-center gap-2">
                 <Button size="sm" variant="outline" onClick={() => setActiveTab('references')}>
@@ -193,7 +193,7 @@ export function ResultsVisualization({
                 </Badge>
               </TabsTrigger>
               <TabsTrigger value="analyses">
-                Analyses{' '}
+                Assessments{' '}
                 <Badge className="rounded-full h-4.5 min-w-4.5" variant="secondary">
                   {results.filter((r) => isWorkflowTypeVisible(r.run.type)).length}
                 </Badge>

--- a/frontend/components/results/tabs/analyses-tab.tsx
+++ b/frontend/components/results/tabs/analyses-tab.tsx
@@ -160,13 +160,13 @@ export function AnalysesTab({
         ) : (
           <div className="flex items-center justify-center h-32">
             <p className="text-muted-foreground flex items-center gap-2">
-              {readOnly && <>Select an analysis to view its results</>}
+              {readOnly && <>Select an assessment to view its results</>}
               {!readOnly && (
                 <>
-                  Select an analysis to view its results or
+                  Select an assessment to view its results or
                   <Button size="xs" variant="default" onClick={handleStartNewAnalysis}>
                     <PlusIcon className="size-3" />
-                    Start a new analysis
+                    Start a new assessment
                   </Button>
                 </>
               )}

--- a/frontend/components/results/tabs/document-explorer-tab.tsx
+++ b/frontend/components/results/tabs/document-explorer-tab.tsx
@@ -100,7 +100,7 @@ export function DocumentExplorerTab({
                 onClick={onNavigateToAnalyses}
                 className="text-blue-600 hover:text-blue-800 underline font-medium"
               >
-                Analyses tab
+                Assessments tab
               </button>
               <span>for details.</span>
             </div>
@@ -128,7 +128,7 @@ export function DocumentExplorerTab({
               onClick={onNavigateToAnalyses}
               className="text-blue-600 hover:text-blue-800 underline font-medium cursor-pointer"
             >
-              Analyses tab
+              Assessments tab
             </button>
             <span>for details.</span>
           </div>

--- a/frontend/components/results/tabs/reference-review/unmatched-references-approve-dialog.tsx
+++ b/frontend/components/results/tabs/reference-review/unmatched-references-approve-dialog.tsx
@@ -44,7 +44,7 @@ export function UnmatchedReferencesApproveDialog({
             </p>
             <p>
               Without source documents, we won&apos;t be able to fully verify claims that cite these references. You can
-              still run the analysis, but results may be incomplete.
+              still run the assessment, but results may be incomplete.
             </p>
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/frontend/components/results/tabs/workflow-list-sidebar.tsx
+++ b/frontend/components/results/tabs/workflow-list-sidebar.tsx
@@ -78,11 +78,11 @@ export function WorkflowListSidebar({
     <div className="w-1/4 overflow-y-auto border-r pr-4">
       <div className="space-y-2">
         <div className="flex items-center justify-between mb-3">
-          <h3 className="text-sm font-semibold">Analyses</h3>
+          <h3 className="text-sm font-semibold">Assessments</h3>
           {!readOnly && (
             <Button size="xs" variant="outline" onClick={onStartNewAnalysis}>
               <PlusIcon className="size-3" />
-              New Analysis
+              New Assessment
             </Button>
           )}
         </div>
@@ -104,7 +104,7 @@ export function WorkflowListSidebar({
                 className={cn('w-3 h-3 text-muted-foreground transition-transform', !internalExpanded && '-rotate-90')}
               />
               <h4 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide group-hover:text-foreground transition-colors">
-                Internal Analyses
+                Internal Workflows
               </h4>
               <span className="text-xs text-muted-foreground font-normal">({internalWorkflows.length})</span>
               <Tooltip>
@@ -115,7 +115,7 @@ export function WorkflowListSidebar({
                   />
                 </TooltipTrigger>
                 <TooltipContent>
-                  These analyses run automatically as part of the analysis pipeline and are not user-triggered.
+                  These workflows run automatically as part of the analysis pipeline and are not user-triggered.
                 </TooltipContent>
               </Tooltip>
             </button>

--- a/frontend/components/results/tabs/workflow-results-renderer.tsx
+++ b/frontend/components/results/tabs/workflow-results-renderer.tsx
@@ -24,7 +24,7 @@ function InternalWorkflowResults({ workflowName }: { workflowName: string }) {
   return (
     <Callout title="Internal Workflow" variant="info" icon={FlaskConicalIcon}>
       <p className="text-sm">
-        <strong>{workflowName}</strong> runs automatically as a dependency of other analyses and is not meant to be
+        <strong>{workflowName}</strong> runs automatically as a dependency of other assessments and is not meant to be
         triggered directly — its results feed into higher-level workflows that surface findings in their own result
         views.
       </p>

--- a/frontend/components/settings/api-key-settings.tsx
+++ b/frontend/components/settings/api-key-settings.tsx
@@ -55,8 +55,8 @@ export function ApiKeySettings() {
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-sm text-muted-foreground">
-          Store your OpenAI API key so it is used automatically when running analyses — including from MCP clients like
-          Claude. The key is encrypted at rest and never exposed in API responses.
+          Store your OpenAI API key so it is used automatically when running assessments — including from MCP clients
+          like Claude. The key is encrypted at rest and never exposed in API responses.
         </p>
 
         {user?.has_openai_api_key ? (

--- a/frontend/components/share/filter-warning-dialog.tsx
+++ b/frontend/components/share/filter-warning-dialog.tsx
@@ -62,7 +62,7 @@ export function FilterWarningDialog({
               )}
               {hasWorkflowTypeFilter && (
                 <div className="space-y-1">
-                  <p className="text-sm font-medium text-foreground">Analysis types:</p>
+                  <p className="text-sm font-medium text-foreground">Assessment types:</p>
                   <div className="flex flex-wrap gap-2">
                     {workflowTypeFilter.map((type) => (
                       <Badge key={type} variant="secondary">

--- a/frontend/components/share/share-dialog.tsx
+++ b/frontend/components/share/share-dialog.tsx
@@ -79,7 +79,7 @@ export function ShareDialog({
             <DialogDescription asChild>
               <div className="text-sm text-muted-foreground space-y-2">
                 <p>
-                  This will <strong>immediately break all existing links</strong> to this analysis.
+                  This will <strong>immediately break all existing links</strong> to this assessment.
                 </p>
                 <p>You can re-enable sharing later.</p>
               </div>
@@ -109,11 +109,11 @@ export function ShareDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>{isEnabled ? '🔗 Share Link Ready' : 'Share This Analysis'}</DialogTitle>
+          <DialogTitle>{isEnabled ? '🔗 Share Link Ready' : 'Share This Assessment'}</DialogTitle>
           <DialogDescription>
             {isEnabled
-              ? 'Anyone with this link can view a read-only version of your analysis.'
-              : 'Create a public link that anyone can use to view this analysis.'}
+              ? 'Anyone with this link can view a read-only version of your assessment.'
+              : 'Create a public link that anyone can use to view this assessment.'}
           </DialogDescription>
         </DialogHeader>
 

--- a/frontend/components/share/share-warning-dialog.tsx
+++ b/frontend/components/share/share-warning-dialog.tsx
@@ -66,7 +66,7 @@ export function ShareWarningDialog({
           </DialogTitle>
           <DialogDescription asChild>
             <div className="text-sm text-muted-foreground pt-2">
-              Choose how reviewers should see this analysis in the downloaded DOCX.
+              Choose how reviewers should see this assessment in the downloaded DOCX.
             </div>
           </DialogDescription>
         </DialogHeader>
@@ -102,7 +102,7 @@ export function ShareWarningDialog({
                 className="mt-0.5"
               />
               <span className="text-sm text-muted-foreground">
-                Make this analysis public and add links to comments redirecting to the full analysis page.
+                Make this assessment public and add links to comments redirecting to the full assessment page.
               </span>
             </label>
           )}
@@ -112,7 +112,7 @@ export function ShareWarningDialog({
               <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
               <span className="text-sm text-muted-foreground">
                 Requires the AI Reviewer Word add-in.
-                {!isProjectPublic && ' This will make this analysis public.'}
+                {!isProjectPublic && ' This will make this assessment public.'}
               </span>
             </div>
           )}

--- a/frontend/components/share/share-warning-dialog.tsx
+++ b/frontend/components/share/share-warning-dialog.tsx
@@ -80,7 +80,7 @@ export function ShareWarningDialog({
             <RadioGroupItemWithDescription
               id="add-in"
               value={selectedExportType}
-              label="AI Reviewer add-in"
+              label="Draft Detective add-in"
               description="Reviewers can see issues directly in the add-in as they do in the app."
               disabled={isProcessing}
             />
@@ -111,7 +111,7 @@ export function ShareWarningDialog({
             <div className="flex items-start gap-2 rounded-md border p-3">
               <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
               <span className="text-sm text-muted-foreground">
-                Requires the AI Reviewer Word add-in.
+                Requires the Draft Detective Word add-in.
                 {!isProjectPublic && ' This will make this assessment public.'}
               </span>
             </div>

--- a/frontend/components/workflows/results/about-this-ger-results.tsx
+++ b/frontend/components/workflows/results/about-this-ger-results.tsx
@@ -133,8 +133,8 @@ export function AboutThisGerResults({ workflowDetail }: AboutThisGerResultsProps
     return (
       <EmptyState
         icon={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />}
-        message="Analyzing Document..."
-        description="The About This (GER) analysis is currently running. Results will appear here once complete."
+        message="Assessing Document..."
+        description="The About This (GER) assessment is currently running. Results will appear here once complete."
       />
     );
   }
@@ -143,8 +143,8 @@ export function AboutThisGerResults({ workflowDetail }: AboutThisGerResultsProps
     return (
       <EmptyState
         icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
-        message="Analysis Cancelled"
-        description="The About This (GER) analysis was cancelled before it could complete."
+        message="Assessment Cancelled"
+        description="The About This (GER) assessment was cancelled before it could complete."
       />
     );
   }

--- a/frontend/components/workflows/results/advocacy-tone-results.tsx
+++ b/frontend/components/workflows/results/advocacy-tone-results.tsx
@@ -228,7 +228,7 @@ export function AdvocacyToneResults({ project, onNavigateToDocumentExplorer }: A
 
   // Not run yet
   if (!advocacyToneRun) {
-    return <EmptyState message="Advocacy & Tone analysis has not been run." />;
+    return <EmptyState message="Advocacy & Tone assessment has not been run." />;
   }
 
   // Still processing
@@ -236,8 +236,8 @@ export function AdvocacyToneResults({ project, onNavigateToDocumentExplorer }: A
     return (
       <EmptyState
         icon={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />}
-        message="Analyzing Advocacy & Tone..."
-        description="The Advocacy & Tone analysis is currently running. Results will appear here once complete."
+        message="Assessing Advocacy & Tone..."
+        description="The Advocacy & Tone assessment is currently running. Results will appear here once complete."
       />
     );
   }
@@ -246,8 +246,8 @@ export function AdvocacyToneResults({ project, onNavigateToDocumentExplorer }: A
     return (
       <EmptyState
         icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
-        message="Analysis Cancelled"
-        description="The Advocacy & Tone analysis was cancelled before it could complete."
+        message="Assessment Cancelled"
+        description="The Advocacy & Tone assessment was cancelled before it could complete."
       />
     );
   }
@@ -326,7 +326,7 @@ function AdvocacyToneContent({ state, chunkContentMap, onNavigateToDocumentExplo
       {/* Summary */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Advocacy & Tone Analysis</CardTitle>
+          <CardTitle className="text-base">Advocacy & Tone Assessment</CardTitle>
           <CardDescription>
             Detected language issues that may require attention for objectivity and neutrality.
           </CardDescription>

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -72,8 +72,8 @@ export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleD
     return (
       <EmptyState
         icon={<Loader2 className="h-8 w-8 animate-spin text-muted-foreground mx-auto" />}
-        message={`Analyzing Document…`}
-        description={`The ${workflowName} analysis is currently running. Results will appear here once complete.`}
+        message={`Assessing Document…`}
+        description={`The ${workflowName} assessment is currently running. Results will appear here once complete.`}
       />
     );
   }
@@ -82,8 +82,8 @@ export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleD
     return (
       <EmptyState
         icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
-        message="Analysis Cancelled"
-        description={`The ${workflowName} analysis was cancelled before it could complete.`}
+        message="Assessment Cancelled"
+        description={`The ${workflowName} assessment was cancelled before it could complete.`}
       />
     );
   }

--- a/frontend/components/workflows/web-search-consent-checkbox.tsx
+++ b/frontend/components/workflows/web-search-consent-checkbox.tsx
@@ -22,8 +22,8 @@ export function WebSearchConsentCheckbox({
           id="web-search-consent"
           checked={checked}
           onCheckedChange={(checked) => onCheckedChange(checked === true)}
-          label="I consent to perform web search using parts or the whole document for this analysis"
-          description="Web search is required to perform this analysis. Parts of the document will be used to perform web search, so we don't recommend using confidential information. Don't proceed if you don't consent to perform web search."
+          label="I consent to perform web search using parts or the whole document for this assessment"
+          description="Web search is required to perform this assessment. Parts of the document will be used to perform web search, so we don't recommend using confidential information. Don't proceed if you don't consent to perform web search."
           disabled={disabled}
         />
       </div>

--- a/frontend/components/workflows/workflow-config-dialog.tsx
+++ b/frontend/components/workflows/workflow-config-dialog.tsx
@@ -165,7 +165,7 @@ export function WorkflowConfigDialog({ isOpen, type, projectId, onConfirm, onCan
         {user?.has_openai_api_key && (
           <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
             <KeyRound className="h-3.5 w-3.5 shrink-0" />
-            Your saved OpenAI API key will be used for this analysis.
+            Your saved OpenAI API key will be used for this assessment.
           </p>
         )}
 

--- a/frontend/components/workflows/workflow-progress-toast-content.tsx
+++ b/frontend/components/workflows/workflow-progress-toast-content.tsx
@@ -89,7 +89,7 @@ function ToastWrapper({ children, actions }: { children: React.ReactNode; action
   return (
     <div className="w-96 space-y-2.5 p-4 bg-background border rounded-lg shadow-lg">
       <div className="flex items-center justify-between">
-        <span className="text-sm font-semibold tracking-tight text-foreground">Analysis in Progress</span>
+        <span className="text-sm font-semibold tracking-tight text-foreground">Assessment in Progress</span>
         {actions}
       </div>
       <div className="max-h-[80vh] overflow-y-auto space-y-1.5">{children}</div>
@@ -167,7 +167,7 @@ export function LoadingToastContent() {
     <ToastWrapper>
       <div className="flex items-center gap-3 p-2.5 rounded-lg border border-blue-200 bg-blue-50">
         <Loader2 className="h-4 w-4 text-blue-600 animate-spin" />
-        <span className="text-[13px] text-muted-foreground">Starting analysis...</span>
+        <span className="text-[13px] text-muted-foreground">Starting assessment...</span>
       </div>
     </ToastWrapper>
   );

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -151,7 +151,7 @@ export function WorkflowTypeCheckbox({
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
-                    This analysis is part of the QA Screener tool, designed for quality assurance screening of
+                    This assessment is part of the QA Screener tool, designed for quality assurance screening of
                     documents.
                   </TooltipContent>
                 </Tooltip>
@@ -165,7 +165,7 @@ export function WorkflowTypeCheckbox({
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
-                    This analysis requires the full text of referenced documents. Claims citing references without
+                    This assessment requires the full text of referenced documents. Claims citing references without
                     matched source documents will be skipped. You can upload sources or fetch from the web in Step 3.
                   </TooltipContent>
                 </Tooltip>
@@ -179,8 +179,8 @@ export function WorkflowTypeCheckbox({
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
-                    This analysis searches the web (using a web search tool) for additional context and information to
-                    enhance the analysis. Parts of the document might be used as web search query/context.
+                    This assessment searches the web (using a web search tool) for additional context and information to
+                    enhance the assessment. Parts of the document might be used as web search query/context.
                   </TooltipContent>
                 </Tooltip>
               )}
@@ -193,7 +193,7 @@ export function WorkflowTypeCheckbox({
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
-                    This analysis is still highly experimental and being refined. Results may vary and the feature may
+                    This assessment is still highly experimental and being refined. Results may vary and the feature may
                     change in future updates.
                   </TooltipContent>
                 </Tooltip>

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -189,12 +189,11 @@ export function WorkflowTypeCheckbox({
                   <TooltipTrigger asChild>
                     <Badge variant="secondary" className="flex items-center gap-1 text-xs">
                       <FlaskConical className="size-3" />
-                      Experimental
+                      Beta
                     </Badge>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-xs">
-                    This assessment is still highly experimental and being refined. Results may vary and the feature may
-                    change in future updates.
+                    This assessment is in beta. Results may vary and features/performance may change in future updates.
                   </TooltipContent>
                 </Tooltip>
               )}

--- a/frontend/components/workflows/workflow-type-selector.tsx
+++ b/frontend/components/workflows/workflow-type-selector.tsx
@@ -68,7 +68,7 @@ export function WorkflowTypeSelector({
       {showHeader && (
         <div className="space-y-1">
           <h2 className="text-lg font-semibold">
-            Analyses Type Selection{' '}
+            Assessment Type Selection{' '}
             {visibleCount > 0 && (
               <span className="text-sm font-normal text-muted-foreground">
                 ({selectedTypes.length}/{visibleCount} selected)


### PR DESCRIPTION
## Summary
- Renamed all user-facing "analysis/analyses" labels to "assessment/assessments" across the frontend
- Renamed all user-facing "experimental" labels to "beta" (badges, toggles, tooltips)
- Updated homepage title to "Draft Detective" with a rewritten intro paragraph

## Motivation
Aligns user-visible language with the product's terminology and branding. "Assessment" better describes the tool's purpose; "beta" is more standard than "experimental."

## What's Changed

**Frontend:**
- `frontend/app/` — updated share page loading text
- `frontend/components/analysis-wizard/` — updated step labels and descriptions
- `frontend/components/analysis-form/` — updated document field descriptions
- `frontend/components/results/` — updated tabs, health monitor, share dialogs, options menu, results visualization
- `frontend/components/workflows/` — updated workflow type selector, config dialog, web search consent, results components (advocacy-tone, about-this-ger, simple-deep-agent)
- `frontend/components/layout/profile-dropdown.tsx` — renamed "Experimental features" to "Beta features"
- `frontend/components/workflows/workflow-type-checkbox.tsx` — updated badge and tooltip text
- `frontend/app/page.tsx` — new title and intro copy

## Risks and Mitigations
- Low risk: all changes are display strings only, no logic or API changes
- Code identifiers (`showExperimentalFeatures`, `is_experimental`, etc.) intentionally left unchanged
- Domain-specific workflow names ("Advocacy & Tone Analysis", etc.) preserved where they are proper names