### PR TITLE
feat(frontend): bottom-right version + GitHub badge

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,7 @@
 import { ProjectsList } from '@/components/projects-list';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { ArrowRight, Brain, FlaskConical, Github } from 'lucide-react';
+import { ArrowRight, Brain, FlaskConical } from 'lucide-react';
 import Link from 'next/link';
 
 export default function Home() {
@@ -29,12 +29,6 @@ export default function Home() {
               <FlaskConical className="w-5 h-5" />
               Start a Project
               <ArrowRight className="w-4 h-4" />
-            </Button>
-          </Link>
-          <Link href="https://github.com/agencyenterprise/ai-reviewer" target="_blank" rel="noopener noreferrer">
-            <Button variant="outline" size="lg">
-              <Github className="w-5 h-5" />
-              View on GitHub
             </Button>
           </Link>
         </div>

--- a/frontend/components/version-badge.tsx
+++ b/frontend/components/version-badge.tsx
@@ -7,36 +7,30 @@ export function VersionBadge() {
   const repoUrl = packageJson.repository?.url;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2">
-      <a
-        href={repoUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-block"
-        aria-label="View source on GitHub"
+    <div className="fixed bottom-4 right-4 z-50">
+      <Badge
+        variant="outline"
+        className="text-xs font-mono bg-background/80 backdrop-blur-sm opacity-50 hover:opacity-100 transition-opacity gap-2"
       >
-        <Badge
-          variant="outline"
-          className="text-xs bg-background/80 backdrop-blur-sm opacity-50 hover:opacity-100 transition-opacity cursor-pointer"
-        >
-          <Github className="w-3 h-3 mr-1" />
-          GitHub
-        </Badge>
-      </a>
-      <a
-        href={`${repoUrl}/blob/main/CHANGELOG.md`}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-block"
-        aria-label={`View release notes for version ${packageJson.version}`}
-      >
-        <Badge
-          variant="outline"
-          className="text-xs font-mono bg-background/80 backdrop-blur-sm opacity-50 hover:opacity-100 transition-opacity cursor-pointer"
+        <a
+          href={`${repoUrl}/blob/main/CHANGELOG.md`}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`View release notes for version ${packageJson.version}`}
+          className="hover:underline"
         >
           v{packageJson.version}
-        </Badge>
-      </a>
+        </a>
+        <a
+          href={repoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View source on GitHub"
+          className="inline-flex items-center"
+        >
+          <Github className="w-3 h-3" />
+        </a>
+      </Badge>
     </div>
   );
 }

--- a/frontend/components/version-badge.tsx
+++ b/frontend/components/version-badge.tsx
@@ -1,3 +1,5 @@
+import { Github } from 'lucide-react';
+
 import { Badge } from '@/components/ui/badge';
 import packageJson from '@/package.json';
 
@@ -5,7 +7,22 @@ export function VersionBadge() {
   const repoUrl = packageJson.repository?.url;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50">
+    <div className="fixed bottom-4 right-4 z-50 flex items-center gap-2">
+      <a
+        href={repoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block"
+        aria-label="View source on GitHub"
+      >
+        <Badge
+          variant="outline"
+          className="text-xs bg-background/80 backdrop-blur-sm opacity-50 hover:opacity-100 transition-opacity cursor-pointer"
+        >
+          <Github className="w-3 h-3 mr-1" />
+          GitHub
+        </Badge>
+      </a>
       <a
         href={`${repoUrl}/blob/main/CHANGELOG.md`}
         target="_blank"


### PR DESCRIPTION
## Summary
- Move the "View on GitHub" link out of the homepage hero into a small badge fixed to the bottom-right corner.
- Combine the GitHub link and version pill into a single badge: version label on the left (links to CHANGELOG), GitHub icon on the right (links to the repo).

## Motivation
Free up space in the homepage hero and keep the GitHub/version affordances persistently accessible across pages without dominating the layout.

## What's Changed
### Frontend
- `frontend/app/page.tsx` — Remove the inline "View on GitHub" button from the hero section.
- `frontend/components/version-badge.tsx` — Merge the previously-separate GitHub and version badges into a single pill; the GitHub link is now icon-only on the right side of the version badge.

## Risks and Mitigations
- Low risk — purely presentational. Both links still point to the same URLs and the badge is non-blocking (fixed, low-opacity until hover). No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)