### PR TITLE
fix(reference-downloader): preserve prior fetch results on subset runs

### DIFF
--- a/frontend/components/results/tabs/reference-review/queries.ts
+++ b/frontend/components/results/tabs/reference-review/queries.ts
@@ -53,12 +53,10 @@ export function useReferenceReviewReferences(projectDetail: ProjectDetailed | un
         (ref) => ref.reference_id === item.id,
       );
 
-      // In case the reference was fetched but the matching file no longer exists, we don't want to show the fetched result.
-      // Also hide fetch results when the file was manually uploaded by the user.
-      const shouldShowFetchedResult =
-        (!item.source || item.source === MatchSource.AutoFetched) &&
-        fetchedReference &&
-        (fetchedReference.result?.file_id ? !!matchedFile : true);
+      // Hide fetch results when the file was manually uploaded by the user — the fetch outcome is
+      // irrelevant once a user-uploaded source is in place. Otherwise always surface the fetch
+      // result (including "Not Found" / errored outcomes) so users can see why no source is attached.
+      const shouldShowFetchedResult = !!fetchedReference && item.source !== MatchSource.ManualUpload;
 
       return {
         id: item.id,

--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -22,19 +22,17 @@ from lib.models.project import AccessLevel
 from lib.models.user import User
 from lib.services.docx_workflow_service import DocxManipulatorType, get_or_generate_docx
 from lib.services.file_finalization import finalize_file
-from lib.services.files import delete_project_files, get_files_by_project_id
+from lib.services.files import get_files_by_project_id
 from lib.services.projects import create_project as create_project_record
 from lib.services.projects import (
     create_new_revision,
+    delete_project_file_with_cleanup,
     get_project_access,
     get_project_detailed_from_project,
     get_user_projects,
 )
 from lib.services.files import get_project_files_list_items
-from lib.services.references import (
-    get_file_reference_matches,
-    remove_file_from_references,
-)
+from lib.services.references import get_file_reference_matches
 from lib.services.users import get_or_create_user_by_email
 from lib.services.workflow_types import get_workflow_types_for_user
 from lib.workflows.models import SeverityEnum, WorkflowRunType
@@ -443,13 +441,11 @@ async def remove_reference_file(
         project_id, user=user, required_level=AccessLevel.WRITE
     )
 
-    deleted_count = await delete_project_files(project.id, target_file_ids=[file_id])
-    if deleted_count == 0:
-        raise ValueError(f"File {file_id!r} not found in project {project_id!r}")
-
-    removed_reference_ids = await remove_file_from_references(
+    deleted_count, removed_reference_ids = await delete_project_file_with_cleanup(
         project_id, file_id, revision=project.current_revision
     )
+    if deleted_count == 0:
+        raise ValueError(f"File {file_id!r} not found in project {project_id!r}")
 
     return json.dumps(
         {

--- a/lib/api/routers/projects.py
+++ b/lib/api/routers/projects.py
@@ -12,7 +12,6 @@ from lib.models.file import File, FileListItem, FileRole
 from lib.models.project import AccessLevel, Project
 from lib.models.user import User
 from lib.services.docx_workflow_service import DocxManipulatorType, get_or_generate_docx
-from lib.services.files import delete_project_files
 from lib.services.project_zip import create_project_files_zip
 from lib.services.projects import (
     ProjectDetailed,
@@ -21,13 +20,13 @@ from lib.services.projects import (
     create_project,
     create_new_revision,
     delete_project,
+    delete_project_file_with_cleanup,
     get_project_access,
     get_project_detailed_from_project,
     get_project_files,
     get_user_projects,
     update_user_project,
 )
-from lib.services.references import remove_file_from_references
 from lib.services.workflow_progress import get_project_workflow_progress
 from lib.services.workflow_runs import (
     WorkflowRunDetail,
@@ -208,14 +207,12 @@ async def delete_project_file_endpoint(
         project_id, user=current_user, required_level=AccessLevel.WRITE
     )
 
-    # Delete the file from the project
-    deleted_count = await delete_project_files(project.id, target_file_ids=[file_id])
+    deleted_count, _ = await delete_project_file_with_cleanup(
+        project_id, file_id, revision=project.current_revision
+    )
 
     if deleted_count == 0:
         raise HTTPException(status_code=404, detail="File not found in project")
-
-    # Update workflow state to remove file_id from references
-    await remove_file_from_references(project_id, file_id, revision=project.current_revision)
 
     return {"message": "File deleted successfully", "file_id": file_id}
 

--- a/lib/services/projects.py
+++ b/lib/services/projects.py
@@ -18,6 +18,10 @@ from lib.models.user import User, UserRole
 from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
 from lib.services.files import delete_project_files, get_project_files_list_items
 from lib.services.issue_persistence import get_project_issues
+from lib.services.references import (
+    remove_fetch_result_for_file,
+    remove_file_from_references,
+)
 from lib.services.share_links import get_resource_by_token, is_project_shared
 from lib.services.workflow_runs import WorkflowRunDetail, cancel_workflow_run, get_project_workflow_runs
 from lib.workflows.checkpointer import get_checkpointer
@@ -323,6 +327,33 @@ async def get_project_files(project_id: str) -> List[File]:
         )
         result = await session.execute(stmt)
         return list(result.scalars().all())
+
+
+async def delete_project_file_with_cleanup(
+    project_id: str, file_id: str, revision: int
+) -> tuple[int, List[str]]:
+    """
+    Delete a file from a project and clean up all references to it.
+
+    Performs three steps:
+    1. Delete the file record and its disk content (unless shared with another project)
+    2. Unlink the file from any ReferenceFileMatching matches
+    3. Clear any ReferenceDownloader fetch result that pointed at this file
+
+    Returns:
+        (deleted_count, removed_reference_ids): number of files actually deleted and the
+        list of reference IDs that were unlinked from the file.
+    """
+    deleted_count = await delete_project_files(project_id, target_file_ids=[file_id])
+    if deleted_count == 0:
+        return 0, []
+
+    removed_reference_ids = await remove_file_from_references(
+        project_id, file_id, revision=revision
+    )
+    await remove_fetch_result_for_file(project_id, file_id, revision=revision)
+
+    return deleted_count, removed_reference_ids
 
 
 async def update_user_project(

--- a/lib/services/references.py
+++ b/lib/services/references.py
@@ -13,6 +13,9 @@ from lib.services.workflow_runs import (
 )
 from lib.workflows.checkpointer import get_checkpointer
 from lib.workflows.models import WorkflowRunType
+from langgraph.types import Overwrite
+
+from lib.workflows.reference_downloader.state import ReferenceDownloaderState
 from lib.workflows.reference_extraction.state import ReferenceExtractionState
 from lib.workflows.reference_file_matching.state import (
     MatchSource,
@@ -234,6 +237,67 @@ async def remove_file_from_references(project_id: str, file_id: str, revision: i
             f"Removed {len(removed_reference_ids)} matches with file_id {file_id}"
         )
         return removed_reference_ids
+
+
+async def _get_downloader_workflow_state(
+    project_id: str,
+    revision: int,
+) -> Tuple[Optional[WorkflowRun], Optional[ReferenceDownloaderState]]:
+    """Get the ReferenceDownloader workflow run and state for a project."""
+    run = await get_project_workflow_run_by_type(
+        project_id, WorkflowRunType.REFERENCE_DOWNLOADER, revision=revision
+    )
+    if run is None:
+        return None, None
+
+    state = await get_workflow_run_state_by_thread_id(
+        run.langgraph_thread_id, WorkflowRunType.REFERENCE_DOWNLOADER
+    )
+    return run, state
+
+
+async def remove_fetch_result_for_file(
+    project_id: str, file_id: str, revision: int
+) -> int:
+    """
+    Remove any ReferenceDownloader fetch results whose downloaded file matches file_id.
+
+    Called when a user deletes a file so the stale fetch result (e.g. "Source Found"
+    pointing at a file that no longer exists) does not linger in workflow state.
+
+    Returns the number of fetch_references entries that were removed.
+    """
+    async with _project_lock(project_id):
+        run, state = await _get_downloader_workflow_state(project_id, revision)
+        if run is None or state is None or not state.fetched_references:
+            return 0
+
+        filtered = [
+            item
+            for item in state.fetched_references
+            if not (item.result and item.result.file_id == file_id)
+        ]
+
+        removed_count = len(state.fetched_references) - len(filtered)
+        if removed_count == 0:
+            return 0
+
+        # Overwrite is required to bypass the merge_fetch_results reducer, which otherwise
+        # upserts-only and would keep the entries we are trying to delete.
+        async with get_checkpointer() as checkpointer:
+            graph = create_graph(WorkflowRunType.REFERENCE_DOWNLOADER)
+            app = graph.compile(checkpointer=checkpointer)
+
+            await app.aupdate_state(
+                {"configurable": {"thread_id": run.langgraph_thread_id}},
+                {"fetched_references": Overwrite(filtered)},
+                as_node="cleanup_failed_resources",
+            )
+
+        logger.info(
+            f"Removed {removed_count} fetch result(s) for file {file_id} in project {project_id}"
+        )
+        return removed_count
 
 
 async def add_file_to_reference(

--- a/lib/workflows/reference_downloader/nodes/fetch_references.py
+++ b/lib/workflows/reference_downloader/nodes/fetch_references.py
@@ -2,7 +2,7 @@ import logging
 from typing import List
 
 from langgraph.runtime import Runtime
-from langgraph.types import Overwrite, Send
+from langgraph.types import Send
 
 from lib.models.file import FileRole
 from lib.services.files import (
@@ -46,8 +46,9 @@ async def initialize_references(
         for ref in references
     ]
 
-    # Overwrite is needed in case references changed since last run
-    return {"fetched_references": Overwrite(pending_results)}
+    # Rely on the merge_fetch_results reducer so prior results for references NOT in this run
+    # (e.g. when fetching a single reference) are preserved.
+    return {"fetched_references": pending_results}
 
 
 @register_node("Distribute references")

--- a/tests/unit/services/test_delete_project_file_with_cleanup.py
+++ b/tests/unit/services/test_delete_project_file_with_cleanup.py
@@ -1,0 +1,107 @@
+"""Unit tests for delete_project_file_with_cleanup service function."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lib.services.projects import delete_project_file_with_cleanup
+
+
+@pytest.mark.asyncio
+async def test_happy_path_runs_all_three_steps_and_returns_tuple():
+    project_id = str(uuid.uuid4())
+    file_id = str(uuid.uuid4())
+    ref_id = str(uuid.uuid4())
+    revision = 3
+
+    delete_mock = AsyncMock(return_value=1)
+    unlink_mock = AsyncMock(return_value=[ref_id])
+    clear_fetch_mock = AsyncMock(return_value=1)
+
+    with (
+        patch("lib.services.projects.delete_project_files", delete_mock),
+        patch("lib.services.projects.remove_file_from_references", unlink_mock),
+        patch("lib.services.projects.remove_fetch_result_for_file", clear_fetch_mock),
+    ):
+        deleted_count, removed_reference_ids = await delete_project_file_with_cleanup(
+            project_id, file_id, revision=revision
+        )
+
+    assert deleted_count == 1
+    assert removed_reference_ids == [ref_id]
+    delete_mock.assert_awaited_once_with(project_id, target_file_ids=[file_id])
+    unlink_mock.assert_awaited_once_with(project_id, file_id, revision=revision)
+    clear_fetch_mock.assert_awaited_once_with(project_id, file_id, revision=revision)
+
+
+@pytest.mark.asyncio
+async def test_file_not_found_short_circuits_cleanup_steps():
+    """If the file wasn't actually deleted, we must not run reference cleanup —
+    otherwise we'd unlink references / clear fetch results that still validly point at a file."""
+    project_id = str(uuid.uuid4())
+    file_id = str(uuid.uuid4())
+
+    delete_mock = AsyncMock(return_value=0)
+    unlink_mock = AsyncMock()
+    clear_fetch_mock = AsyncMock()
+
+    with (
+        patch("lib.services.projects.delete_project_files", delete_mock),
+        patch("lib.services.projects.remove_file_from_references", unlink_mock),
+        patch("lib.services.projects.remove_fetch_result_for_file", clear_fetch_mock),
+    ):
+        deleted_count, removed_reference_ids = await delete_project_file_with_cleanup(
+            project_id, file_id, revision=1
+        )
+
+    assert deleted_count == 0
+    assert removed_reference_ids == []
+    unlink_mock.assert_not_awaited()
+    clear_fetch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_matches_still_clears_fetch_results():
+    """A reference may have a fetch result (e.g. SourceFound pointing at file_id)
+    even when no ReferenceFileMatching entry exists yet. The fetch-result cleanup
+    must run regardless of whether the unlink step found anything."""
+    project_id = str(uuid.uuid4())
+    file_id = str(uuid.uuid4())
+
+    delete_mock = AsyncMock(return_value=1)
+    unlink_mock = AsyncMock(return_value=[])
+    clear_fetch_mock = AsyncMock(return_value=1)
+
+    with (
+        patch("lib.services.projects.delete_project_files", delete_mock),
+        patch("lib.services.projects.remove_file_from_references", unlink_mock),
+        patch("lib.services.projects.remove_fetch_result_for_file", clear_fetch_mock),
+    ):
+        deleted_count, removed_reference_ids = await delete_project_file_with_cleanup(
+            project_id, file_id, revision=1
+        )
+
+    assert deleted_count == 1
+    assert removed_reference_ids == []
+    clear_fetch_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_revision_is_forwarded_to_cleanup_calls():
+    project_id = str(uuid.uuid4())
+    file_id = str(uuid.uuid4())
+    revision = 42
+
+    unlink_mock = AsyncMock(return_value=[])
+    clear_fetch_mock = AsyncMock(return_value=0)
+
+    with (
+        patch("lib.services.projects.delete_project_files", AsyncMock(return_value=1)),
+        patch("lib.services.projects.remove_file_from_references", unlink_mock),
+        patch("lib.services.projects.remove_fetch_result_for_file", clear_fetch_mock),
+    ):
+        await delete_project_file_with_cleanup(project_id, file_id, revision=revision)
+
+    assert unlink_mock.await_args.kwargs["revision"] == revision
+    assert clear_fetch_mock.await_args.kwargs["revision"] == revision

--- a/tests/unit/services/test_delete_project_files.py
+++ b/tests/unit/services/test_delete_project_files.py
@@ -1,0 +1,170 @@
+"""Unit tests for delete_project_files service function."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.services.files import delete_project_files
+
+
+def _make_file(
+    file_path: str, original_file_path: str | None = None, file_id: uuid.UUID | None = None
+) -> MagicMock:
+    file = MagicMock()
+    file.id = file_id or uuid.uuid4()
+    file.file_path = file_path
+    file.original_file_path = original_file_path
+    return file
+
+
+class _FakeSession:
+    def __init__(self, files: list):
+        self._files = files
+        self.deleted: list = []
+        self.committed = False
+
+    async def execute(self, _stmt):
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all.return_value = self._files
+        result.scalars.return_value = scalars
+        return result
+
+    async def delete(self, obj):
+        self.deleted.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _patch_session(session: _FakeSession):
+    return patch("lib.services.files.get_async_db_session", return_value=session)
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_project_has_no_files():
+    session = _FakeSession(files=[])
+
+    with _patch_session(session):
+        count = await delete_project_files(uuid.uuid4())
+
+    assert count == 0
+    assert session.deleted == []
+    assert session.committed
+
+
+@pytest.mark.asyncio
+async def test_deletes_all_files_when_no_target_ids():
+    f1 = _make_file("/tmp/a.pdf")
+    f2 = _make_file("/tmp/b.pdf")
+    session = _FakeSession(files=[f1, f2])
+
+    with (
+        _patch_session(session),
+        patch(
+            "lib.services.files._is_path_shared", new=AsyncMock(return_value=False)
+        ),
+        patch("lib.services.files._delete_file_from_disk") as disk_mock,
+    ):
+        count = await delete_project_files(uuid.uuid4())
+
+    assert count == 2
+    assert session.deleted == [f1, f2]
+    assert disk_mock.call_args_list[0].args[0] == "/tmp/a.pdf"
+    assert disk_mock.call_args_list[1].args[0] == "/tmp/b.pdf"
+
+
+@pytest.mark.asyncio
+async def test_only_deletes_files_matching_target_ids():
+    keep = _make_file("/tmp/keep.pdf")
+    drop = _make_file("/tmp/drop.pdf")
+    session = _FakeSession(files=[keep, drop])
+
+    with (
+        _patch_session(session),
+        patch(
+            "lib.services.files._is_path_shared", new=AsyncMock(return_value=False)
+        ),
+        patch("lib.services.files._delete_file_from_disk") as disk_mock,
+    ):
+        count = await delete_project_files(
+            uuid.uuid4(), target_file_ids=[str(drop.id)]
+        )
+
+    assert count == 1
+    assert session.deleted == [drop]
+    disk_mock.assert_called_once_with("/tmp/drop.pdf")
+
+
+@pytest.mark.asyncio
+async def test_skips_disk_delete_for_shared_paths():
+    shared = _make_file("/tmp/shared.pdf")
+    session = _FakeSession(files=[shared])
+
+    with (
+        _patch_session(session),
+        patch(
+            "lib.services.files._is_path_shared", new=AsyncMock(return_value=True)
+        ),
+        patch("lib.services.files._delete_file_from_disk") as disk_mock,
+    ):
+        count = await delete_project_files(uuid.uuid4())
+
+    assert count == 1
+    assert session.deleted == [shared]
+    disk_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deletes_both_file_path_and_original_file_path():
+    f = _make_file("/tmp/converted.md", original_file_path="/tmp/original.docx")
+    session = _FakeSession(files=[f])
+
+    with (
+        _patch_session(session),
+        patch(
+            "lib.services.files._is_path_shared", new=AsyncMock(return_value=False)
+        ),
+        patch("lib.services.files._delete_file_from_disk") as disk_mock,
+    ):
+        count = await delete_project_files(uuid.uuid4())
+
+    assert count == 1
+    paths = [c.args[0] for c in disk_mock.call_args_list]
+    assert paths == ["/tmp/converted.md", "/tmp/original.docx"]
+
+
+@pytest.mark.asyncio
+async def test_handles_missing_original_file_path():
+    f = _make_file("/tmp/a.pdf", original_file_path=None)
+    session = _FakeSession(files=[f])
+
+    with (
+        _patch_session(session),
+        patch(
+            "lib.services.files._is_path_shared", new=AsyncMock(return_value=False)
+        ),
+        patch("lib.services.files._delete_file_from_disk") as disk_mock,
+    ):
+        count = await delete_project_files(uuid.uuid4())
+
+    assert count == 1
+    disk_mock.assert_called_once_with("/tmp/a.pdf")
+
+
+@pytest.mark.asyncio
+async def test_accepts_project_id_as_string():
+    session = _FakeSession(files=[])
+    project_id = str(uuid.uuid4())
+
+    with _patch_session(session):
+        count = await delete_project_files(project_id)
+
+    assert count == 0

--- a/tests/unit/services/test_remove_fetch_result_for_file.py
+++ b/tests/unit/services/test_remove_fetch_result_for_file.py
@@ -1,0 +1,262 @@
+"""Unit tests for remove_fetch_result_for_file service function."""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langgraph.types import Overwrite
+
+from lib.services.references import remove_fetch_result_for_file
+from lib.workflows.reference_downloader.state import (
+    ReferenceDownloaderState,
+    ReferenceDownloaderWorkflowConfig,
+    ReferenceFetchResult,
+    ReferenceFetchStatus,
+)
+from lib.workflows.reference_downloader.agents.reference_fetcher import (
+    ReferenceFetchConclusion,
+    ReferenceFetchItem,
+)
+from lib.workflows.models import WorkflowRunType
+
+
+def _make_fetch_item(
+    file_id: str | None, conclusion: ReferenceFetchConclusion
+) -> ReferenceFetchItem:
+    return ReferenceFetchItem(
+        reference_details="ref",
+        reasoning="",
+        source_url=None,
+        file_id=file_id,
+        final_conclusion=conclusion,
+    )
+
+
+def _make_state(results: list[ReferenceFetchResult]) -> ReferenceDownloaderState:
+    return ReferenceDownloaderState(
+        type=WorkflowRunType.REFERENCE_DOWNLOADER,
+        config=ReferenceDownloaderWorkflowConfig(
+            type=WorkflowRunType.REFERENCE_DOWNLOADER,
+            project_id=str(uuid.uuid4()),
+            references=[],
+        ),
+        fetched_references=results,
+    )
+
+
+def _make_run() -> MagicMock:
+    run = MagicMock()
+    run.langgraph_thread_id = str(uuid.uuid4())
+    return run
+
+
+@asynccontextmanager
+async def _fake_checkpointer():
+    yield MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_no_downloader_run_exists():
+    with patch(
+        "lib.services.references._get_downloader_workflow_state",
+        new=AsyncMock(return_value=(None, None)),
+    ):
+        removed = await remove_fetch_result_for_file(
+            str(uuid.uuid4()), str(uuid.uuid4()), revision=1
+        )
+
+    assert removed == 0
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_state_has_no_fetched_references():
+    state = _make_state([])
+
+    with patch(
+        "lib.services.references._get_downloader_workflow_state",
+        new=AsyncMock(return_value=(_make_run(), state)),
+    ):
+        removed = await remove_fetch_result_for_file(
+            str(uuid.uuid4()), str(uuid.uuid4()), revision=1
+        )
+
+    assert removed == 0
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_no_result_matches_file_id():
+    other_file_id = str(uuid.uuid4())
+    state = _make_state(
+        [
+            ReferenceFetchResult(
+                reference_id="r1",
+                input_reference="ref 1",
+                status=ReferenceFetchStatus.COMPLETED,
+                result=_make_fetch_item(
+                    other_file_id, ReferenceFetchConclusion.SOURCE_FOUND
+                ),
+            )
+        ]
+    )
+
+    aupdate_mock = AsyncMock()
+    graph_app = MagicMock()
+    graph_app.aupdate_state = aupdate_mock
+    graph = MagicMock()
+    graph.compile.return_value = graph_app
+
+    with (
+        patch(
+            "lib.services.references._get_downloader_workflow_state",
+            new=AsyncMock(return_value=(_make_run(), state)),
+        ),
+        patch("lib.services.references.get_checkpointer", _fake_checkpointer),
+        patch("lib.services.references.create_graph", return_value=graph),
+    ):
+        removed = await remove_fetch_result_for_file(
+            str(uuid.uuid4()), str(uuid.uuid4()), revision=1
+        )
+
+    assert removed == 0
+    aupdate_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_removes_matching_entry_via_overwrite():
+    target_file_id = str(uuid.uuid4())
+    other_file_id = str(uuid.uuid4())
+    keep = ReferenceFetchResult(
+        reference_id="r_keep",
+        input_reference="keep",
+        status=ReferenceFetchStatus.COMPLETED,
+        result=_make_fetch_item(other_file_id, ReferenceFetchConclusion.SOURCE_FOUND),
+    )
+    drop = ReferenceFetchResult(
+        reference_id="r_drop",
+        input_reference="drop",
+        status=ReferenceFetchStatus.COMPLETED,
+        result=_make_fetch_item(target_file_id, ReferenceFetchConclusion.SOURCE_FOUND),
+    )
+    state = _make_state([keep, drop])
+    run = _make_run()
+
+    aupdate_mock = AsyncMock()
+    graph_app = MagicMock()
+    graph_app.aupdate_state = aupdate_mock
+    graph = MagicMock()
+    graph.compile.return_value = graph_app
+
+    with (
+        patch(
+            "lib.services.references._get_downloader_workflow_state",
+            new=AsyncMock(return_value=(run, state)),
+        ),
+        patch("lib.services.references.get_checkpointer", _fake_checkpointer),
+        patch(
+            "lib.services.references.create_graph", return_value=graph
+        ) as create_graph_mock,
+    ):
+        removed = await remove_fetch_result_for_file(
+            str(uuid.uuid4()), target_file_id, revision=1
+        )
+
+    assert removed == 1
+    create_graph_mock.assert_called_once_with(WorkflowRunType.REFERENCE_DOWNLOADER)
+    aupdate_mock.assert_awaited_once()
+    call_args = aupdate_mock.await_args
+    assert call_args.args[0] == {"configurable": {"thread_id": run.langgraph_thread_id}}
+    state_update = call_args.args[1]
+    overwrite_value = state_update["fetched_references"]
+    # The reducer must be bypassed — Overwrite is the only way to remove entries.
+    assert isinstance(overwrite_value, Overwrite)
+    assert list(overwrite_value.value) == [keep]
+    assert call_args.kwargs["as_node"] == "cleanup_failed_resources"
+
+
+@pytest.mark.asyncio
+async def test_removes_multiple_entries_pointing_at_same_file():
+    target_file_id = str(uuid.uuid4())
+    dup_a = ReferenceFetchResult(
+        reference_id="ra",
+        input_reference="a",
+        status=ReferenceFetchStatus.COMPLETED,
+        result=_make_fetch_item(target_file_id, ReferenceFetchConclusion.SOURCE_FOUND),
+    )
+    dup_b = ReferenceFetchResult(
+        reference_id="rb",
+        input_reference="b",
+        status=ReferenceFetchStatus.COMPLETED,
+        result=_make_fetch_item(target_file_id, ReferenceFetchConclusion.SOURCE_FOUND),
+    )
+    state = _make_state([dup_a, dup_b])
+
+    aupdate_mock = AsyncMock()
+    graph_app = MagicMock()
+    graph_app.aupdate_state = aupdate_mock
+    graph = MagicMock()
+    graph.compile.return_value = graph_app
+
+    with (
+        patch(
+            "lib.services.references._get_downloader_workflow_state",
+            new=AsyncMock(return_value=(_make_run(), state)),
+        ),
+        patch("lib.services.references.get_checkpointer", _fake_checkpointer),
+        patch("lib.services.references.create_graph", return_value=graph),
+    ):
+        removed = await remove_fetch_result_for_file(
+            str(uuid.uuid4()), target_file_id, revision=1
+        )
+
+    assert removed == 2
+    overwrite_value = aupdate_mock.await_args.args[1]["fetched_references"]
+    assert list(overwrite_value.value) == []
+
+
+@pytest.mark.asyncio
+async def test_preserves_entries_without_result():
+    """PENDING / ERROR entries have `result=None` and must never be filtered out."""
+    target_file_id = str(uuid.uuid4())
+    pending = ReferenceFetchResult(
+        reference_id="pending",
+        input_reference="pending",
+        status=ReferenceFetchStatus.PENDING,
+        result=None,
+    )
+    errored = ReferenceFetchResult(
+        reference_id="errored",
+        input_reference="errored",
+        status=ReferenceFetchStatus.ERROR,
+        result=None,
+        error="boom",
+    )
+    drop = ReferenceFetchResult(
+        reference_id="drop",
+        input_reference="drop",
+        status=ReferenceFetchStatus.COMPLETED,
+        result=_make_fetch_item(target_file_id, ReferenceFetchConclusion.SOURCE_FOUND),
+    )
+    state = _make_state([pending, errored, drop])
+
+    aupdate_mock = AsyncMock()
+    graph_app = MagicMock()
+    graph_app.aupdate_state = aupdate_mock
+    graph = MagicMock()
+    graph.compile.return_value = graph_app
+
+    with (
+        patch(
+            "lib.services.references._get_downloader_workflow_state",
+            new=AsyncMock(return_value=(_make_run(), state)),
+        ),
+        patch("lib.services.references.get_checkpointer", _fake_checkpointer),
+        patch("lib.services.references.create_graph", return_value=graph),
+    ):
+        removed = await remove_fetch_result_for_file(
+            str(uuid.uuid4()), target_file_id, revision=1
+        )
+
+    assert removed == 1
+    overwrite_value = aupdate_mock.await_args.args[1]["fetched_references"]
+    assert list(overwrite_value.value) == [pending, errored]

--- a/tests/unit/services/test_remove_file_from_references.py
+++ b/tests/unit/services/test_remove_file_from_references.py
@@ -1,0 +1,173 @@
+"""Unit tests for remove_file_from_references service function."""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.services.references import remove_file_from_references
+from lib.workflows.reference_file_matching.state import (
+    MatchSource,
+    ReferenceFileMatch,
+    ReferenceFileMatchingConfig,
+    ReferenceFileMatchingState,
+)
+from lib.workflows.models import WorkflowRunType
+
+
+def _make_state(matches: list[ReferenceFileMatch]) -> ReferenceFileMatchingState:
+    return ReferenceFileMatchingState(
+        type=WorkflowRunType.REFERENCE_FILE_MATCHING,
+        config=ReferenceFileMatchingConfig(project_id=str(uuid.uuid4())),
+        file_id=str(uuid.uuid4()),
+        supporting_file_ids=[],
+        matches=matches,
+    )
+
+
+def _make_run() -> MagicMock:
+    run = MagicMock()
+    run.langgraph_thread_id = str(uuid.uuid4())
+    return run
+
+
+@asynccontextmanager
+async def _fake_checkpointer():
+    yield MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_workflow_run():
+    with patch(
+        "lib.services.references._get_file_matching_workflow_state",
+        new=AsyncMock(return_value=(None, None)),
+    ):
+        removed = await remove_file_from_references(
+            str(uuid.uuid4()), str(uuid.uuid4()), revision=1
+        )
+
+    assert removed == []
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_state():
+    with patch(
+        "lib.services.references._get_file_matching_workflow_state",
+        new=AsyncMock(return_value=(_make_run(), None)),
+    ):
+        removed = await remove_file_from_references(
+            str(uuid.uuid4()), str(uuid.uuid4()), revision=1
+        )
+
+    assert removed == []
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_when_no_match_for_file_id():
+    other_file_id = str(uuid.uuid4())
+    state = _make_state(
+        [
+            ReferenceFileMatch(
+                reference_id="r1",
+                file_id=other_file_id,
+                source=MatchSource.AUTO_MATCHED,
+            )
+        ]
+    )
+
+    aupdate_mock = AsyncMock()
+    graph_app = MagicMock()
+    graph_app.aupdate_state = aupdate_mock
+    graph = MagicMock()
+    graph.compile.return_value = graph_app
+
+    with (
+        patch(
+            "lib.services.references._get_file_matching_workflow_state",
+            new=AsyncMock(return_value=(_make_run(), state)),
+        ),
+        patch("lib.services.references.get_checkpointer", _fake_checkpointer),
+        patch("lib.services.references.create_graph", return_value=graph),
+    ):
+        removed = await remove_file_from_references(
+            str(uuid.uuid4()), str(uuid.uuid4()), revision=1
+        )
+
+    assert removed == []
+    aupdate_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_removes_single_match_and_preserves_others():
+    target_file_id = str(uuid.uuid4())
+    other_file_id = str(uuid.uuid4())
+    keep = ReferenceFileMatch(
+        reference_id="r_keep", file_id=other_file_id, source=MatchSource.AUTO_MATCHED
+    )
+    drop = ReferenceFileMatch(
+        reference_id="r_drop", file_id=target_file_id, source=MatchSource.AUTO_MATCHED
+    )
+    state = _make_state([keep, drop])
+    run = _make_run()
+
+    aupdate_mock = AsyncMock()
+    graph_app = MagicMock()
+    graph_app.aupdate_state = aupdate_mock
+    graph = MagicMock()
+    graph.compile.return_value = graph_app
+
+    with (
+        patch(
+            "lib.services.references._get_file_matching_workflow_state",
+            new=AsyncMock(return_value=(run, state)),
+        ),
+        patch("lib.services.references.get_checkpointer", _fake_checkpointer),
+        patch(
+            "lib.services.references.create_graph", return_value=graph
+        ) as create_graph_mock,
+    ):
+        removed = await remove_file_from_references(
+            str(uuid.uuid4()), target_file_id, revision=1
+        )
+
+    assert removed == ["r_drop"]
+    create_graph_mock.assert_called_once_with(WorkflowRunType.REFERENCE_FILE_MATCHING)
+    aupdate_mock.assert_awaited_once()
+    call_args = aupdate_mock.await_args
+    assert call_args.args[0] == {"configurable": {"thread_id": run.langgraph_thread_id}}
+    assert call_args.args[1] == {"matches": [keep]}
+    assert call_args.kwargs["as_node"] == "match_supporting_docs"
+
+
+@pytest.mark.asyncio
+async def test_removes_multiple_matches_pointing_at_same_file():
+    target_file_id = str(uuid.uuid4())
+    dup_a = ReferenceFileMatch(
+        reference_id="ra", file_id=target_file_id, source=MatchSource.AUTO_MATCHED
+    )
+    dup_b = ReferenceFileMatch(
+        reference_id="rb", file_id=target_file_id, source=MatchSource.AUTO_FETCHED
+    )
+    state = _make_state([dup_a, dup_b])
+
+    aupdate_mock = AsyncMock()
+    graph_app = MagicMock()
+    graph_app.aupdate_state = aupdate_mock
+    graph = MagicMock()
+    graph.compile.return_value = graph_app
+
+    with (
+        patch(
+            "lib.services.references._get_file_matching_workflow_state",
+            new=AsyncMock(return_value=(_make_run(), state)),
+        ),
+        patch("lib.services.references.get_checkpointer", _fake_checkpointer),
+        patch("lib.services.references.create_graph", return_value=graph),
+    ):
+        removed = await remove_file_from_references(
+            str(uuid.uuid4()), target_file_id, revision=1
+        )
+
+    assert sorted(removed) == ["ra", "rb"]
+    assert aupdate_mock.await_args.args[1] == {"matches": []}

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -609,8 +609,10 @@ async def test_remove_reference_file_returns_file_and_unlinked_refs():
     with (
         patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
         patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
-        patch("lib.api.mcp.delete_project_files", new=AsyncMock(return_value=1)),
-        patch("lib.api.mcp.remove_file_from_references", new=AsyncMock(return_value=[ref_id])),
+        patch(
+            "lib.api.mcp.delete_project_file_with_cleanup",
+            new=AsyncMock(return_value=(1, [ref_id])),
+        ),
     ):
         raw = await remove_reference_file(
             project_id=str(project.id), file_id=file_id, token=_make_token()
@@ -631,7 +633,10 @@ async def test_remove_reference_file_raises_when_not_found():
     with (
         patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
         patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
-        patch("lib.api.mcp.delete_project_files", new=AsyncMock(return_value=0)),
+        patch(
+            "lib.api.mcp.delete_project_file_with_cleanup",
+            new=AsyncMock(return_value=(0, [])),
+        ),
     ):
         with pytest.raises(ValueError, match="not found in project"):
             await remove_reference_file(
@@ -649,8 +654,10 @@ async def test_remove_reference_file_with_no_associations():
     with (
         patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
         patch("lib.api.mcp.get_project_access", new=AsyncMock(return_value=(project, MagicMock()))),
-        patch("lib.api.mcp.delete_project_files", new=AsyncMock(return_value=1)),
-        patch("lib.api.mcp.remove_file_from_references", new=AsyncMock(return_value=[])),
+        patch(
+            "lib.api.mcp.delete_project_file_with_cleanup",
+            new=AsyncMock(return_value=(1, [])),
+        ),
     ):
         raw = await remove_reference_file(
             project_id=str(project.id), file_id=file_id, token=_make_token()


### PR DESCRIPTION
## Summary

Fixes [RANDZ-537](https://linear.app/ae-studio/issue/RANDZ-537/failed-fetch-from-web-shows-no-outcome-indicator-user-cant-tell-if).

Three related issues were preventing users from seeing reliable fetch-from-web outcomes in the References tab:

1. **Backend — subset fetch wiping prior results.** `initialize_references` used `Overwrite(...)` on `fetched_references`, which wiped every prior entry when the workflow ran for a subset of references (e.g. retrying a single reference via the per-card button). All previously-stored SourceFound / SourceNotFound / error outcomes for the other references were lost.
2. **Frontend — fetch box hidden for failed outcomes.** The visibility rule for the fetch-results box required `item.source` to be null or `AutoFetched`, and hid the box whenever `result.file_id` existed but the matched file didn't. Together these could suppress the box for legitimately failed fetches.
3. **Backend — stale fetch result after manual file removal.** When a user deleted an auto-fetched file, the ReferenceDownloader workflow state still held the original fetch result (with the now-missing `file_id`), so the UI could render a "Source Found" indicator pointing at a file that no longer exists.

## Motivation

Users running "Fetch from web" on a single reference lost visibility into which other references had previously failed to fetch, failed-fetch outcomes could be silently hidden, and removing a fetched file left a stale outcome behind.

## What's Changed

### Backend

- `lib/workflows/reference_downloader/nodes/fetch_references.py` — removed the `Overwrite` wrapper (and now-unused import) in `initialize_references`. PENDING entries are now written through the existing `merge_fetch_results` reducer, preserving prior results for references not in the current run. Full-batch "Fetch from web" still resets every reference to PENDING because `config.references` contains all of them in that flow.
- `lib/services/references.py` — added `remove_fetch_result_for_file(project_id, file_id, revision)`. Loads the `ReferenceDownloader` state, filters out `fetched_references` whose `result.file_id` matches the removed file, and writes the filtered list back via `aupdate_state` using `Overwrite(...)` to bypass the merge reducer (which otherwise only upserts).
- `lib/services/projects.py` — added `delete_project_file_with_cleanup(project_id, file_id, revision)` that encapsulates the full file-removal flow: delete the file record → unlink from `ReferenceFileMatching` matches → clear any `ReferenceDownloader` fetch result pointing at the file. Returns `(deleted_count, removed_reference_ids)`. Placed in `projects.py` to avoid a circular import (`files.py` → `references.py` cycles via the downloader's `download_file_from_url` tool).
- `lib/api/routers/projects.py` — the `DELETE /api/project/{project_id}/files/{file_id}` endpoint now delegates to `delete_project_file_with_cleanup`.
- `lib/api/mcp.py` — the `remove_reference_file` MCP tool now delegates to `delete_project_file_with_cleanup`, sharing the same orchestration as the HTTP endpoint.

### Frontend

- `frontend/components/results/tabs/reference-review/queries.ts` — simplified the `shouldShowFetchedResult` rule to `!!fetchedReference && item.source !== MatchSource.ManualUpload`. The fetch-results box now surfaces whenever a fetch was attempted, except when the user manually uploaded the source. Covers `SourceNotFound`, `SourceFoundButNotAccessible`, and error statuses.

### Tests

- `tests/unit/test_mcp_tools.py` — the three `test_remove_reference_file_*` tests were patching symbols (`delete_project_files`, `remove_file_from_references`) that are no longer imported into `lib.api.mcp` after the refactor. Updated them to patch `lib.api.mcp.delete_project_file_with_cleanup` and assert against its new `(deleted_count, removed_reference_ids)` return tuple. All three pass.

## Risks and Mitigations

- **Stale entries across reference re-extraction (backend).** Reference IDs change when extraction re-runs, so orphaned entries are never rendered (frontend looks up `fetched_references` by `reference_id`). Harmless.
- **File cleanup during fetch (backend).** `cleanup_failed_resources` operates against `SUPPORTING_CANDIDATE` files only. Previously-promoted successful fetches are `SUPPORT` and are not touched.
- **Full-batch fetch (backend).** `config.references` contains every reference, so behavior is unchanged for that path.
- **`Overwrite` in `remove_fetch_result_for_file` (backend).** Bypasses the merge reducer intentionally; this is the only supported way to delete entries from a reducer-annotated list in LangGraph state. Write is node-scoped (`as_node="cleanup_failed_resources"`) to match the existing pattern used by `on_cancel`.

## Test plan

- [ ] Start backend (`uv run dev.py`) and frontend (`cd frontend && pnpm dev`).
- [ ] Open a project with extracted references. Click the top-level "Fetch from web" and wait for completion so multiple references show fetch-result boxes (mix of found / not found).
- [ ] Click "Fetch from the web" on a single unmatched reference. Confirm the other references' fetch-result boxes remain visible with their previous conclusions.
- [ ] Confirm references where the fetch concluded `SourceNotFound` or errored now display the fetch-results box with the corresponding badge.
- [ ] Remove an auto-fetched file via the "Remove" button on a matched reference card. Confirm the fetch-results box for that reference also disappears (no stale "Source Found" indicator).
- [ ] Exercise the same removal flow via the MCP `remove_reference_file` tool and confirm parity.
- [ ] Re-run the batch "Fetch from web" and confirm all references are reset to PENDING and updated normally.
- [ ] `uv run pytest tests/unit/test_mcp_tools.py -k remove_reference_file` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)