### PR TITLE
fix(doc-explorer): replace skeleton cards with loading spinner in sidebar header

### DIFF
--- a/frontend/components/results/components/document-explorer-sidebar.tsx
+++ b/frontend/components/results/components/document-explorer-sidebar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { SkeletonList } from '@/components/ui/skeleton-list';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Issue, ProjectDetailed } from '@/lib/generated-api';
 import { getIssueCount, hasActiveFilters, useDocumentExplorerStore } from '@/lib/stores/document-explorer-store';
-import { X } from 'lucide-react';
+import { Loader2, X } from 'lucide-react';
 import { Ref, useImperativeHandle, useRef } from 'react';
 import { DocumentExplorerSidebarFilter } from './document-explorer-sidebar-filter';
 import { DocumentIssuesList } from './document-issues-list';
@@ -60,7 +60,20 @@ export function DocumentExplorerSidebar({
   return (
     <div className="col-span-5 bg-muted/50 rounded-lg rounded-l-none text-sm flex flex-col overflow-hidden">
       <div className="flex items-center justify-between gap-2 flex-wrap px-4 pt-4 pb-2 flex-shrink-0">
-        <span className="text-xs text-muted-foreground">
+        <span className="text-xs text-muted-foreground inline-flex items-center gap-1.5">
+          {isAnyProcessing && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  className="inline-flex size-3.5 items-center justify-center"
+                  aria-label="Some results are still loading"
+                >
+                  <Loader2 className="size-3.5 animate-spin" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Some results are still loading, see Assessments tab for more details</TooltipContent>
+            </Tooltip>
+          )}
           {visibleIssueCount > 0 &&
             (filteredIssueCount === visibleIssueCount
               ? `${visibleIssueCount} issues`
@@ -100,8 +113,6 @@ export function DocumentExplorerSidebar({
             <p>You can still view detailed assessment for each chunk by selecting a chunk from the document.</p>
           </div>
         )}
-
-        {isAnyProcessing && <SkeletonList count={3} />}
 
         {visibleIssues.length > 0 &&
           filteredIssues.length === 0 &&


### PR DESCRIPTION
## Summary

Replaces the 3 empty skeleton cards in the doc explorer's right sidebar with a small spinner + tooltip next to the issue count, so users aren't confused by blank cards while analyses are still running.

Closes [RANDZ-536](https://linear.app/ae-studio/issue/RANDZ-536/replace-empty-skeleton-cards-with-some-results-still-loading-message).

## Motivation

While references are loading, the sidebar previously rendered 3 empty `SkeletonList` cards. Users read these as real-but-blank results and were unsure whether analysis had finished. The ticket asks for a single, explicit loading indicator instead.

## What's Changed

### Frontend

- `frontend/components/results/components/document-explorer-sidebar.tsx`
  - Removed `SkeletonList count={3}` render and its import.
  - Added a small `Loader2` spinner to the left of the "{x} issues" / "Finding issues..." label in the sidebar header, gated on the existing `isAnyProcessing` flag.
  - Wrapped the spinning icon in a static `span` trigger so the tooltip anchors to a stable bounding box (the rotating SVG caused tooltip jitter).
  - Tooltip copy: "Some results are still loading, see Assessments tab for more details".

## Risks and Mitigations

- Behavior change is purely cosmetic and uses the same `isAnyProcessing` signal that previously gated the skeletons, so visibility semantics are unchanged.
- Verified type-check passes; visual behavior should be manually spot-checked on a project with in-flight workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)