### PR TITLE
fix(mcp): persist OAuth state in Postgres (RANDZ-534)

### DIFF
--- a/alembic/versions/3b1c8a9d2f04_add_mcp_oauth_kv_table.py
+++ b/alembic/versions/3b1c8a9d2f04_add_mcp_oauth_kv_table.py
@@ -1,0 +1,41 @@
+"""add mcp_oauth_kv table for multi-pod OAuth state
+
+Revision ID: 3b1c8a9d2f04
+Revises: 8ece42fd6856
+Create Date: 2026-04-20 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3b1c8a9d2f04"
+down_revision: Union[str, None] = "8ece42fd6856"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_oauth_kv",
+        sa.Column("collection", sa.String(), nullable=False),
+        sa.Column("key", sa.String(), nullable=False),
+        sa.Column("value", JSONB(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("collection", "key"),
+    )
+    op.create_index(
+        "ix_mcp_oauth_kv_expires_at",
+        "mcp_oauth_kv",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mcp_oauth_kv_expires_at", table_name="mcp_oauth_kv")
+    op.drop_table("mcp_oauth_kv")

--- a/lib/api/mcp_auth.py
+++ b/lib/api/mcp_auth.py
@@ -1,15 +1,42 @@
 import logging
 from urllib.parse import urlparse, urlunparse
 
+from key_value.aio.protocols.key_value import AsyncKeyValue
+from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
 from lib.config.env import config
+from lib.mcp.postgres_kv_store import PostgresKeyValueStore
 
 logger = logging.getLogger(__name__)
+
+# Stable salt: rotating it would invalidate every stored OAuth registration
+# and force every client through re-auth. Versioned so we can rotate
+# deliberately if AUTH_SECRET is ever compromised.
+_MCP_STORAGE_SALT = "mcp-oauth-storage-v1"
 
 
 def _root_url(url: str) -> str:
     """Strip path from a URL, returning just scheme + netloc."""
     parsed = urlparse(url)
     return urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+
+
+def _build_client_storage() -> AsyncKeyValue:
+    """Build the shared OAuth ``client_storage`` for MCP providers.
+
+    Without this, FastMCP defaults to an in-memory store, which loses client
+    registrations and PKCE state across pods — the root cause of the
+    re-auth hang on multi-pod deployments (RANDZ-534).
+
+    Encryption key is derived from ``AUTH_SECRET`` via PBKDF2 (handled by
+    ``FernetEncryptionWrapper``) so we don't need a second secret in the
+    environment.
+    """
+    return FernetEncryptionWrapper(
+        key_value=PostgresKeyValueStore(),
+        source_material=config.AUTH_SECRET,
+        salt=_MCP_STORAGE_SALT,
+    )
 
 
 def create_mcp_auth():
@@ -27,6 +54,8 @@ def create_mcp_auth():
     # Some MCP clients (e.g. Claude) don't support path-aware discovery.
     issuer_url = _root_url(base_url)
 
+    client_storage = _build_client_storage()
+
     if config.AUTH_GOOGLE_ID and config.AUTH_GOOGLE_SECRET:
         from fastmcp.server.auth.providers.google import GoogleProvider
 
@@ -41,6 +70,7 @@ def create_mcp_auth():
                 "https://www.googleapis.com/auth/userinfo.email",
             ],
             enable_cimd=config.MCP_CIMD_ENABLED,
+            client_storage=client_storage,
         )
 
     if (
@@ -63,6 +93,7 @@ def create_mcp_auth():
             issuer_url=issuer_url,
             required_scopes=["mcp-access"],
             enable_cimd=config.MCP_CIMD_ENABLED,
+            client_storage=client_storage,
         )
 
     raise RuntimeError(

--- a/lib/mcp/postgres_kv_store.py
+++ b/lib/mcp/postgres_kv_store.py
@@ -1,0 +1,218 @@
+"""Postgres-backed AsyncKeyValue store for FastMCP OAuth state.
+
+Plugs into FastMCP OAuth providers via ``client_storage=``. Every acquire is
+one short transaction; no background tasks, no locks. Concurrent writes to
+the same ``(collection, key)`` are serialised by the composite primary key
+via ``ON CONFLICT DO UPDATE``.
+
+Rows can carry an ``expires_at``; expired rows are filtered out of reads and
+deleted lazily so stale state doesn't accumulate forever. No background
+sweeper — volume from OAuth flows is tiny.
+"""
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime
+
+from key_value.aio._utils.managed_entry import ManagedEntry
+from key_value.aio.stores.base import BaseStore
+from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlmodel import col
+
+from lib.config.database import AsyncSessionLocal
+from lib.models.mcp_oauth_kv import MCPOAuthKV
+
+logger = logging.getLogger(__name__)
+
+
+def _to_managed_entry(row: MCPOAuthKV) -> ManagedEntry:
+    return ManagedEntry(
+        value=row.value,
+        created_at=row.created_at,
+        expires_at=row.expires_at,
+    )
+
+
+class PostgresKeyValueStore(BaseStore):
+    """Shared-across-pods AsyncKeyValue store backed by the ``mcp_oauth_kv`` table.
+
+    FastMCP's ``BaseStore`` handles the protocol boilerplate (TTL evaluation,
+    batch iteration when only a single-entry hook is defined, collection
+    sanitisation). We only implement the three required managed-entry hooks
+    plus batch overrides that collapse N operations into one SQL statement.
+    """
+
+    def __init__(self) -> None:
+        # stable_api=True suppresses the "unstable store" warning; our DB
+        # schema is under our own migration control.
+        super().__init__(stable_api=True)
+
+    async def _get_managed_entry(self, *, collection: str, key: str) -> ManagedEntry | None:
+        async with AsyncSessionLocal() as session:
+            row = (
+                await session.execute(
+                    select(MCPOAuthKV).where(
+                        col(MCPOAuthKV.collection) == collection,
+                        col(MCPOAuthKV.key) == key,
+                    )
+                )
+            ).scalar_one_or_none()
+
+            if row is None:
+                return None
+
+            entry = _to_managed_entry(row)
+            if entry.is_expired:
+                await session.execute(
+                    delete(MCPOAuthKV).where(
+                        col(MCPOAuthKV.collection) == collection,
+                        col(MCPOAuthKV.key) == key,
+                    )
+                )
+                await session.commit()
+                return None
+
+            return entry
+
+    async def _get_managed_entries(
+        self, *, collection: str, keys: Sequence[str]
+    ) -> list[ManagedEntry | None]:
+        if not keys:
+            return []
+
+        async with AsyncSessionLocal() as session:
+            rows = (
+                await session.execute(
+                    select(MCPOAuthKV).where(
+                        col(MCPOAuthKV.collection) == collection,
+                        col(MCPOAuthKV.key).in_(list(keys)),
+                    )
+                )
+            ).scalars().all()
+
+            by_key = {row.key: row for row in rows}
+            expired_keys: list[str] = []
+            results: list[ManagedEntry | None] = []
+            for key in keys:
+                row = by_key.get(key)
+                if row is None:
+                    results.append(None)
+                    continue
+                entry = _to_managed_entry(row)
+                if entry.is_expired:
+                    expired_keys.append(key)
+                    results.append(None)
+                else:
+                    results.append(entry)
+
+            if expired_keys:
+                await session.execute(
+                    delete(MCPOAuthKV).where(
+                        col(MCPOAuthKV.collection) == collection,
+                        col(MCPOAuthKV.key).in_(expired_keys),
+                    )
+                )
+                await session.commit()
+
+            return results
+
+    async def _put_managed_entry(
+        self,
+        *,
+        collection: str,
+        key: str,
+        managed_entry: ManagedEntry,
+    ) -> None:
+        created_at = managed_entry.created_at or datetime.now().astimezone()
+        async with AsyncSessionLocal() as session:
+            stmt = pg_insert(MCPOAuthKV).values(
+                collection=collection,
+                key=key,
+                value=dict(managed_entry.value),
+                created_at=created_at,
+                expires_at=managed_entry.expires_at,
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["collection", "key"],
+                set_={
+                    "value": stmt.excluded.value,
+                    "created_at": stmt.excluded.created_at,
+                    "expires_at": stmt.excluded.expires_at,
+                },
+            )
+            await session.execute(stmt)
+            await session.commit()
+
+    async def _put_managed_entries(
+        self,
+        *,
+        collection: str,
+        keys: Sequence[str],
+        managed_entries: Sequence[ManagedEntry],
+        ttl: float | None,  # unused — expires_at already baked into entries
+        created_at: datetime,
+        expires_at: datetime | None,
+    ) -> None:
+        if not keys:
+            return
+
+        async with AsyncSessionLocal() as session:
+            rows = [
+                {
+                    "collection": collection,
+                    "key": key,
+                    "value": dict(entry.value),
+                    "created_at": entry.created_at or created_at,
+                    "expires_at": entry.expires_at or expires_at,
+                }
+                for key, entry in zip(keys, managed_entries, strict=True)
+            ]
+            stmt = pg_insert(MCPOAuthKV).values(rows)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["collection", "key"],
+                set_={
+                    "value": stmt.excluded.value,
+                    "created_at": stmt.excluded.created_at,
+                    "expires_at": stmt.excluded.expires_at,
+                },
+            )
+            await session.execute(stmt)
+            await session.commit()
+
+    async def _delete_managed_entry(self, *, key: str, collection: str) -> bool:
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                delete(MCPOAuthKV).where(
+                    col(MCPOAuthKV.collection) == collection,
+                    col(MCPOAuthKV.key) == key,
+                )
+            )
+            await session.commit()
+            return (result.rowcount or 0) > 0
+
+    async def _delete_managed_entries(
+        self, *, keys: Sequence[str], collection: str
+    ) -> int:
+        if not keys:
+            return 0
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                delete(MCPOAuthKV).where(
+                    col(MCPOAuthKV.collection) == collection,
+                    col(MCPOAuthKV.key).in_(list(keys)),
+                )
+            )
+            await session.commit()
+            return result.rowcount or 0
+
+    async def cull(self) -> None:
+        """Delete all rows whose ``expires_at`` has passed. Safe to call periodically."""
+        async with AsyncSessionLocal() as session:
+            await session.execute(
+                delete(MCPOAuthKV).where(
+                    col(MCPOAuthKV.expires_at).is_not(None),
+                    col(MCPOAuthKV.expires_at) <= func.now(),
+                )
+            )
+            await session.commit()

--- a/lib/models/__init__.py
+++ b/lib/models/__init__.py
@@ -3,6 +3,7 @@ from .bibliography_item import BibliographyItem
 from .feedback import Feedback
 from .file import File, FileRole
 from .issue import Issue, IssueStatus
+from .mcp_oauth_kv import MCPOAuthKV
 from .project import Project
 from .rate_limiter_bucket import RateLimiterBucket
 from .share_link import ShareLink

--- a/lib/models/mcp_oauth_kv.py
+++ b/lib/models/mcp_oauth_kv.py
@@ -1,0 +1,40 @@
+"""Shared key-value state for FastMCP OAuth providers.
+
+FastMCP's OAuth providers keep client registrations, authorization codes, and
+PKCE state in a pluggable ``AsyncKeyValue`` store. The default is in-memory,
+which breaks in multi-pod deployments: pod A stores the registration, pod B
+gets the browser callback, and the handoff hangs. Persisting the state here
+lets any pod resume any flow.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlmodel import Field, SQLModel
+
+
+class MCPOAuthKV(SQLModel, table=True):
+    __tablename__ = "mcp_oauth_kv"
+
+    collection: str = Field(
+        sa_column=Column(String, primary_key=True),
+        description="Logical namespace for the key (FastMCP uses this to separate client registrations, tokens, etc.).",
+    )
+    key: str = Field(
+        sa_column=Column(String, primary_key=True),
+        description="Entry key within the collection.",
+    )
+    value: dict = Field(
+        sa_column=Column(JSONB, nullable=False),
+        description="Opaque payload. Already encrypted by FernetEncryptionWrapper before reaching this row.",
+    )
+    created_at: datetime = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=False),
+        description="When this entry was written.",
+    )
+    expires_at: datetime | None = Field(
+        default=None,
+        sa_column=Column(DateTime(timezone=True), nullable=True, index=True),
+        description="Optional absolute expiry. Rows past this are treated as missing and cleaned up lazily on read.",
+    )

--- a/tests/integration/test_mcp_postgres_kv_store.py
+++ b/tests/integration/test_mcp_postgres_kv_store.py
@@ -1,0 +1,134 @@
+"""Integration tests for PostgresKeyValueStore.
+
+Hits the real Postgres used by the rest of the test suite (same DATABASE_URL).
+Verifies the FastMCP AsyncKeyValue contract: round-trip, TTL expiry + lazy
+cleanup, batch ops, collection isolation, and upsert-overwrites semantics.
+"""
+
+import asyncio
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlmodel import col
+
+from lib.config.database import get_async_db_session
+from lib.mcp.postgres_kv_store import PostgresKeyValueStore
+from lib.models.mcp_oauth_kv import MCPOAuthKV
+
+
+@pytest_asyncio.fixture
+async def collection():
+    """Unique collection per test so parallel runs don't interfere."""
+    name = f"test-{uuid.uuid4().hex[:12]}"
+    yield name
+
+    async with get_async_db_session() as session:
+        await session.execute(
+            delete(MCPOAuthKV).where(col(MCPOAuthKV.collection) == name)
+        )
+        await session.commit()
+
+
+@pytest_asyncio.fixture
+async def store():
+    return PostgresKeyValueStore()
+
+
+@pytest.mark.asyncio
+async def test_round_trip(store, collection):
+    await store.put("k1", {"client_id": "abc", "scopes": ["a", "b"]}, collection=collection)
+    got = await store.get("k1", collection=collection)
+    assert got == {"client_id": "abc", "scopes": ["a", "b"]}
+
+
+@pytest.mark.asyncio
+async def test_get_missing_returns_none(store, collection):
+    assert await store.get("nope", collection=collection) is None
+
+
+@pytest.mark.asyncio
+async def test_delete_returns_true_only_when_row_existed(store, collection):
+    await store.put("k", {"v": 1}, collection=collection)
+    assert await store.delete("k", collection=collection) is True
+    assert await store.delete("k", collection=collection) is False
+    assert await store.get("k", collection=collection) is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_overwrites_value_and_ttl(store, collection):
+    await store.put("k", {"v": 1}, collection=collection, ttl=60)
+    await store.put("k", {"v": 2}, collection=collection)  # no TTL this time
+    value, ttl = await store.ttl("k", collection=collection)
+    assert value == {"v": 2}
+    assert ttl is None
+
+
+@pytest.mark.asyncio
+async def test_ttl_expiry_returns_none_and_cleans_up(store, collection):
+    await store.put("k", {"v": "will-expire"}, collection=collection, ttl=0.5)
+    assert await store.get("k", collection=collection) == {"v": "will-expire"}
+
+    await asyncio.sleep(0.7)
+
+    # Expired read returns None and lazily deletes the row.
+    assert await store.get("k", collection=collection) is None
+
+    async with get_async_db_session() as session:
+        remaining = (
+            await session.execute(
+                delete(MCPOAuthKV)
+                .where(col(MCPOAuthKV.collection) == collection)
+                .where(col(MCPOAuthKV.key) == "k")
+                .returning(col(MCPOAuthKV.key))
+            )
+        ).all()
+    assert remaining == []  # already gone
+
+
+@pytest.mark.asyncio
+async def test_collection_isolation(store):
+    col_a = f"a-{uuid.uuid4().hex[:8]}"
+    col_b = f"b-{uuid.uuid4().hex[:8]}"
+    try:
+        await store.put("same-key", {"v": "A"}, collection=col_a)
+        await store.put("same-key", {"v": "B"}, collection=col_b)
+
+        assert await store.get("same-key", collection=col_a) == {"v": "A"}
+        assert await store.get("same-key", collection=col_b) == {"v": "B"}
+    finally:
+        async with get_async_db_session() as session:
+            await session.execute(
+                delete(MCPOAuthKV).where(col(MCPOAuthKV.collection).in_([col_a, col_b]))
+            )
+            await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_batch_put_get_delete(store, collection):
+    keys = ["a", "b", "c"]
+    values = [{"v": 1}, {"v": 2}, {"v": 3}]
+
+    await store.put_many(keys, values, collection=collection)
+
+    got = await store.get_many(keys + ["missing"], collection=collection)
+    assert got == [{"v": 1}, {"v": 2}, {"v": 3}, None]
+
+    deleted = await store.delete_many(["a", "c", "missing"], collection=collection)
+    assert deleted == 2
+
+    got = await store.get_many(keys, collection=collection)
+    assert got == [None, {"v": 2}, None]
+
+
+@pytest.mark.asyncio
+async def test_cull_removes_expired_rows(store, collection):
+    await store.put("fresh", {"v": 1}, collection=collection, ttl=60)
+    await store.put("stale", {"v": 2}, collection=collection, ttl=0.1)
+    await asyncio.sleep(0.3)
+
+    await store.cull()
+
+    assert await store.get("fresh", collection=collection) == {"v": 1}
+    assert await store.get("stale", collection=collection) is None

--- a/tests/unit/test_mcp_auth.py
+++ b/tests/unit/test_mcp_auth.py
@@ -1,10 +1,29 @@
 """Unit tests for MCP auth provider creation."""
 
-from unittest.mock import patch, MagicMock
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from lib.api.mcp_auth import _root_url, create_mcp_auth
+
+
+def _base_mock_config() -> MagicMock:
+    """Shared baseline: no creds, real AUTH_SECRET for storage key derivation.
+
+    Tests that need creds override them. ``AUTH_SECRET`` is a real string so
+    ``FernetEncryptionWrapper``'s PBKDF2 derivation succeeds (it rejects
+    ``MagicMock`` / empty values).
+    """
+    mock_config = MagicMock()
+    mock_config.AUTH_GOOGLE_ID = None
+    mock_config.AUTH_GOOGLE_SECRET = None
+    mock_config.AUTH_MICROSOFT_ENTRA_ID_ID = None
+    mock_config.AUTH_MICROSOFT_ENTRA_ID_SECRET = None
+    mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = None
+    mock_config.MCP_BASE_URL = "http://localhost:8000/mcp"
+    mock_config.MCP_CIMD_ENABLED = False
+    mock_config.AUTH_SECRET = "test-auth-secret-for-kdf"
+    return mock_config
 
 
 # --- _root_url ---
@@ -26,14 +45,7 @@ def test_root_url_handles_root_url():
 
 
 def test_create_mcp_auth_raises_without_credentials():
-    mock_config = MagicMock()
-    mock_config.AUTH_GOOGLE_ID = None
-    mock_config.AUTH_GOOGLE_SECRET = None
-    mock_config.AUTH_MICROSOFT_ENTRA_ID_ID = None
-    mock_config.AUTH_MICROSOFT_ENTRA_ID_SECRET = None
-    mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = None
-    mock_config.MCP_BASE_URL = "http://localhost:8000/mcp"
-    mock_config.MCP_CIMD_ENABLED = False
+    mock_config = _base_mock_config()
 
     with patch("lib.api.mcp_auth.config", mock_config):
         with pytest.raises(RuntimeError, match="MCP auth requires either Google"):
@@ -41,11 +53,10 @@ def test_create_mcp_auth_raises_without_credentials():
 
 
 def test_create_mcp_auth_with_google_credentials():
-    mock_config = MagicMock()
+    mock_config = _base_mock_config()
     mock_config.AUTH_GOOGLE_ID = "google-client-id"
     mock_config.AUTH_GOOGLE_SECRET = "google-client-secret"
     mock_config.MCP_BASE_URL = "https://api.example.com/mcp"
-    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -65,20 +76,18 @@ def test_create_mcp_auth_with_google_credentials():
             "https://www.googleapis.com/auth/userinfo.email",
         ],
         enable_cimd=False,
+        client_storage=ANY,
     )
 
 
 def test_create_mcp_auth_with_entra_id_credentials():
-    mock_config = MagicMock()
-    mock_config.AUTH_GOOGLE_ID = None
-    mock_config.AUTH_GOOGLE_SECRET = None
+    mock_config = _base_mock_config()
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ID = "entra-id"
     mock_config.AUTH_MICROSOFT_ENTRA_ID_SECRET = "entra-secret"
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = (
         "https://login.microsoftonline.com/tenant-abc/v2.0"
     )
     mock_config.MCP_BASE_URL = "https://api.example.com/mcp"
-    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -96,12 +105,13 @@ def test_create_mcp_auth_with_entra_id_credentials():
         issuer_url="https://api.example.com",
         required_scopes=["mcp-access"],
         enable_cimd=False,
+        client_storage=ANY,
     )
 
 
 def test_create_mcp_auth_google_takes_priority():
     """When both Google and Entra ID are configured, Google is selected."""
-    mock_config = MagicMock()
+    mock_config = _base_mock_config()
     mock_config.AUTH_GOOGLE_ID = "google-id"
     mock_config.AUTH_GOOGLE_SECRET = "google-secret"
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ID = "entra-id"
@@ -109,8 +119,6 @@ def test_create_mcp_auth_google_takes_priority():
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = (
         "https://login.microsoftonline.com/tenant/v2.0"
     )
-    mock_config.MCP_BASE_URL = "http://localhost:8000/mcp"
-    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -129,16 +137,13 @@ def test_create_mcp_auth_google_takes_priority():
 
 def test_create_mcp_auth_extracts_tenant_from_issuer():
     """Tenant ID is correctly parsed from the Microsoft issuer URL."""
-    mock_config = MagicMock()
-    mock_config.AUTH_GOOGLE_ID = None
-    mock_config.AUTH_GOOGLE_SECRET = None
+    mock_config = _base_mock_config()
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ID = "id"
     mock_config.AUTH_MICROSOFT_ENTRA_ID_SECRET = "secret"
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = (
         "https://login.microsoftonline.com/my-tenant-123/v2.0"
     )
     mock_config.MCP_BASE_URL = "http://localhost/mcp"
-    mock_config.MCP_CIMD_ENABLED = False
 
     with (
         patch("lib.api.mcp_auth.config", mock_config),
@@ -154,7 +159,7 @@ def test_create_mcp_auth_extracts_tenant_from_issuer():
 
 def test_create_mcp_auth_cimd_enabled_google():
     """CIMD flag is forwarded to Google provider when enabled."""
-    mock_config = MagicMock()
+    mock_config = _base_mock_config()
     mock_config.AUTH_GOOGLE_ID = "google-client-id"
     mock_config.AUTH_GOOGLE_SECRET = "google-client-secret"
     mock_config.MCP_BASE_URL = "https://api.example.com/mcp"
@@ -168,24 +173,14 @@ def test_create_mcp_auth_cimd_enabled_google():
     ):
         create_mcp_auth()
 
-    MockProvider.assert_called_once_with(
-        client_id="google-client-id",
-        client_secret="google-client-secret",
-        base_url="https://api.example.com/mcp",
-        issuer_url="https://api.example.com",
-        required_scopes=[
-            "openid",
-            "https://www.googleapis.com/auth/userinfo.email",
-        ],
-        enable_cimd=True,
-    )
+    call_kwargs = MockProvider.call_args.kwargs
+    assert call_kwargs["enable_cimd"] is True
+    assert "client_storage" in call_kwargs
 
 
 def test_create_mcp_auth_cimd_enabled_entra_id():
     """CIMD flag is forwarded to Azure provider when enabled."""
-    mock_config = MagicMock()
-    mock_config.AUTH_GOOGLE_ID = None
-    mock_config.AUTH_GOOGLE_SECRET = None
+    mock_config = _base_mock_config()
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ID = "entra-id"
     mock_config.AUTH_MICROSOFT_ENTRA_ID_SECRET = "entra-secret"
     mock_config.AUTH_MICROSOFT_ENTRA_ID_ISSUER = (
@@ -202,12 +197,22 @@ def test_create_mcp_auth_cimd_enabled_entra_id():
     ):
         create_mcp_auth()
 
-    MockProvider.assert_called_once_with(
-        client_id="entra-id",
-        client_secret="entra-secret",
-        tenant_id="tenant-abc",
-        base_url="https://api.example.com/mcp",
-        issuer_url="https://api.example.com",
-        required_scopes=["mcp-access"],
-        enable_cimd=True,
-    )
+    call_kwargs = MockProvider.call_args.kwargs
+    assert call_kwargs["enable_cimd"] is True
+    assert "client_storage" in call_kwargs
+
+
+def test_client_storage_wraps_postgres_in_fernet_derived_from_auth_secret():
+    """Storage is a FernetEncryptionWrapper over Postgres, keyed off AUTH_SECRET."""
+    from key_value.aio.wrappers.encryption import FernetEncryptionWrapper
+
+    from lib.api.mcp_auth import _build_client_storage
+    from lib.mcp.postgres_kv_store import PostgresKeyValueStore
+
+    mock_config = _base_mock_config()
+
+    with patch("lib.api.mcp_auth.config", mock_config):
+        storage = _build_client_storage()
+
+    assert isinstance(storage, FernetEncryptionWrapper)
+    assert isinstance(storage.key_value, PostgresKeyValueStore)


### PR DESCRIPTION
## Summary

- Fixes [RANDZ-534](https://linear.app/ae-studio/issue/RANDZ-534): MCP re-auth hangs on repeat use in multi-pod deployments.
- FastMCP's OAuth providers default to an in-memory `client_storage`; in multi-pod, the pod that receives the browser redirect has no record of the client registration stored on another pod, so the flow hangs.
- Wires `GoogleProvider` and `AzureProvider` to a shared Postgres-backed `client_storage` wrapped in Fernet encryption, keyed off the existing `AUTH_SECRET`.

## Motivation

`stateless_http=True` was already set, correctly, for multi-pod serving — but the OAuth provider's own state (DCR client registrations, PKCE, auth codes, short-lived tokens) silently fell back to per-process memory. After the first successful auth, re-auth routed to any other pod would find no registration and hang. Wiping all registrations worked once because the fresh registration completed before any cross-pod lookup was needed, and the cycle repeated.

## What's Changed

### Backend

- **`lib/models/mcp_oauth_kv.py`** (new) — SQLModel `mcp_oauth_kv` table with `(collection, key)` composite PK, JSONB `value`, and an optional `expires_at` for TTL.
- **`lib/mcp/postgres_kv_store.py`** (new) — `PostgresKeyValueStore` implementing FastMCP's `AsyncKeyValue` protocol on top of the existing async SQLAlchemy session. Batched get/put/delete via single statements (`ON CONFLICT DO UPDATE`, `col(...).in_(...)`), lazy expiry on read, plus a `cull()` helper.
- **`lib/api/mcp_auth.py`** — builds the shared `client_storage` once and passes it to both `GoogleProvider` and `AzureProvider`. Encryption key is derived from `AUTH_SECRET` via PBKDF2 using a versioned salt (`mcp-oauth-storage-v1`), so no new env var is required.
- **`alembic/versions/3b1c8a9d2f04_add_mcp_oauth_kv_table.py`** (new) — migration for `mcp_oauth_kv`. Run `uv run alembic upgrade head` after merge.
- **`lib/models/__init__.py`** — register the new model.

### Tests

- **`tests/unit/test_mcp_auth.py`** — updated provider kwargs assertions to include `client_storage`; added a test that `_build_client_storage()` returns a `FernetEncryptionWrapper` over `PostgresKeyValueStore`.
- **`tests/integration/test_mcp_postgres_kv_store.py`** (new) — round-trip, missing-key, delete semantics, upsert overwrites value+TTL, TTL expiry + lazy cleanup, collection isolation, batch ops, `cull()`.

### Frontend

- None.

## Risks and Mitigations

- **Existing in-memory registrations are lost on deploy.** Clients will re-register once — same observable behavior as the current recovery workaround described in the ticket. No data loss beyond that.
- **`AUTH_SECRET` rotation would invalidate every stored registration.** The salt is versioned (`…-v1`) so we can roll deliberately if `AUTH_SECRET` is ever compromised without affecting unrelated stores. Normal operation does not rotate it.
- **Encrypted-at-rest.** Fernet wrapper ensures OAuth client secrets and tokens aren't stored in plaintext, as required by FastMCP's production guidance.
- **Migration required before merge to prod.** The app will start without the table — any OAuth flow will fail fast with a missing-table error — so this cannot silently regress. Run `uv run alembic upgrade head` as part of the deploy.
- **Integration tests blocked locally on migration.** Unit tests (12) pass. Integration tests in `tests/integration/test_mcp_postgres_kv_store.py` are ready to run once the migration is applied.