### PR TITLE
feat(reproducibility-check): mark as beta

### DIFF
--- a/lib/workflows/results_extraction/manifest.py
+++ b/lib/workflows/results_extraction/manifest.py
@@ -22,6 +22,7 @@ class ResultsExtractionManifest(
         "Could someone reproduce your results from the document alone? Extracts main results and classifies each by how reproducible it is based on whether the data is present and the methodology is described."
     )
     needs_web_search = False
+    is_experimental = True
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
 
     def get_state_type(self) -> Type[ResultsExtractionState]:


### PR DESCRIPTION
## Summary

Marks the Reproducibility Check workflow as beta so the UI shows the Beta badge and tooltip.

Closes [RANDZ-547](https://linear.app/ae-studio/issue/RANDZ-547/make-reproducibility-check-to-be-beta).

## Motivation

The Reproducibility Check (results extraction workflow) is still being evaluated for accuracy and consistency. Surfacing it as Beta sets expectations that results may vary and the feature may change.

## What's Changed

### Backend

- `lib/workflows/results_extraction/manifest.py` — set `is_experimental = True` on `ResultsExtractionManifest`. The frontend already renders the Beta badge based on the `is_experimental` flag exposed via the workflow type description, so no frontend changes are needed.

### Frontend

- None.

## Risks and Mitigations

- **Risk:** users see a new Beta badge on a workflow they were already using. **Mitigation:** the existing tooltip explains what Beta means; behavior of the workflow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)