### PR TITLE
feat(mcp): add install instructions for Codex and Opencode

### DIFF
--- a/frontend/components/mcp/mcp-instructions.tsx
+++ b/frontend/components/mcp/mcp-instructions.tsx
@@ -2,37 +2,51 @@
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { baseUrl } from '@/lib/api';
 import { Check, Copy, Server } from 'lucide-react';
 import { useState } from 'react';
 
 const mcpUrl = `${baseUrl}/mcp/`;
 
-const tools = [
-  { name: 'list_workflow_types', description: 'Lists all available workflow analysis types' },
-  { name: 'create_project', description: 'Creates a project and ingests a markdown document' },
-  { name: 'run_workflow', description: 'Runs one or more workflow analyses on a project and returns results' },
-  { name: 'get_project', description: 'Retrieves full project details and workflow results by ID' },
-];
-
 const claudeCodeCommand = `claude mcp add-json "draft-detective" '{"type":"http","url":"${mcpUrl}"}'`;
 
-export function McpInstructions() {
+const codexCommand = `codex mcp add draft-detective --url ${mcpUrl}`;
+
+const sampleTriggers = [
+  'Use Draft Detective to extract claims from this paper: <paste-markdown-or-path>',
+  'Run a reference validation review on this manuscript with Draft Detective.',
+  'Check figures and tables in this document using Draft Detective and summarize the findings.',
+  'List the available Draft Detective workflows and recommend which ones to run on this draft.',
+];
+
+function CopyableCode({ code, multiline = false }: { code: string; multiline?: boolean }) {
   const [copied, setCopied] = useState(false);
-  const [copiedCommand, setCopiedCommand] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(mcpUrl);
+    await navigator.clipboard.writeText(code);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
 
-  const handleCopyCommand = async () => {
-    await navigator.clipboard.writeText(claudeCodeCommand);
-    setCopiedCommand(true);
-    setTimeout(() => setCopiedCommand(false), 2000);
-  };
+  return (
+    <div className="flex items-start gap-2">
+      <code
+        className={`flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all ${
+          multiline ? 'whitespace-pre overflow-x-auto' : ''
+        }`}
+      >
+        {code}
+      </code>
+      <Button variant="outline" onClick={handleCopy} title="Copy">
+        {copied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
+        {copied ? 'Copied' : 'Copy'}
+      </Button>
+    </div>
+  );
+}
 
+export function McpInstructions() {
   return (
     <div className="space-y-6">
       <div>
@@ -50,13 +64,7 @@ export function McpInstructions() {
           <CardTitle className="text-base">Your MCP Server URL</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <div className="flex items-center gap-2">
-            <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">{mcpUrl}</code>
-            <Button variant="outline" onClick={handleCopy} title="Copy URL">
-              {copied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
-              {copied ? 'Copied' : 'Copy'}
-            </Button>
-          </div>
+          <CopyableCode code={mcpUrl} />
           <p className="text-sm text-muted-foreground">
             Paste this URL when adding the integration in your MCP client.
           </p>
@@ -65,35 +73,85 @@ export function McpInstructions() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Add via Claude Code CLI</CardTitle>
+          <CardTitle className="text-base">Install instructions</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-3">
-          <p className="text-sm text-muted-foreground">Run this single command to add the MCP server to Claude Code:</p>
-          <div className="flex items-center gap-2">
-            <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
-              {claudeCodeCommand}
-            </code>
-            <Button variant="outline" onClick={handleCopyCommand} title="Copy command">
-              {copiedCommand ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
-              {copiedCommand ? 'Copied' : 'Copy'}
-            </Button>
-          </div>
+        <CardContent>
+          <Tabs defaultValue="claude-code">
+            <TabsList>
+              <TabsTrigger value="claude-code">Claude Code</TabsTrigger>
+              <TabsTrigger value="codex">Codex</TabsTrigger>
+              <TabsTrigger value="opencode">Opencode</TabsTrigger>
+            </TabsList>
+            <TabsContent value="claude-code" className="space-y-3 mt-4">
+              <p className="text-sm text-muted-foreground">
+                Run this command in your terminal to register the MCP server with Claude Code:
+              </p>
+              <CopyableCode code={claudeCodeCommand} />
+              <p className="text-sm text-muted-foreground">
+                After adding it, run <code className="font-mono text-xs">/mcp</code> inside Claude Code to authenticate.
+              </p>
+            </TabsContent>
+            <TabsContent value="codex" className="space-y-3 mt-4">
+              <p className="text-sm text-muted-foreground">
+                Run this command in your terminal to register the MCP server with Codex:
+              </p>
+              <CopyableCode code={codexCommand} />
+              <p className="text-sm text-muted-foreground">
+                A browser window will open the first time you use it so you can authenticate.
+              </p>
+            </TabsContent>
+            <TabsContent value="opencode" className="space-y-3 mt-4">
+              <p className="text-sm text-muted-foreground">In your terminal, run the interactive add command:</p>
+              <CopyableCode code="opencode mcp add" />
+              <p className="text-sm text-muted-foreground">Answer the prompts as follows:</p>
+              <ul className="text-sm text-muted-foreground list-disc pl-5 space-y-1">
+                <li>
+                  <strong>Location:</strong> <code className="font-mono text-xs">Global</code> (or{' '}
+                  <code className="font-mono text-xs">Project</code> if you only want it in this project)
+                </li>
+                <li>
+                  <strong>MCP server name:</strong> <code className="font-mono text-xs">Draft Detective</code>
+                </li>
+                <li>
+                  <strong>MCP server type:</strong> <code className="font-mono text-xs">Remote</code>
+                </li>
+                <li>
+                  <strong>MCP server URL:</strong> <code className="font-mono text-xs break-all">{mcpUrl}</code>
+                </li>
+                <li>
+                  <strong>Does this server require OAuth authentication?</strong>{' '}
+                  <code className="font-mono text-xs">Yes</code>
+                </li>
+                <li>
+                  <strong>Do you have a pre-registered client ID?</strong> <code className="font-mono text-xs">No</code>
+                </li>
+              </ul>
+              <p className="text-sm text-muted-foreground">Then authenticate:</p>
+              <CopyableCode code="opencode mcp auth" />
+            </TabsContent>
+          </Tabs>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Available tools</CardTitle>
+          <CardTitle className="text-base">How to use</CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Once installed, just ask your AI assistant in plain English. Here are some prompts to get you started:
+          </p>
           <ul className="space-y-3">
-            {tools.map((tool) => (
-              <li key={tool.name} className="flex flex-col gap-0.5">
-                <code className="text-sm font-mono font-semibold">{tool.name}</code>
-                <span className="text-sm text-muted-foreground">{tool.description}</span>
+            {sampleTriggers.map((trigger) => (
+              <li key={trigger} className="rounded-md bg-muted px-3 py-2 text-sm font-mono break-words">
+                {trigger}
               </li>
             ))}
           </ul>
+          <p className="text-sm text-muted-foreground">
+            The assistant will pick the right Draft Detective tools (creating a project, running a workflow, fetching
+            results) and walk you through the analysis.
+          </p>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary

- Adds tabbed install instructions on the `/mcp` page for Claude Code, Codex, and Opencode.
- Adds a "How to use" section with sample prompts users can paste into their assistant.
- Removes the user-facing list of available MCP tool names (not relevant to end users).

## Motivation

Resolves [RANDZ-545](https://linear.app/ae-studio/issue/RANDZ-545/add-mcp-usage-instructions-for-claude-code-codex-and-opencode-to-mcp). The `/mcp` page only documented the Claude Code one-liner. Users on Codex and Opencode had no setup guidance.

## What's Changed

### Frontend

- `frontend/components/mcp/mcp-instructions.tsx`
  - Replaced the single Claude Code install card with a single "Install instructions" card containing tabs for Claude Code, Codex, and Opencode.
    - Claude Code: existing `claude mcp add-json` one-liner.
    - Codex: `codex mcp add draft-detective --url <mcpUrl>`.
    - Opencode: walks through the interactive `opencode mcp add` prompts (Location, name, type, URL, OAuth, client ID), followed by `opencode mcp auth`.
  - Added a new "How to use" card with sample natural-language prompts for invoking Draft Detective from any assistant.
  - Removed the "Available tools" list (internal detail not useful to end users).
  - Extracted a reusable `CopyableCode` helper so each command/snippet has a consistent copy button.

## Risks and Mitigations

- Documentation-only change, no runtime behavior or API surface affected.
- Tabs component (`@/components/ui/tabs`) is already used elsewhere in the app, no new dependencies.
- Type check (`pnpm tsc --noEmit`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)