### PR TITLE
feat(reference-validation): add v2 with red/yellow/green severity tiers

### DIFF
--- a/evals_inspectai/e2e/reference_validation/dataset.json
+++ b/evals_inspectai/e2e/reference_validation/dataset.json
@@ -1,366 +1,366 @@
 [
   {
     "input": "https://www.britannica.com/topic/think-tank/Think-tanks-in-practice",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "missing_fields",
     "target_answer": "URL-only reference should be replaced with a full citation including the author, title, publisher, and year. Field validations should say field is MISSING for all fields except 'identifier' that doesn't matter (can be the URL itself or marked as missing."
   },
   {
     "input": "https://www.youtube.com/watch?v=wKfq63nU9CM",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "missing_fields",
     "target_answer": "URL-only reference should be replaced with a full citation including the author, title, publisher, and year. Field validations should say field is MISSING for all fields except 'identifier' that doesn't matter (can be the URL itself or marked as missing)"
   },
   {
     "input": "https://ieakenya.or.ke/blog/the-ai-preparedness-landscape-for-think-tanks/",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "missing_fields",
     "target_answer": "URL-only reference should be replaced with a full citation including the author, title, publisher, and year. Field validations should say field is MISSING for all fields except 'identifier' that doesn't matter (can be the URL itself or marked as missing)"
   },
   {
     "input": "John Doe and Jane Smith. Webvoyager: Building an end-to-end web agent with large multimodal models. arXiv preprint arXiv:2401.00001, 2024.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "1- The authors are incorrect; 2- The arxiv ID is incorrect"
   },
   {
     "input": "Asma Issa, George Mohler, and John Johnson. Paraphrase identification using deep contextualized representations. In Proceedings of the 2018 Conference on Empirical Methods in Natural Language Processing (EMNLP), pp. 517-526, 2018.",
-    "target_final_result": "not_found",
+    "target_final_result": "incorrect_fields",
     "target_answer": "This is a made up reference, so validations should say reference is not found and not include a suggested updated reference."
   },
   {
     "input": "John Smith and Jane Doe. Deep learning techniques for avatar-based interaction in virtual environments. IEEE Transactions on Neural Networks and Learning Systems, 32(12):5600-5612, 2021. doi: 10.1109/ TNNLS.2021.3071234. URL https://ieeexplore.ieee.org/document/307123",
-    "target_final_result": "not_found",
+    "target_final_result": "incorrect_fields",
     "target_answer": "This is a made up reference, so validations should say reference is not found and not include a suggested updated reference."
   },
   {
     "input": "Goodison, Sean E., Robert C. Davis, and Brian A. Jackson. Digital Evidence and the U.S. Criminal Justice System: Identifying Technology and Other Needs to More Effectively Acquire and Utilize Digital Evidence. Santa Monica, CA: RAND Corporation, 2015.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "Doe, John. The Effects of Widgets on Gadgets. Journal of Widgetry, 2020.",
-    "target_final_result": "not_found",
+    "target_final_result": "incorrect_fields",
     "target_answer": "This is a made up reference, so validations should say reference is not found and not include a suggested updated reference."
   },
   {
     "input": "Vermeer, Michael J. D., Dulani Woods, and Brian A. Jackson. Identifying Law Enforcement Needs for Access to Digital Evidence in Remote Data Centers. Santa Monica, CA: RAND Corporation, 2019.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "1- Publication year is incorrect; 2- Identifier should be added"
   },
   {
     "input": "Bistline, John, Geoffrey Blanford, Maxwell Brown, Dallas Burtraw, Maya Domeshek, Jamil Farbes, Allen Fawcett, Anne Hamilton, Jesse Jenkins, Ryan Jones, Ben King, Hannah Kolus, John Larsen, Amanda Levin, Megan Mahajan, Cara Marcy, Erin Mayfield, James McFarland, Haewon McJeon, Robbie Orvis, Neha Patankar, Kevin Rennert, Christopher Roney, Nicholas Roy, Greg Schivley, Daniel Steinberg, Nadejda Victor, Shelley Wenzel, John Weyant, Ryan Wiser, Mei Yuan, and Alicia Zhao, \"Emissions and energy impacts of the Inflation Reduction Act,\" Science, Vol. 380, No. 6652, 1324 – 1327, 29 June 2023. https://doi.org/10.1126/science.adg3781",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "Davenport, Carly, Brian Singer, Neil Mehta, Brian Lee, and John Mackay, \"Generational growth: AI, data centers and the coming US power demand surge,\" Goldman Sachs Equity Research, April 28, 2024: https://www.goldmansachs.com/pdfs/insights/pages/generational-growth-ai-data-centers-and-the-coming-us-power-surge/report.pdf",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "Patel, Dylan, Daniel Nishball, and Jeremie Elliahou Ontiveros, \"AI Data center Energy Dilemma - Race for AI Data center Space,\" SemiAnalysis, March 13, 2024. As of September 18, 2024: https://www.semianalysis.com/p/ai-data center-energy-dilemma-race",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "1- Author name is mispelled; 2- URL is malformed"
   },
   {
     "input": "Daniel Furrer, Jonathan Berant, Panupong Pasupat, Don Tuggener, Mark Cieliebak, and Mark Steedman. Compositional generalization in semantic parsing: Pre-training vs. specialized architectures. In Findings of the Association for Computational Linguistics: EMNLP, 2020.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "1- Author list is incorrect"
   },
   {
     "input": "Jonathan Herzig. Unlocking compositional generalization in pretrained models using intermediate representations. In EMNLP, 2021a.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Replace the venue (it is an arXiv preprint, not an EMNLP proceedings paper), correct the author list, normalize the year, and add the arXiv identifier/DOI."
   },
   {
     "input": "Jonathan Herzig and Jonathan Berant. Unlocking compositional generalization in pretrained models using intermediate representations.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Replace the incorrect author list (it is not coauthored with Jonathan Berant) and add the missing publication details (arXiv, 2021, and arXiv/DOI identifier)."
   },
   {
     "input": "Jonathan Herzig and Jonathan Berant. Unlocking compositional generalization in pretrained models using intermediate representations. In EMNLP, 2021c.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Replace the listed authors and venue (it is not an EMNLP paper by Herzig & Berant) and add the arXiv identifier so the citation points to the correct work."
   },
   {
     "input": "Takashi Ito, Brenden M. Lake, and Marco Baroni. Compositional generalization through abstract representations in human and artificial neural networks. In NeurIPS, 2022.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Replace the listed authors with the correct NeurIPS 2022 paper author list (Ito, Klinger, Schultz, Murray, Cole, Rigotti) and add the persistent identifier (arXiv:2209.07431)."
   },
   {
     "input": "Najoung Kim and Tal Linzen. Cogs: A compositional generalization challenge based on semantic interpretation. In NAACL, 2021.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Venue is wrong (should be EMNLP, not NAACL) and year is wrong (should be 2020, not 2021). Authors are correct."
   },
   {
     "input": "Brenden M. Lake and Marco Baroni. Generalization without systematicity: On the compositional skills of sequence-to-sequence recurrent networks. ICML, 2018.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "Xueguang Li, Yizhe Zhang, Xuezhe Ma, Lemao Liu, Xiang Chen, Ming Zhou, Tie-Yan Liu, and Jianfeng Gao. Compositional generalization through meta sequence-to-sequence learning. In EMNLP, 2021.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Replace the (incorrect) author list, venue, and year with the correct NeurIPS 2019 citation information and add the arXiv identifier"
   },
   {
     "input": "Laura Ruis, Jacob Andreas, Marco Baroni, Diane Bouchacourt, and Brenden M. Lake. A benchmark for systematic generalization in grounded language understanding. In NeurIPS, 2020.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "Herzig, Jonathan, Peter Shaw, Ming-Wei Chang, Kelvin Guu, Panupong Pasupat, and Yuan Zhang. \"Unlocking compositional generalization in pre-trained models using intermediate representations.\" arXiv preprint arXiv:2104.07478 (2021).",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "North American Electric Reliability Corporation, \"2024 Long-Term Reliability Assessment,\" December 2024: https://www.nerc.com/pa/RAPA/ra/Reliability%20Assessments%20DL/NERC_Long%20Term%20Reliability%20Assessment_2024.pdf",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "Sevilla, Jaime, Tamay Besiroglu, Ben Cottier, Josh You, Edu Roldán, Pablo Villalobos, and Ege Erdil, \"Can AI Scaling Continue Through 2030?\" Epoch AI, August 20, 2024: https://epoch.ai/blog/can-ai-scaling-continue-through-2030",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "Srivathsan, Bhargs, Haripreet Batra, Raman Sharma, Rishi Gupta, and Surbhi Choudhary, \"AI power: Expanding data center capacity to meet growing demand,\" McKinsey & Company, October 2024: https://www.mckinsey.com/industries/technology-media-and-telecommunications/our-insights/ai-power-expanding-data-center-capacity-to-meet-growing-demand#/",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Replace the author list with the article’s listed authors"
   },
   {
     "input": "Blanchard, Lauren Ploch, U.S.-Kenya Relations: Current Political and Security Issues, Congressional Research Service, R42967, July 23, 2015.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid CRS report with potential small inconsistencies in citation format"
   },
   {
     "input": "Smart, Rosanna, Andrew R. Morral, Sierra Smucker, Samantha Cherney, Terry L. Schell, Samuel Peterson, Sangeeta C. Ahluwalia, Matthew Cefalu, Lea Xenakis, Rajeev Ramchand, and Carole Roan Gresenz, The Science of Gun Policy: A Critical Synthesis of Research Evidence on the Effects of Gun Policies in the United States, 2nd ed., RAND Corporation, RR-2088-1-RC/AV, 2020. As of May 21, 2022: https://www.rand.org/pubs/research_reports/RR2088-1.html",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid RAND report reference with potential small inconsistencies"
   },
   {
     "input": "Lin, Luona, and Kim Parker, \"US workers are more worried than hopeful about future AI use in the workplace,\" Pew Research Center, 2025. As of November 13, 2025: https://www.pewresearch.org/wp-content/uploads/sites/20/2025/02/ST_2025.2.25_AI-Workers_REPORT.pdf",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies"
   },
   {
     "input": "de Dianous, Valérie, and Cécile Fiévez, \"ARAMIS Project: A More Explicit Demonstration of Risk Control Through the Use of Bow-Tie Diagrams and the Evaluation of Safety Barrier Performance,\" Journal of Hazardous Materials, Vol. 130, No. 3, March 31, 2006.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid journal article reference with potential small inconsistencies"
   },
   {
     "input": "Bick, Alexander, Adam Blandin, and David J. Deming, \"The Rapid Adoption of Generative AI,\" NBER Working Paper 32966, 2024. As of November 13, 2025: https://doi.org/10.3386/w32966",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid NBER working paper reference with potential small inconsistencies"
   },
   {
     "input": "Brachman, Michelle, Amina El-Ashry, Casey Dugan, and Werner Geyer, \"Current and future use of large language models for knowledge work,\" Proceedings of the ACM on Human-Computer Interaction, Vol. 9, No. 7, 2025. As of November 13, 2025: https://dl.acm.org/doi/pdf/10.1145/3757403",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid ACM journal article reference with potential small inconsistencies"
   },
   {
     "input": "Becker, Joel, Nate Rush, Elizabeth Barnes, and David Rein, \"Measuring the impact of early-2025 AI on experienced open-source developer productivity,\" arXiv, 2025. As of November 13, 2025: https://arxiv.org/abs/2507.09089",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid arXiv preprint reference with potential small inconsistencies"
   },
   {
     "input": "Wang, Dakuo, Q. Vera Liao, Yunfeng Zhang, Udayan Khurana, Horst Samulowitz, Soya Park, Michael Muller, and Lisa Amini, \"How much automation does a data scientist want?\" arXiv, arXiv:2101.03970, 2021. As of November 13, 2025: https://arxiv.org/abs/2101.03970",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid arXiv preprint reference with potential small inconsistencies"
   },
   {
     "input": "Murphy, Kim, \"Iraq Rejects Warning, Assails Mubarak,\" Los Angeles Times, January 2, 1991.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid newspaper article reference with potential small inconsistencies"
   },
   {
     "input": "\"Xi urges good start to 15th Five-Year Plan period,\" Xinhua, February 26, 2026.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid wire news article reference with potential small inconsistencies"
   },
   {
     "input": "Perficient. \"The State of GenAI in the Workforce,\" Perficient, 2025. As of January 30, 2026: https://www.perficient.com/insights/generative-ai-workforce-study",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid organizational report reference with potential small inconsistencies"
   },
   {
     "input": "Kemp, Andy. \"AI Use at Work Rises,\" Gallup, December 2025. As of January 30, 2026: https://www.gallup.com/workplace/699689/ai-use-at-work-rises.aspx",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid online article reference with potential small inconsistencies"
   },
   {
     "input": "Raytheon Technologies, homepage, undated. As of May 11, 2022:https://www.rtx.com",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid homepage reference with potential small inconsistencies"
   },
   {
     "input": "Office of the Under Secretary of War (Comptroller), \"Defense Wide Budget Documentation,\" webpage, undated. As of September 18, 2025: https://comptroller.defense.gov/Budget-Materials/FY2009BudgetJustification",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "The organization name is incorrect: 'Under Secretary of War' is a historical pre-1947 title; it should be 'Office of the Under Secretary of Defense (Comptroller)'"
   },
   {
     "input": "Phoebe Liu, \"Three months after a blockbuster $20 billion deal, Nvidia announced its plans for Groq's inference-speed tech. Here's how it came together and what's next,\" Bluesky post, March 18, 2026. As of March 18, 2026: https://bsky.app/profile/pheebini.bsky.social/post/3mhdyfduj2k2a",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid social media post reference with potential small inconsistencies"
   },
   {
     "input": "Air Force Policy Directive 10-601, Operational Capability Requirements Documentation and Validation, Department of the Air Force, April 27, 2021.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid official Air Force publication reference with potential small inconsistencies"
   },
   {
     "input": "Joint Chiefs of Staff, Doctrine for the Armed Forces of the United States, Joint Publication 1, March 25, 2013, change 1, July 12, 2017.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid joint doctrine publication reference with potential small inconsistencies"
   },
   {
     "input": "Public Law 107-296, Homeland Security Act of 2002, November 25, 2002.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid public law citation with potential small inconsistencies"
   },
   {
     "input": "Brownlee, Les, \"Current Army Issues,\" testimony before the U.S. Senate Committee on Armed Services, U.S. Government Printing Office, November 19, 2003.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid congressional testimony reference with potential small inconsistencies"
   },
   {
     "input": "Williams, Heather J., and Alexandra T. Evans, \"Extremist Use of Online Spaces,\" testimony submitted to the Select Committee to Investigate the January 6th Attack on the United States Capitol, RAND Corporation, CT-A1458-1, April 25, 2022. As of July 7, 2022: https://www.rand.org/pubs/testimonies/CTA1458-1.html",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid RAND testimony reference with potential small inconsistencies"
   },
   {
     "input": "Costanzo, George, and Mary Ann Spott, \"Joint Theater Trauma System (JTTS)/Joint Theater Trauma Registry (JTTR),\" briefing slides, U.S. Army Institute of Surgical Research, July 10, 2010.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid briefing slides citation with potential small inconsistencies"
   },
   {
     "input": "Carter, Ashton B., \"0% Headquarters Reductions,\" memorandum to secretaries of the military departments et al., U.S. Department of Defense, July 31, 2013.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "The title is incorrect: the actual memo subject is '20% Headquarters Reductions', not '0% Headquarters Reductions'. Author, publisher, and date are correct."
   },
   {
     "input": "Embassy of the United States in Jordan, \"The United States and the Hashemite Kingdom of Jordan Sign Memorandum of Understanding on Assistance,\" press release, September 23, 2008.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid press release citation with potential small inconsistencies"
   },
   {
     "input": "World Bank, World Integrated Trade Solution, database, undated. As of May 2, 2022: https://wits.worldbank.org",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid database reference with potential small inconsistencies"
   },
   {
     "input": "Defense Manpower Data Center, \"Number of Military and DoD Appropriated Fund (APF) Civilian Personnel Permanently Assigned,\" spreadsheet, last updated September 30, 2019.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid government dataset citation with potential small inconsistencies"
   },
   {
     "input": "Brandon Vigliarolo. \"Anthropic accidentally exposes Claude Code source code.\" The Register. Mar 31, 2026. https://www.theregister.com/2026/03/31/anthropic_claude_code_source_code/ (The Register, 2026)",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "The title is incorrect. The actual article headline on The Register is 'Anthropic goes nude, exposes Claude Code source by accident', not 'Anthropic accidentally exposes Claude Code source code'. The validator must use the title from the article's content body (the on-page headline), not a sanitized version from metadata tags or search snippets. Author, publisher, year, and URL are correct."
   },
   {
     "input": "Microsoft Security Blog. (2024, April 1). Navigating the cyber threat landscape with AI. https://www.microsoft.com/en-us/security/blog/2024/04/01/navigating-cyber-threat-landscape-ai",
-    "target_final_result": "not_found",
+    "target_final_result": "incorrect_fields",
     "target_answer": "This blog post does not exist at the given URL and cannot be found via web search. The agent must not validate a reference based solely on the URL having a plausible pattern; it must verify the content actually exists by searching for the title or confirming the URL resolves to real content."
   },
   {
     "input": "Bass, Frank M., \"A New Product Growth for Model Consumer Durables,\" Management Science, Vol. 15, No. 5, 1969. As of April 9, 2026: https://doi.org/10.1287/mnsc.15.5.215.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid journal article reference with potential small inconsistencies",
     "note": "False positive: DD flagged inconsistencies in the title, but the reference is actually correct."
   },
   {
     "input": "Battula, Narendar, \"Prompt-Driven Vulnerability Chains: How to Build Multi-Step Exploits from Low-Severity Bugs with AI,\" Medium, As of July 23, 2025: https://medium.com/@narendarlb123/prompt-driven-vulnerability-chains-how-to-build-multi-step-exploits-from-low-severity-bugs-with-ai-7f79a701535b.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid online article reference with potential small inconsistencies",
     "note": "Link redirects to a custom site on Medium; AI may be unable to follow the redirect and may incorrectly report not_found."
   },
   {
     "input": "Frontier Model Forum. (n.d.). About. https://www.frontiermodelforum.org/about-us/",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid online article reference with potential small inconsistencies",
     "note": "Page has no listed author, so entry in 'author' field should be publisher. Publisher does not need to be repeated twice in the reference."
   },
   {
     "input": "Google Security Blog. (2024, June 12). Secure AI Framework (SAIF): Conceptualizing secure AI systems. https://security.googleblog.com/2024/06/secure-ai-framework.html",
-    "target_final_result": "not_found",
+    "target_final_result": "incorrect_fields",
     "target_answer": "The post does not exist at the given URL and a post with this title cannot be found via web search. Since a post with this title cannot be found, validations should say reference is not found.",
     "note": "DD completions often return found_with_inconsistencies citing a closely matching official Google source (Hansen, R., & Venables, P. (2023, June 8). Introducing Google's Secure AI Framework. The Keyword.) — however all 4 fields differ from the original reference. The result should be not_found when all 4 fields are different."
   },
   {
     "input": "Khare, A., Dutta, S., Li, Z., Solko-Breslin, A., Alur, R., & Naik, M. (2024). Understanding the Effectiveness of Large Language Models in Detecting Security Vulnerabilities. arXiv [Cs.CR]. Retrieved from http://arxiv.org/abs/2311.16169.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies",
     "note": "False positive: DD thinks year should be 2023. Original submission on arXiv is 2023, but there is an updated submission in 2024. For an arXiv citation to the unversioned record, the year should refer to the most recent submission (2024)."
   },
   {
     "input": "Fang, R., Bindu, R., Gupta, A., Zhan, Q., & Kang, D. (2024b). Teams of LLM Agents can Exploit Zero-Day Vulnerabilities. ArXiv, abs/2406.01637.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Cited v1 author list instead of using the list of authors from the most recent version on arXiv (v2).",
     "note": "Some arXiv papers have multiple uploaded versions with different author lists. DD should always match fields against the most recent version, unless the citation explicitly references an older version (e.g. https://arxiv.org/abs/2406.01637v1)."
   },
   {
     "input": "Kwa, T., West, B., Becker, J., Deng, A., Garcia, K., Hasin, M., Jawhar, S., Kinniment, M., Rush, N., Arx, S.V., Bloom, R., Broadley, T., Du, H., Goodrich, B., Jurkovic, N., Miles, L.H., Nix, S., Lin, T.R., Parikh, N., Rein, D., Sato, L.J., Wijk, H., Ziegler, D.M., Barnes, E., & Chan, L. (2025). Measuring AI Ability to Complete Long Tasks. ArXiv, abs/2503.14499.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Uses v1 arXiv title instead of the current v3 title. Author list has small differences.",
     "note": "Some arXiv papers have multiple uploaded versions with different author lists. DD should always match fields against the most recent version, unless the citation explicitly references an older version."
   },
   {
     "input": "Patwardhan, T., Dias, R., Proehl, E., Kim, G., Wang, M., Watkins, O., Fishman, S. P., Aljubeh, M., Thacker, P., Fauconnet, L., Kim, N. S., Chao, P., Miserendino, S., Chabot, G., Li, D., Sharman, M., Barr, A., Glaese, A., ... Tworek, J. (2025). GDPval: Evaluating AI model performance on real-world economically valuable tasks (arXiv:2312.12575v2). arXiv. https://arxiv.org/html/2312.12575v2",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Incorrect arXiv identifier; the identifier links to a different, unrelated paper."
   },
   {
     "input": "Stevens, Rock & Dykstra, Josiah & Everette, Wendy Knox & Chapman, James & Bladow, Garrett & Farmer, Alexander & Halliday, Kevin & Mazurek, Michelle L. (2020). Compliance Cautions: Investigating Security Issues Associated with U.S. Digital-Security Standards. 10.14722/ndss.2020.24003.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "missing_fields",
     "target_answer": "Publisher/venue is missing; the DOI resolves to an NDSS 2020 paper and the venue should be added."
   },
   {
     "input": "Stevens, Rock & Dykstra, Josiah & Everette, Wendy & Chapman, James & Bladow, Garrett & Farmer, Alexander & Halliday, Kevin & Mazurek, Michelle. (2020). Compliance Cautions: Investigating Security Issues Associated with U.S. Digital-Security Standards. NDSS Symposium (Internet Society). 10.14722/ndss.2020.24003.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies",
     "note": "Minor name inconsistencies (Everette, Wendy vs. Everette, Wendy Knox; Mazurek, Michelle vs. Mazurek, Michelle L.) should not trigger found_with_inconsistencies."
   },
   {
     "input": "Ghosh, R., Farri, O., Stockhausen, H.V., Schmitt, M., & Vasile, G.M. (2024). CVE-LLM : Automatic vulnerability evaluation in medical device industry using large language models. ArXiv, abs/2407.14640.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid reference with potential small inconsistencies",
     "note": "Consistency test: 'Stockhausen, H.V.' should be 'von Stockhausen, H. M.' — a small author name discrepancy that should not trigger found_with_inconsistencies."
   },
   {
     "input": "Dissanayake, N., Zahedi, M., Jayatilaka, A., & Babar, M. A. (2022). Why, how and where of delays in software security patch management: An empirical investigation in the healthcare sector. Proceedings of the ACM on Human-Computer Interaction, 6(CSCW1), 1–28. https://doi.org/10.1145/3512948",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "DOI in the reference resolves to a different ACM article. The source metadata also indicates the article appeared in Proceedings of the ACM on Human-Computer Interaction, volume 6, CSCW2, 1-29, so the issue/pages in the supplied citation are also inconsistent even though those fields are outside the required validation categories."
   },
   {
     "input": "Pearce, H., Tan, B., Ahmad, B., Karri, R., & Dolan-Gavitt, B. (2024). Examining zero-shot vulnerability repair with large language models. Proceedings of the 2024 IEEE Symposium on Security and Privacy (SP), 2339–2356.",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Year is incorrect; the paper was published at IEEE S&P 2023, not 2024. The conference proceedings year should also be corrected to 2023.",
     "note": "Reference is also missing an identifier (DOI or link), but a missing identifier alone should not trigger found_with_inconsistencies — the year error is the primary issue."
   },
   {
     "input": "Tihanyi, N., Ferrag, M. A., Jain, R., Bisztray, T., & Debbah, M. (2024). CyberMetric: Creating a benchmark dataset RAG with human validation for evaluating cybersecurity knowledge of LLMs. arXiv. https://arxiv.org/html/2402.07688v2",
-    "target_final_result": "found_with_inconsistencies",
+    "target_final_result": "incorrect_fields",
     "target_answer": "Title is incorrect (appears to originate from errors in the arXiv HTML rendering); publisher should be updated to the IEEE conference where the paper was officially published.",
     "note": "The link is technically valid but points to the experimental arXiv HTML view, which contains rendering errors that produced the wrong title. Listing publisher as 'arXiv' is not wrong per se, but the paper was officially published at an IEEE conference and that should be preferred."
   },
   {
     "input": "Parker, Charlie, Sam Scott, and Alistair Geddes. \"Snowball Sampling.\" In Sage Research Methods Foundations, edited by Paul Atkinson, Sara Delamont, Alexandru Cernat, Joseph W. Sakshaug, and Richard A. Williams. London: SAGE Publications Ltd, 2019. https://doi.org/10.4135/9781526421036831710.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid article reference with potential small inconsistencies",
     "note": "False positive: DD says year should be 2020 (Google Books lists 2020) but Google Scholar lists the year as 2019, which matches the citation."
   },
   {
     "input": "Adan, Sumaya Nur, Joanna Wiaterek, Varun Sen Bahl, Ima Bello, Camila Beltran, Tobias Dierks, Luise Eder, Liam Epstein, Abra Ganz, Natalie Kiilu, Marianne Lu, Chinasa T. Okolo, Sydney Reis, Said Saillant, Krishna Sharma, Marjia Siddik, Jan Pieter Snoeij, José Jaime Villalobos, and Anna Yelizarova. AI Benefit-Sharing Framework: Balancing Access and Safety. Oxford Martin AI Governance Initiative, Oxford Martin School, University of Oxford, December 1, 2025. As of January 22, 2026: https://aigi.ox.ac.uk/publications/ai-benefit-sharing-framework-balancing-access-and-safety/",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid white paper reference with potential small inconsistencies",
     "note": "DD returned 'not_found' but article exists."
   },
   {
     "input": "Sundharbaabu, P.R., J. Chang, Y. Kim, Y. Shim, B. Lee, C. Noh, S. Heo, S. S. Lee, S. H. Shim, K. L. Lim, K. Jo, and J. H. Lee. \"Artificial Intelligence‐Enhanced Analysis of Genomic DNA Visualized with Nanoparticle‐Tagged Peptides under Electron Microscopy,\" Small, Vol. 21, No. 12, Mar, 2025.",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid journal article reference with potential small inconsistencies",
     "note": "DD returned 'not_found' but article exists."
   },
   {
     "input": "Rajan, Kanna and Karlyn D. Stanley, Unmanned Cargo Vessels: A Working Paper, RAND Corporation, WR-A2889-1, 2023. As of April 18, 2026: https://www.rand.org/pubs/working_papers/WRA2889-1.html",
-    "target_final_result": "valid",
+    "target_final_result": "correct",
     "target_answer": "Valid RAND working paper reference with potential small inconsistencies"
   }
 ]

--- a/evals_inspectai/e2e/reference_validation/reference_validation_e2e.py
+++ b/evals_inspectai/e2e/reference_validation/reference_validation_e2e.py
@@ -70,7 +70,7 @@ def reference_validation_e2e():
     return Task(
         dataset=dataset,
         solver=api_workflow_agent(
-            "reference_validation",
+            "reference_validation_v2",
         ),
         scorer=[
             structured_output_scorer(ReferenceValidationOutput, _compare_final_result),

--- a/evals_inspectai/internal/reference_validation/reference_validation.py
+++ b/evals_inspectai/internal/reference_validation/reference_validation.py
@@ -7,9 +7,9 @@ from langgraph.graph.state import RunnableConfig
 from evals_inspectai.common.scorers import model_graded_check, structured_output_scorer
 from evals_inspectai.internal.common.config import get_model_or_agent_default
 from evals_inspectai.internal.common.lc_agent_solver import langchain_agent
-from lib.agents.reference_validator import (
-    BibliographyItemValidation,
-    ReferenceValidatorAgent,
+from lib.agents.reference_validator_v2 import (
+    BibliographyItemValidationV2,
+    ReferenceValidatorV2Agent,
 )
 
 
@@ -22,14 +22,15 @@ def reference_validation():
 
     return Task(
         dataset=dataset,
-        model=get_model_or_agent_default(ReferenceValidatorAgent),
+        model=get_model_or_agent_default(ReferenceValidatorV2Agent),
         solver=langchain_agent(
-            ReferenceValidatorAgent,
+            ReferenceValidatorV2Agent,
             invoke_func=_invoke_reference_validator,
         ),
         scorer=[
             structured_output_scorer(
-                model_type=BibliographyItemValidation, compare=_compare_final_result
+                model_type=BibliographyItemValidationV2,
+                compare=_compare_final_result,
             ),
             model_graded_check(
                 target_from_metadata="target_answer", partial_credit=True
@@ -39,10 +40,12 @@ def reference_validation():
 
 
 async def _invoke_reference_validator(
-    agent: ReferenceValidatorAgent, input: str, config: RunnableConfig
-) -> tuple[BibliographyItemValidation, list[BaseMessage]]:
+    agent: ReferenceValidatorV2Agent, input: str, config: RunnableConfig
+) -> tuple[BibliographyItemValidationV2, list[BaseMessage]]:
     return await agent.ainvoke({"reference": input}, config=config)
 
 
-def _compare_final_result(output: BibliographyItemValidation, state: TaskState) -> bool:
+def _compare_final_result(
+    output: BibliographyItemValidationV2, state: TaskState
+) -> bool:
     return output.final_result.value == state.target.text

--- a/frontend/components/results/tabs/reference-review/validation-results-box-v2.tsx
+++ b/frontend/components/results/tabs/reference-review/validation-results-box-v2.tsx
@@ -1,0 +1,289 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { LabeledValue } from '@/components/labeled-value';
+import { Markdown } from '@/components/markdown';
+import { AgentMessagesDialog } from '@/components/shared/agent-messages-dialog';
+import {
+  ReferenceValidationFinalResultV2,
+  ReferenceValidationV2Item,
+  ReferenceValidationV2Status,
+} from '@/lib/generated-api';
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ClipboardCheck,
+  Loader2,
+  MessageSquare,
+  SearchX,
+  XCircle,
+} from 'lucide-react';
+import * as React from 'react';
+
+function humanizeLabel(value: string): string {
+  return value.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export interface ValidationResultsBoxV2Props {
+  validation: ReferenceValidationV2Item;
+  /** Whether to show the reference text in the header. */
+  showReference?: boolean;
+  /** Label for the reference text when showReference is true. */
+  referenceLabel?: string;
+  /** Size variant controlling padding. */
+  size?: 'sm' | 'default';
+}
+
+const sizeClasses = {
+  sm: 'py-1 px-2',
+  default: 'py-3 px-4',
+} as const;
+
+export function ValidationResultsBoxV2({
+  validation,
+  showReference = false,
+  referenceLabel = 'Reference',
+  size = 'sm',
+}: ValidationResultsBoxV2Props) {
+  const paddingClass = sizeClasses[size];
+  const [isExpanded, setIsExpanded] = React.useState(false);
+  const [isMessagesOpen, setIsMessagesOpen] = React.useState(false);
+
+  const status = validation.status ?? ReferenceValidationV2Status.Pending;
+  const result = validation.validation_result;
+  const hasMessages = validation.messages && validation.messages.length > 0;
+
+  if (status === ReferenceValidationV2Status.Cancelled) {
+    return (
+      <div className={`rounded border ${paddingClass} bg-gray-50/80 border-gray-200`}>
+        <div className="flex items-center gap-2">
+          <ClipboardCheck className="w-4 h-4 text-muted-foreground" />
+          <span className="text-xs font-medium text-gray-700">Validation results</span>
+          <span className="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full border bg-gray-50 text-gray-500 border-gray-200">
+            <Ban className="w-3.5 h-3.5" />
+            Not validated
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  if (status === ReferenceValidationV2Status.Pending) {
+    return (
+      <div className={`rounded border ${paddingClass} bg-blue-50/80 border-blue-200`}>
+        <div className="flex items-center gap-2">
+          <ClipboardCheck className="w-4 h-4 text-muted-foreground" />
+          <span className="text-xs font-medium text-gray-700">Validation results</span>
+          <span className="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full border bg-blue-50 text-blue-700 border-blue-200">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+            Validating...
+          </span>
+        </div>
+        {showReference && validation.input_reference && (
+          <div className="pt-2 mt-2 border-t border-current/10">
+            <span className="text-xs font-medium text-muted-foreground">{referenceLabel}:</span>
+            <div className="text-sm mt-1 break-words">
+              <Markdown>{validation.input_reference}</Markdown>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (status === ReferenceValidationV2Status.Error) {
+    return (
+      <div className={`rounded border ${paddingClass} bg-red-50/80 border-red-200`}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <ClipboardCheck className="w-4 h-4 text-muted-foreground" />
+            <span className="text-xs font-medium text-gray-700">Validation results</span>
+            <span className="inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full border bg-red-50 text-red-700 border-red-200">
+              <XCircle className="w-3.5 h-3.5" />
+              Error
+            </span>
+          </div>
+          <Button variant="outline" size="xs" onClick={() => setIsExpanded(!isExpanded)}>
+            {isExpanded ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
+            {isExpanded ? 'Hide details' : 'Show details'}
+          </Button>
+        </div>
+        {showReference && validation.input_reference && (
+          <div className="pt-2 mt-2 border-t border-current/10">
+            <span className="text-xs font-medium text-muted-foreground">{referenceLabel}:</span>
+            <div className="text-sm mt-1 break-words">
+              <Markdown>{validation.input_reference}</Markdown>
+            </div>
+          </div>
+        )}
+        {isExpanded && validation.error && (
+          <div className="pt-2 mt-2 border-t border-current/10 text-sm text-red-700">{validation.error}</div>
+        )}
+      </div>
+    );
+  }
+
+  if (!result) {
+    return null;
+  }
+
+  const issues = result.bibliography_field_validations?.filter((field) => field.problem_type !== 'correct') || [];
+  const missingCount = issues.filter((field) => field.problem_type === 'missing').length;
+  const incorrectCount = issues.filter(
+    (field) => field.problem_type === 'incorrect' || field.problem_type === 'other',
+  ).length;
+  const finalResult = result.final_result;
+
+  const resultConfig = {
+    [ReferenceValidationFinalResultV2.Correct]: {
+      boxClass: 'bg-green-50/80 border-green-200',
+      badgeClass: 'bg-green-50 text-green-700 border-green-200',
+      icon: <CheckCircle2 className="w-3.5 h-3.5" />,
+      label: 'Valid',
+    },
+    [ReferenceValidationFinalResultV2.MissingFields]: {
+      boxClass: 'bg-yellow-50/80 border-yellow-200',
+      badgeClass: 'bg-yellow-50 text-yellow-700 border-yellow-200',
+      icon: <AlertTriangle className="w-3.5 h-3.5" />,
+      label: `${missingCount || issues.length} missing field${(missingCount || issues.length) !== 1 ? 's' : ''}`,
+    },
+    [ReferenceValidationFinalResultV2.IncorrectFields]: {
+      boxClass: 'bg-red-50/80 border-red-200',
+      badgeClass: 'bg-red-50 text-red-700 border-red-200',
+      icon: <SearchX className="w-3.5 h-3.5" />,
+      label:
+        incorrectCount > 0
+          ? `${incorrectCount} incorrect field${incorrectCount !== 1 ? 's' : ''}`
+          : 'Reference not found',
+    },
+  };
+
+  const config = resultConfig[finalResult];
+
+  return (
+    <div className={`rounded border ${paddingClass} ${config.boxClass}`}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <ClipboardCheck className="w-4 h-4 text-muted-foreground" />
+          <span className="text-xs font-medium text-gray-700">Validation results</span>
+          <span
+            className={`inline-flex items-center gap-1.5 px-2 py-0.5 text-xs font-medium rounded-full border ${config.badgeClass}`}
+          >
+            {config.icon}
+            {config.label}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          {hasMessages && (
+            <Button variant="outline" size="xs" onClick={() => setIsMessagesOpen(true)} title="View agent messages">
+              <MessageSquare className="size-4" />
+              Messages
+            </Button>
+          )}
+          <Button variant="outline" size="xs" onClick={() => setIsExpanded(!isExpanded)}>
+            {isExpanded ? <ChevronDownIcon className="size-4" /> : <ChevronRightIcon className="size-4" />}
+            {isExpanded ? 'Hide details' : 'Show details'}
+          </Button>
+        </div>
+      </div>
+
+      {showReference && validation.input_reference && (
+        <div className="pt-2 mt-2 border-t border-current/10">
+          <span className="text-xs font-medium text-muted-foreground">{referenceLabel}:</span>
+          <div className="text-sm mt-1 break-words">
+            <Markdown>{validation.input_reference}</Markdown>
+          </div>
+        </div>
+      )}
+
+      {isExpanded && (
+        <div className="space-y-3 pt-2 mt-2 border-t border-current/10 text-sm leading-relaxed">
+          <LabeledValue label="Suggested Action">
+            <span className="break-words">{result.suggested_action}</span>
+          </LabeledValue>
+
+          {result.updated_reference && (
+            <LabeledValue label="Updated Reference">
+              <p className="break-words text-xs bg-white/50 p-2 rounded border border-gray-200">
+                {result.updated_reference}
+              </p>
+            </LabeledValue>
+          )}
+
+          {result.url && (
+            <LabeledValue label="URL">
+              <a
+                href={result.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:underline break-all"
+              >
+                {result.url}
+              </a>
+            </LabeledValue>
+          )}
+
+          {result.reasoning && (
+            <LabeledValue label="Reasoning">
+              <span className="break-words">{result.reasoning}</span>
+            </LabeledValue>
+          )}
+
+          {result.bibliography_field_validations && result.bibliography_field_validations.length > 0 && (
+            <div>
+              <h4 className="text-xs font-medium text-muted-foreground mb-2">Field Validations</h4>
+              <div className="space-y-2">
+                {result.bibliography_field_validations.map((field, idx) => {
+                  const isCorrect = field.problem_type === 'correct';
+                  const isIncorrect = field.problem_type === 'incorrect' || field.problem_type === 'other';
+                  return (
+                    <div key={idx} className="pl-3 border-l-2 border-gray-200 text-xs">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="font-medium uppercase text-gray-600">{humanizeLabel(field.category)}</span>
+                        <Badge
+                          variant={isCorrect ? 'success' : 'outline'}
+                          className={`text-xs ${
+                            isCorrect
+                              ? ''
+                              : isIncorrect
+                                ? 'bg-red-100 text-red-800 border-red-300 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800'
+                                : 'bg-yellow-100 text-yellow-800 border-yellow-300 dark:bg-yellow-900/20 dark:text-yellow-400 dark:border-yellow-800'
+                          }`}
+                        >
+                          {isCorrect ? 'Valid' : humanizeLabel(field.problem_type)}
+                        </Badge>
+                      </div>
+                      <div className="text-gray-600 space-y-0.5">
+                        {field.current_value && (
+                          <div className="break-words">
+                            <span className="font-medium">Current:</span> {field.current_value}
+                          </div>
+                        )}
+                        {field.suggested_value && field.problem_type !== 'correct' && (
+                          <div className="break-words">
+                            <span className="font-medium">Suggested:</span> {field.suggested_value}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {hasMessages && (
+        <AgentMessagesDialog
+          messages={validation.messages!}
+          open={isMessagesOpen}
+          onOpenChange={setIsMessagesOpen}
+          title={showReference && referenceLabel ? `Messages — ${referenceLabel}` : undefined}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/components/results/tabs/workflow-results-renderer.tsx
+++ b/frontend/components/results/tabs/workflow-results-renderer.tsx
@@ -12,6 +12,7 @@ import { LiveReportsResults } from '@/components/workflows/results/live-reports-
 import { MethodologicalAlignmentResults } from '@/components/workflows/results/methodological-alignment-results';
 import { ReferenceDownloaderResults } from '@/components/workflows/results/reference-downloader-results';
 import { ReferenceValidationResults } from '@/components/workflows/results/reference-validation-results';
+import { ReferenceValidationV2Results } from '@/components/workflows/results/reference-validation-v2-results';
 import { ResultsExtractorResults } from '@/components/workflows/results/results-extractor-results';
 import { Reviewer2Results } from '@/components/workflows/results/reviewer-2-results';
 import { SimpleDeepAgentResults } from '@/components/workflows/results/simple-deep-agent-results';
@@ -100,6 +101,8 @@ function renderWorkflowResults(
       return <Reviewer2Results workflowDetail={workflowRun} />;
     case WorkflowRunType.ReferenceValidation:
       return <ReferenceValidationResults workflowDetail={workflowRun} />;
+    case WorkflowRunType.ReferenceValidationV2:
+      return <ReferenceValidationV2Results workflowDetail={workflowRun} />;
     case WorkflowRunType.DocumentStructure:
     case WorkflowRunType.FiguresTablesCheck:
       return (

--- a/frontend/components/workflows/results/reference-validation-v2-results.tsx
+++ b/frontend/components/workflows/results/reference-validation-v2-results.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { EmptyState } from '@/components/shared/empty-state';
+import { ValidationResultsBoxV2 } from '@/components/results/tabs/reference-review/validation-results-box-v2';
+import {
+  ReferenceValidationFinalResultV2,
+  ReferenceValidationV2Item,
+  ReferenceValidationV2State,
+  ReferenceValidationV2Status,
+  WorkflowRunDetail,
+} from '@/lib/generated-api';
+import { AlertTriangle, Ban, CheckCircle2, ClipboardCheck, Loader2, XCircle } from 'lucide-react';
+import * as React from 'react';
+
+type FilterType = 'all' | 'correct' | 'missing_fields' | 'incorrect_fields' | 'pending' | 'error' | 'cancelled';
+
+interface ReferenceValidationV2ResultsProps {
+  workflowDetail: WorkflowRunDetail;
+}
+
+function getValidationCategory(v: ReferenceValidationV2Item): Exclude<FilterType, 'all'> {
+  const status = v.status ?? ReferenceValidationV2Status.Pending;
+  if (status === ReferenceValidationV2Status.Pending) return 'pending';
+  if (status === ReferenceValidationV2Status.Error) return 'error';
+  if (status === ReferenceValidationV2Status.Cancelled) return 'cancelled';
+
+  const finalResult = v.validation_result?.final_result;
+  if (finalResult === ReferenceValidationFinalResultV2.Correct) return 'correct';
+  if (finalResult === ReferenceValidationFinalResultV2.MissingFields) return 'missing_fields';
+  return 'incorrect_fields';
+}
+
+export function ReferenceValidationV2Results({ workflowDetail }: ReferenceValidationV2ResultsProps) {
+  const results = workflowDetail.state as ReferenceValidationV2State | undefined;
+  const [filter, setFilter] = React.useState<FilterType>('all');
+
+  const { validations, stats } = React.useMemo(() => {
+    const items = results?.reference_validations ?? [];
+    let pending = 0;
+    let errors = 0;
+    let missingFields = 0;
+    let incorrectFields = 0;
+    let correct = 0;
+    let cancelled = 0;
+
+    items.forEach((v: ReferenceValidationV2Item) => {
+      const category = getValidationCategory(v);
+      if (category === 'pending') pending++;
+      else if (category === 'error') errors++;
+      else if (category === 'correct') correct++;
+      else if (category === 'missing_fields') missingFields++;
+      else if (category === 'cancelled') cancelled++;
+      else incorrectFields++;
+    });
+
+    return {
+      validations: items,
+      stats: { pending, errors, missingFields, incorrectFields, correct, cancelled, total: items.length },
+    };
+  }, [results?.reference_validations]);
+
+  const filteredValidations = React.useMemo(() => {
+    if (filter === 'all') return validations;
+    return validations.filter((v) => getValidationCategory(v) === filter);
+  }, [validations, filter]);
+
+  const toggleFilter = (newFilter: FilterType) => {
+    setFilter((current) => (current === newFilter ? 'all' : newFilter));
+  };
+
+  if (validations.length === 0) {
+    return <EmptyState message="No reference validation results available." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center flex-wrap gap-2">
+        <ClipboardCheck className="h-5 w-5 text-blue-600" />
+        <span className="text-sm font-medium">Reference Validation Results</span>
+        <Badge
+          variant="secondary"
+          className={`ml-auto cursor-pointer transition-all ${filter === 'all' ? 'ring-2 ring-offset-1 ring-gray-400' : 'hover:bg-secondary/80'}`}
+          onClick={() => toggleFilter('all')}
+        >
+          {stats.total} Reference{stats.total !== 1 ? 's' : ''}
+        </Badge>
+        {stats.correct > 0 && (
+          <Badge
+            variant="outline"
+            className={`cursor-pointer transition-all bg-green-50 text-green-700 border-green-200 ${filter === 'correct' ? 'ring-2 ring-offset-1 ring-green-400' : 'hover:bg-green-100'}`}
+            onClick={() => toggleFilter('correct')}
+          >
+            <CheckCircle2 className="w-3 h-3 mr-1" />
+            {stats.correct} Correct
+          </Badge>
+        )}
+        {stats.missingFields > 0 && (
+          <Badge
+            variant="outline"
+            className={`cursor-pointer transition-all bg-yellow-50 text-yellow-700 border-yellow-200 ${filter === 'missing_fields' ? 'ring-2 ring-offset-1 ring-yellow-400' : 'hover:bg-yellow-100'}`}
+            onClick={() => toggleFilter('missing_fields')}
+          >
+            <AlertTriangle className="w-3 h-3 mr-1" />
+            {stats.missingFields} Missing Fields
+          </Badge>
+        )}
+        {stats.incorrectFields > 0 && (
+          <Badge
+            variant="outline"
+            className={`cursor-pointer transition-all bg-red-50 text-red-700 border-red-200 ${filter === 'incorrect_fields' ? 'ring-2 ring-offset-1 ring-red-400' : 'hover:bg-red-100'}`}
+            onClick={() => toggleFilter('incorrect_fields')}
+          >
+            <XCircle className="w-3 h-3 mr-1" />
+            {stats.incorrectFields} Incorrect Fields
+          </Badge>
+        )}
+        {stats.pending > 0 && (
+          <Badge
+            variant="outline"
+            className={`cursor-pointer transition-all bg-blue-50 text-blue-700 border-blue-200 ${filter === 'pending' ? 'ring-2 ring-offset-1 ring-blue-400' : 'hover:bg-blue-100'}`}
+            onClick={() => toggleFilter('pending')}
+          >
+            <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+            {stats.pending} Pending
+          </Badge>
+        )}
+        {stats.errors > 0 && (
+          <Badge
+            variant="outline"
+            className={`cursor-pointer transition-all bg-red-50 text-red-700 border-red-200 ${filter === 'error' ? 'ring-2 ring-offset-1 ring-red-400' : 'hover:bg-red-100'}`}
+            onClick={() => toggleFilter('error')}
+          >
+            <XCircle className="w-3 h-3 mr-1" />
+            {stats.errors} Error{stats.errors !== 1 ? 's' : ''}
+          </Badge>
+        )}
+        {stats.cancelled > 0 && (
+          <Badge
+            variant="outline"
+            className={`cursor-pointer transition-all bg-gray-50 text-gray-500 border-gray-200 ${filter === 'cancelled' ? 'ring-2 ring-offset-1 ring-gray-400' : 'hover:bg-gray-100'}`}
+            onClick={() => toggleFilter('cancelled')}
+          >
+            <Ban className="w-3 h-3 mr-1" />
+            {stats.cancelled} Not Validated
+          </Badge>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        {filteredValidations.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-4">No references match the selected filter.</p>
+        ) : (
+          filteredValidations.map((validation, index) => (
+            <ValidationResultsBoxV2
+              key={validation.reference_id || index}
+              validation={validation}
+              showReference
+              referenceLabel={`Reference #${validations.indexOf(validation) + 1}`}
+              size="default"
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -52,6 +52,7 @@ const workflowTypeIcons: Record<WorkflowRunType, LucideIcon> = {
   [WorkflowRunType.LiteratureReview]: Library,
   [WorkflowRunType.LiveReports]: Newspaper,
   [WorkflowRunType.ReferenceValidation]: FileCheck,
+  [WorkflowRunType.ReferenceValidationV2]: FileCheck,
   [WorkflowRunType.CitationSuggester]: Lightbulb,
   [WorkflowRunType.ResultsExtraction]: BarChart3,
   [WorkflowRunType.InferenceValidation]: BrainCircuit,

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -535,6 +535,32 @@ export type BibliographyFieldValidation = {
 };
 
 /**
+ * BibliographyFieldValidationV2
+ */
+export type BibliographyFieldValidationV2 = {
+  /**
+   * Category of the reference. Possible values: ['author', 'title', 'publisher', 'year', 'identifier']
+   */
+  category: FieldCategoryV2;
+  /**
+   * Current Value
+   *
+   * Current value of the reference.
+   */
+  current_value: string;
+  /**
+   * Suggested Value
+   *
+   * Suggested value of the reference.
+   */
+  suggested_value: string;
+  /**
+   * Problem type of the reference. Must be CORRECT if the only differences are capitalization or minor punctuation. Possible values: ['correct', 'missing', 'incorrect', 'other']
+   */
+  problem_type: FieldProblemTypeV2;
+};
+
+/**
  * BibliographyItemValidation
  */
 export type BibliographyItemValidation = {
@@ -554,6 +580,52 @@ export type BibliographyItemValidation = {
    * List of reference field validations.
    */
   bibliography_field_validations: Array<BibliographyFieldValidation>;
+  /**
+   * Suggested Action
+   *
+   * Suggested action to take if the reference is not valid. A summary of the suggested changes to make the reference valid. If the reference is valid, return 'No changes needed'.
+   */
+  suggested_action: string;
+  /**
+   * Url
+   *
+   * Found URL for the reference.
+   */
+  url: string;
+  /**
+   * Reasoning
+   *
+   * Step-by-step reasoning describing your approach to validate the reference.
+   */
+  reasoning?: string;
+  /**
+   * Updated Reference
+   *
+   * Updated reference with the suggested changes made to make the reference valid, matching the format of the original reference. If the reference is already valid, return null.
+   */
+  updated_reference?: string | null;
+};
+
+/**
+ * BibliographyItemValidationV2
+ */
+export type BibliographyItemValidationV2 = {
+  /**
+   * Original Reference
+   *
+   * Original bibliographic item text.
+   */
+  original_reference: string;
+  /**
+   * Overall validation outcome. Possible values: ['correct', 'missing_fields', 'incorrect_fields']
+   */
+  final_result: ReferenceValidationFinalResultV2;
+  /**
+   * Bibliography Field Validations
+   *
+   * List of reference field validations.
+   */
+  bibliography_field_validations: Array<BibliographyFieldValidationV2>;
   /**
    * Suggested Action
    *
@@ -2173,6 +2245,22 @@ export const FieldCategory = {
 export type FieldCategory = (typeof FieldCategory)[keyof typeof FieldCategory];
 
 /**
+ * FieldCategoryV2
+ */
+export const FieldCategoryV2 = {
+  Author: 'author',
+  Title: 'title',
+  Publisher: 'publisher',
+  Year: 'year',
+  Identifier: 'identifier',
+} as const;
+
+/**
+ * FieldCategoryV2
+ */
+export type FieldCategoryV2 = (typeof FieldCategoryV2)[keyof typeof FieldCategoryV2];
+
+/**
  * FieldProblemType
  */
 export const FieldProblemType = {
@@ -2186,6 +2274,21 @@ export const FieldProblemType = {
  * FieldProblemType
  */
 export type FieldProblemType = (typeof FieldProblemType)[keyof typeof FieldProblemType];
+
+/**
+ * FieldProblemTypeV2
+ */
+export const FieldProblemTypeV2 = {
+  Correct: 'correct',
+  Missing: 'missing',
+  Incorrect: 'incorrect',
+  Other: 'other',
+} as const;
+
+/**
+ * FieldProblemTypeV2
+ */
+export type FieldProblemTypeV2 = (typeof FieldProblemTypeV2)[keyof typeof FieldProblemTypeV2];
 
 /**
  * File
@@ -4252,6 +4355,21 @@ export type ReferenceValidationFinalResult =
   (typeof ReferenceValidationFinalResult)[keyof typeof ReferenceValidationFinalResult];
 
 /**
+ * ReferenceValidationFinalResultV2
+ */
+export const ReferenceValidationFinalResultV2 = {
+  Correct: 'correct',
+  MissingFields: 'missing_fields',
+  IncorrectFields: 'incorrect_fields',
+} as const;
+
+/**
+ * ReferenceValidationFinalResultV2
+ */
+export type ReferenceValidationFinalResultV2 =
+  (typeof ReferenceValidationFinalResultV2)[keyof typeof ReferenceValidationFinalResultV2];
+
+/**
  * ReferenceValidationItem
  *
  * Item for tracking individual reference validation with status
@@ -4334,6 +4452,133 @@ export const ReferenceValidationStatus = {
  * Status of a reference validation operation
  */
 export type ReferenceValidationStatus = (typeof ReferenceValidationStatus)[keyof typeof ReferenceValidationStatus];
+
+/**
+ * ReferenceValidationV2Item
+ *
+ * Item for tracking individual reference validation with status
+ */
+export type ReferenceValidationV2Item = {
+  /**
+   * Reference Id
+   *
+   * The ID of the reference to validate.
+   */
+  reference_id: string;
+  /**
+   * Input Reference
+   *
+   * The original reference text.
+   */
+  input_reference: string;
+  /**
+   * Current status of this reference validation.
+   */
+  status?: ReferenceValidationV2Status;
+  /**
+   * The validation result for the reference, present on success.
+   */
+  validation_result?: BibliographyItemValidationV2 | null;
+  /**
+   * Error
+   *
+   * Error message, present on failure.
+   */
+  error?: string | null;
+  /**
+   * Messages
+   *
+   * LLM conversation messages from the agent invocation.
+   */
+  messages?: Array<{
+    [key: string]: unknown;
+  }>;
+};
+
+/**
+ * ReferenceValidationV2State
+ *
+ * State for the reference validation v2 workflow.
+ */
+export type ReferenceValidationV2State = {
+  /**
+   * Errors
+   *
+   * Errors that occurred during the workflow execution.
+   */
+  errors?: Array<WorkflowError>;
+  /**
+   * Type
+   */
+  type?: 'reference_validation_v2';
+  config: ReferenceValidationV2WorkflowConfig;
+  /**
+   * Reference Validations
+   */
+  reference_validations?: Array<ReferenceValidationV2Item>;
+};
+
+/**
+ * ReferenceValidationV2Status
+ *
+ * Status of a reference validation operation
+ */
+export const ReferenceValidationV2Status = {
+  Pending: 'pending',
+  Completed: 'completed',
+  Error: 'error',
+  Cancelled: 'cancelled',
+} as const;
+
+/**
+ * ReferenceValidationV2Status
+ *
+ * Status of a reference validation operation
+ */
+export type ReferenceValidationV2Status =
+  (typeof ReferenceValidationV2Status)[keyof typeof ReferenceValidationV2Status];
+
+/**
+ * ReferenceValidationV2WorkflowConfig
+ *
+ * Configuration model for the reference validation v2 workflow.
+ */
+export type ReferenceValidationV2WorkflowConfig = {
+  /**
+   * Project Id
+   *
+   * The ID of the project that this workflow run should be associated with
+   */
+  project_id: string;
+  /**
+   * Openai Api Key
+   *
+   * The OpenAI API key to use for this workflow execution
+   */
+  openai_api_key?: string | null;
+  /**
+   * Domain
+   *
+   * Domain context for more accurate analysis
+   */
+  domain?: string | null;
+  /**
+   * Target Audience
+   *
+   * Target audience context for analysis
+   */
+  target_audience?: string | null;
+  /**
+   * Publication Date
+   *
+   * Publication date of the document (YYYY-MM-DD format)
+   */
+  publication_date?: string | null;
+  /**
+   * Type
+   */
+  type?: 'reference_validation_v2';
+};
 
 /**
  * ReferenceValidationWorkflowConfig
@@ -5312,6 +5557,7 @@ export type WorkflowRunDetail = {
     | LiteratureReviewState
     | LiveReportsState
     | ReferenceValidationState
+    | ReferenceValidationV2State
     | CitationSuggesterState
     | ResultsExtractionState
     | InferenceValidationV2State
@@ -5354,6 +5600,7 @@ export const WorkflowRunType = {
   LiteratureReview: 'literature_review',
   LiveReports: 'live_reports',
   ReferenceValidation: 'reference_validation',
+  ReferenceValidationV2: 'reference_validation_v2',
   CitationSuggester: 'citation_suggester',
   ResultsExtraction: 'results_extraction',
   InferenceValidation: 'inference_validation',
@@ -5718,6 +5965,7 @@ export type StartWorkflowApiWorkflowsStartPostData = {
     | LiteratureReviewWorkflowConfig
     | LiveReportsWorkflowConfig
     | ReferenceValidationWorkflowConfig
+    | ReferenceValidationV2WorkflowConfig
     | CitationSuggesterWorkflowConfig
     | ResultsExtractionWorkflowConfig
     | InferenceValidationV2WorkflowConfig

--- a/lib/agents/reference_validator_v2.py
+++ b/lib/agents/reference_validator_v2.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+
+from langchain.agents import create_agent
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.runnables import RunnableConfig
+from pydantic import BaseModel, Field
+
+from lib.config.llm_models import gpt_5_4_model
+from lib.models.agent import LangChainAgent
+from lib.workflows.context import ContextSchema
+
+
+class FieldProblemTypeV2(str, Enum):
+    CORRECT = "correct"
+    MISSING = "missing"
+    INCORRECT = "incorrect"
+    OTHER = "other"
+
+
+class FieldCategoryV2(str, Enum):
+    AUTHOR = "author"
+    TITLE = "title"
+    PUBLISHER = "publisher"
+    YEAR = "year"
+    IDENTIFIER = "identifier"
+
+
+class BibliographyFieldValidationV2(BaseModel):
+    category: FieldCategoryV2 = Field(
+        description=f"Category of the reference. Possible values: {[e.value for e in FieldCategoryV2]}"
+    )
+    current_value: str = Field(description="Current value of the reference.")
+    suggested_value: str = Field(description="Suggested value of the reference.")
+    problem_type: FieldProblemTypeV2 = Field(
+        description=f"Problem type of the reference. Must be CORRECT if the only differences are capitalization or minor punctuation. Possible values: {[e.value for e in FieldProblemTypeV2]}"
+    )
+
+
+class ReferenceValidationFinalResultV2(str, Enum):
+    # Green: every field was verified CORRECT against an authoritative source.
+    CORRECT = "correct"
+    # Yellow: at least one field is MISSING but no field is INCORRECT.
+    MISSING_FIELDS = "missing_fields"
+    # Red: at least one field is INCORRECT, OR the reference could not be found online.
+    INCORRECT_FIELDS = "incorrect_fields"
+
+
+class BibliographyItemValidationV2(BaseModel):
+    original_reference: str = Field(description="Original bibliographic item text.")
+    final_result: ReferenceValidationFinalResultV2 = Field(
+        description=f"Overall validation outcome. Possible values: {[e.value for e in ReferenceValidationFinalResultV2]}"
+    )
+    bibliography_field_validations: List[BibliographyFieldValidationV2] = Field(
+        description="List of reference field validations."
+    )
+    suggested_action: str = Field(
+        description="Suggested action to take if the reference is not valid. A summary of the suggested changes to make the reference valid. If the reference is valid, return 'No changes needed'."
+    )
+    url: str = Field(description="Found URL for the reference.")
+    reasoning: str = Field(
+        default="",
+        description="Step-by-step reasoning describing your approach to validate the reference.",
+    )
+    updated_reference: Optional[str] = Field(
+        default=None,
+        description="Updated reference with the suggested changes made to make the reference valid, matching the format of the original reference. If the reference is already valid, return null.",
+    )
+
+
+SYSTEM_PROMPT = """Validate a single bibliographic reference by finding the cited work online and comparing it to the reference. The next message contains the reference to validate — follow the six-step procedure below.
+
+# Step 1 — Parse the reference
+
+Read the reference and note:
+- What type of work it is (journal article, preprint, book, webpage, press release, government report, briefing slides, etc.).
+- Which fields are present: author, title, publisher/venue, year, identifier (DOI, arXiv ID, ISBN, ISSN), URL.
+
+Special case — bare URL: if the reference is only a URL with no bibliographic metadata, skip ahead to Step 6 with final_result `missing_fields`. Reconstruct the full citation from the URL's content and populate `updated_reference`. Mark all five field validations as MISSING except `identifier`, which may be the URL itself or MISSING.
+
+# Step 2 — Resolve the URL (if the reference contains one)
+
+Fetch the URL exactly as given. One of three outcomes:
+
+- URL resolves to real content that appears to match the reference → use that page as your primary authoritative source. Continue to Step 4.
+- URL resolves but the page is clearly unrelated (a different article, a generic landing page) → note the URL as inconsistent. Continue to Step 3 to search.
+- URL returns 404 or error → the URL is inconsistent or fabricated. Continue to Step 3.
+
+Do NOT treat a URL as valid just because its domain/path looks plausible — you must confirm the page actually exists and has real content.
+
+# Step 3 — Search the web for the cited work
+
+Search using the reference's title (quote distinctive phrases) together with a key author surname and/or year. For references with a DOI or arXiv ID, resolve the identifier first and use the canonical page — BUT if the resolved work's title clearly does not match the reference's title, treat the identifier as incorrect or fabricated and search by title instead. Do NOT accept an unrelated work as your candidate just because an identifier happened to resolve to it; when this happens, flag the identifier as INCORRECT in Step 5 and use the title-based candidate for the other fields.
+
+Pick the single best candidate that plausibly IS the cited work. If no candidate matches the cited title or authors, stop and go to Step 6 with `incorrect_fields` (a reference that cannot be located online is treated as a substantive issue).
+
+ArXiv-specific rules:
+- ArXiv versioning: when the reference cites an arXiv paper WITHOUT a version suffix (e.g., `arXiv:2311.16169` rather than `arXiv:2311.16169v1`), treat the MOST RECENT version on arXiv as authoritative — its title, author list, and most-recent submission year. When the reference explicitly pins a version (e.g., `arxiv.org/abs/2406.01637v1`), treat that version as authoritative instead.
+- ArXiv HTML view: URLs of the form `arxiv.org/html/...` sometimes contain rendering artifacts that produce incorrect-looking titles. Do not take the title from the HTML view. Prefer, in order: (a) the title from the official conference/journal publication if one exists, (b) the arXiv abstract page `arxiv.org/abs/...`, (c) the PDF.
+- ArXiv + official publication: if a paper has both an arXiv preprint and an official conference/journal publication (e.g., IEEE S&P, ACM CSCW, NeurIPS), the official venue is the preferred publisher; the arXiv ID remains a valid identifier.
+
+# Step 4 — Decide whether the candidate is the same work
+
+Before comparing fields, confirm the candidate source IS the cited work. Compare the candidate's title to the reference's title, ignoring case and punctuation:
+
+- Titles match in wording → it is the SAME WORK. Proceed to Step 5. (Any disagreements in author, publisher, or year are attribution errors in the citation, not a mis-match.)
+- Titles clearly differ in wording AND two or more of {author, publisher, year} also differ → the candidate is a DIFFERENT WORK on a related topic. Go to Step 6 with `incorrect_fields`. Do not try to "rescue" a bad reference by treating a different work as a match.
+- Titles differ but author, publisher, and year all line up → likely the same work under a retitling or reprinting. Treat as same work and continue to Step 5.
+
+# Step 5 — Compare each field
+
+For each of author, title, publisher, year, identifier, set `problem_type`:
+
+- CORRECT — the reference matches the authoritative source in substance. Apply CORRECT when the only differences are:
+  * Capitalization (title case vs sentence case vs all caps)
+  * Punctuation (commas, periods, hyphens/dashes, colons, quotation marks, trailing separators)
+  * Author name form (full first name vs initial, middle initial present/absent, surname particles like "von"/"de"/"van" present/absent)
+  * Truncated author lists (the reference lists the first N authors, with or without "et al.", while the full work has more authors — this is a valid citation style, not an error)
+  * Organization form (well-known abbreviation vs full name — e.g., "ACM" = "Association for Computing Machinery", "DMDC" = "Defense Manpower Data Center"; current brand vs recent rebrand — e.g., "Raytheon Technologies" = "RTX")
+  * Field ordering
+  * Page ranges (ignore entirely)
+- MISSING — the field is absent from the reference but exists for the work.
+- INCORRECT — the reference contains substantively different content: different words, different people, wrong numbers, wrong dates, historically incorrect names (e.g., a pre-1947 government title used to cite a modern agency).
+
+Field-specific notes:
+- Title: use the title that appears in the main content body of the authoritative page — the `<h1>` heading, the article headline, or the title page of a PDF. Do NOT use the browser tab `<title>` tag, the `og:title` social-sharing title, or a search-engine snippet — these are often shortened or sanitized. For PDF-linked articles, prefer the title inside the PDF.
+- Year: mark CORRECT when the cited year is within ±1 of the authoritative publication year. This tolerance covers the common arXiv-preprint vs. conference-publication off-by-one case and minor in-press/issue-date disagreements. Use INCORRECT only when the gap is larger than one year.
+- Publisher: substring matches and well-known abbreviations or shortened forms are CORRECT as long as a reader can still recognize the publisher (e.g. "ACM" = "Association for Computing Machinery", "Springer" = "Springer Nature", "MIT Press" = "The MIT Press"). Use INCORRECT only when the publisher names refer to different organizations.
+- Identifier: a DOI, arXiv ID, ISBN, or ISSN all qualify. If the reference includes one, check it resolves to the correct work. Accept equivalent forms: a URL that resolves to a persistent identifier (e.g., `https://doi.org/10.xxxx/...`, `https://dl.acm.org/doi/pdf/10.xxxx/...`, `https://arxiv.org/abs/...`) is equivalent to the bare identifier — do NOT flag the URL form as INCORRECT just because the bare DOI or arXiv ID is the canonical form. If the reference omits an identifier but one exists, mark MISSING. If no identifier exists at all, mark CORRECT with empty values. A missing DOI when an arXiv ID is already present is NOT an error.
+- Author for institutional works: when the publishing organization is listed as the author (press releases, homepages, government reports, briefing slides, datasets, policy directives), the org name is the author. Do not demand a list of individuals.
+
+# Step 6 — Decide the final result
+
+`final_result` is mechanical given the per-field `problem_type`s from Step 5. Apply in order:
+
+1. No candidate found, OR candidate is a different work (per Step 4) → `final_result = "incorrect_fields"`. A reference that cannot be located online is treated as a substantive (red) issue. Set `updated_reference = null`.
+2. Same work and at least one field has `problem_type = INCORRECT` → `final_result = "incorrect_fields"`. Populate `updated_reference` with the corrections applied, preserving the reference's original citation style.
+3. Same work, no INCORRECT fields, and at least one field has `problem_type = MISSING` → `final_result = "missing_fields"`. Populate `updated_reference` if there is a useful correction to suggest; otherwise set it to `null`.
+4. Same work and every field has `problem_type = CORRECT` → `final_result = "correct"`. Set `updated_reference = null`.
+
+All leniency belongs at the field level in Step 5 (case/punctuation, name forms, truncated author lists, organizational abbreviations, year ±1, publisher substring/abbreviation, identifier URL forms, missing-identifier-with-clear-venue). Apply that leniency when assigning each field's `problem_type`, then derive `final_result` mechanically from the rules above. Do NOT add any extra "default to correct on the boundary" softening at the result level.
+
+# Output fields
+
+- `original_reference` — the reference as given.
+- `final_result` — `correct` / `missing_fields` / `incorrect_fields`.
+- `bibliography_field_validations` — one entry per field with `current_value`, `suggested_value`, `problem_type`.
+- `url` — the URL identifying the cited work (from the reference, identifier resolution, or your search). Empty string when no candidate was found.
+- `reasoning` — a brief step-by-step summary of how you validated.
+- `suggested_action` — one sentence describing what to fix; `"No changes needed"` when `correct`.
+- `updated_reference` — corrected citation in the reference's original format when there are corrections to suggest (typically `missing_fields` or `incorrect_fields` for a found work); otherwise `null`.
+
+# Response hygiene
+
+Never include internal search tokens (e.g., `turn0search0`) or raw metadata markers in any output field. All text must be clean and human-readable."""
+
+
+class ReferenceValidatorV2Agent(LangChainAgent):
+    name = "Reference Validator V2"
+    description = "Validate a list of references in a document, by searching for their online presence."
+    model = gpt_5_4_model
+    temperature = 0.0
+    reasoning = {"effort": "low", "summary": "auto"}
+
+    async def ainvoke(
+        self,
+        prompt_kwargs: dict,
+        config: Optional[RunnableConfig] = None,
+    ) -> tuple[BibliographyItemValidationV2, list[BaseMessage]]:
+        agent = create_agent(
+            self.llm,
+            [{"type": "web_search"}],
+            context_schema=ContextSchema,
+            response_format=BibliographyItemValidationV2,
+        )
+
+        result = await agent.ainvoke(
+            {
+                "messages": [
+                    SystemMessage(content=SYSTEM_PROMPT),
+                    HumanMessage(content=prompt_kwargs["reference"]),
+                ]
+            },
+            config=config,
+            context=self.context,
+        )
+
+        return result["structured_response"], result["messages"]

--- a/lib/agents/reference_validator_v2.py
+++ b/lib/agents/reference_validator_v2.py
@@ -8,7 +8,7 @@ from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
-from lib.config.llm_models import gpt_5_4_model
+from lib.config.llm_models import gpt_5_5_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 
@@ -160,7 +160,7 @@ Never include internal search tokens (e.g., `turn0search0`) or raw metadata mark
 class ReferenceValidatorV2Agent(LangChainAgent):
     name = "Reference Validator V2"
     description = "Validate a list of references in a document, by searching for their online presence."
-    model = gpt_5_4_model
+    model = gpt_5_5_model
     temperature = 0.0
     reasoning = {"effort": "low", "summary": "auto"}
 

--- a/lib/config/llm_models.py
+++ b/lib/config/llm_models.py
@@ -56,6 +56,7 @@ gpt_5_1_model = LLMModel(provider="openai", name="gpt-5.1")
 gpt_4_1_model = LLMModel(provider="openai", name="gpt-4.1")
 gpt_5_2_model = LLMModel(provider="openai", name="gpt-5.2")
 gpt_5_4_model = LLMModel(provider="openai", name="gpt-5.4")
+gpt_5_5_model = LLMModel(provider="openai", name="gpt-5.5")
 
 # Anthropic models
 claude_3_5_sonnet_model = LLMModel(
@@ -75,6 +76,7 @@ ALL_MODELS = {
     "gpt-5.2": gpt_5_2_model,
     "gpt-4.1": gpt_4_1_model,
     "gpt-5.4": gpt_5_4_model,
+    "gpt-5.5": gpt_5_5_model,
     "claude-sonnet-4-5-20250929": claude_3_5_sonnet_model,
     "gemini-2.5-flash-lite": gemini_2_flash_model,
 }

--- a/lib/workflows/categories.py
+++ b/lib/workflows/categories.py
@@ -24,7 +24,8 @@ WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
         slug="citation_check",
         label="Citation Check",
         workflows=[
-            WorkflowRunType.REFERENCE_VALIDATION,
+            # WorkflowRunType.REFERENCE_VALIDATION,  # legacy v1; kept registered so old projects still load.
+            WorkflowRunType.REFERENCE_VALIDATION_V2,
         ],
     ),
     CategoryConfig(

--- a/lib/workflows/models.py
+++ b/lib/workflows/models.py
@@ -82,6 +82,7 @@ class WorkflowRunType(str, Enum):
     LITERATURE_REVIEW = "literature_review"
     LIVE_REPORTS = "live_reports"
     REFERENCE_VALIDATION = "reference_validation"
+    REFERENCE_VALIDATION_V2 = "reference_validation_v2"
     CITATION_SUGGESTER = "citation_suggester"
     RESULTS_EXTRACTION = "results_extraction"
     INFERENCE_VALIDATION = "inference_validation"

--- a/lib/workflows/reference_validation_v2/graph.py
+++ b/lib/workflows/reference_validation_v2/graph.py
@@ -1,0 +1,27 @@
+from langgraph.graph import StateGraph
+
+from lib.workflows.context import ContextSchema
+from lib.workflows.reference_validation_v2.nodes.reference_validation import (
+    distribute_validations,
+    finalize_validations,
+    initialize_validations,
+    validate_single_reference,
+)
+from lib.workflows.reference_validation_v2.state import ReferenceValidationV2State
+
+
+def build_reference_validation_v2_graph() -> StateGraph:
+    """Build a LangGraph workflow for reference validation v2 with incremental updates."""
+    graph = StateGraph(ReferenceValidationV2State, context_schema=ContextSchema)
+
+    graph.add_node("initialize_validations", initialize_validations)
+    graph.add_node("distribute_validations", distribute_validations)
+    graph.add_node("validate_single_reference", validate_single_reference)
+    graph.add_node("finalize_validations", finalize_validations)
+
+    graph.set_entry_point("initialize_validations")
+    graph.add_conditional_edges("initialize_validations", distribute_validations)
+    graph.add_edge("validate_single_reference", "finalize_validations")
+    graph.set_finish_point("finalize_validations")
+
+    return graph  # type: ignore[return-value]

--- a/lib/workflows/reference_validation_v2/manifest.py
+++ b/lib/workflows/reference_validation_v2/manifest.py
@@ -1,0 +1,137 @@
+from typing import List, Type, cast
+
+from langgraph.graph import StateGraph
+from langgraph.graph.state import CompiledStateGraph, RunnableConfig
+
+from lib.agents.reference_validator_v2 import ReferenceValidationFinalResultV2
+from lib.workflows.manifest import WorkflowManifest
+from lib.workflows.models import DocumentIssue, SeverityEnum, WorkflowRunType
+from lib.workflows.reference_extraction.state import ReferenceExtractionState
+from lib.workflows.reference_validation_v2.graph import (
+    build_reference_validation_v2_graph,
+)
+from lib.workflows.reference_validation_v2.state import (
+    ReferenceValidationV2State,
+    ReferenceValidationV2Status,
+    ReferenceValidationV2WorkflowConfig,
+)
+from lib.workflows.workflow_types import WorkflowState
+from lib.workflows.util import get_state_by_type
+
+
+_FINAL_RESULT_SEVERITY: dict[ReferenceValidationFinalResultV2, SeverityEnum] = {
+    ReferenceValidationFinalResultV2.CORRECT: SeverityEnum.NONE,
+    ReferenceValidationFinalResultV2.MISSING_FIELDS: SeverityEnum.MEDIUM,
+    ReferenceValidationFinalResultV2.INCORRECT_FIELDS: SeverityEnum.HIGH,
+}
+
+_FINAL_RESULT_TITLE: dict[ReferenceValidationFinalResultV2, str] = {
+    ReferenceValidationFinalResultV2.CORRECT: "Valid reference",
+    ReferenceValidationFinalResultV2.MISSING_FIELDS: "Reference is missing fields",
+    ReferenceValidationFinalResultV2.INCORRECT_FIELDS: "Reference has incorrect fields",
+}
+
+
+class ReferenceValidationV2Manifest(
+    WorkflowManifest[ReferenceValidationV2State, ReferenceValidationV2WorkflowConfig]
+):
+    type = WorkflowRunType.REFERENCE_VALIDATION_V2
+    name = "Reference Error Checker"
+    description = "Are your references accurate? Uses web search to check each citation exists online and that the author, title, publisher, and year match public sources. Useful for catching typos or hallucinated references."
+    needs_web_search = True
+    required_dependencies = [WorkflowRunType.REFERENCE_EXTRACTION]
+
+    def get_state_type(self) -> Type[ReferenceValidationV2State]:
+        return ReferenceValidationV2State
+
+    def get_config_type(self) -> Type[ReferenceValidationV2WorkflowConfig]:
+        return ReferenceValidationV2WorkflowConfig
+
+    def build_graph(self) -> StateGraph:
+        return build_reference_validation_v2_graph()
+
+    async def on_cancel(
+        self,
+        state: ReferenceValidationV2State,
+        app: CompiledStateGraph,
+        config: RunnableConfig,
+    ) -> None:
+        """Mark any pending validation items as cancelled so they don't show as in-progress."""
+        updated = [
+            (
+                item.model_copy(
+                    update={"status": ReferenceValidationV2Status.CANCELLED}
+                )
+                if item.status == ReferenceValidationV2Status.PENDING
+                else item
+            )
+            for item in state.reference_validations
+        ]
+        await app.aupdate_state(
+            config, {"reference_validations": updated}, as_node="finalize_validations"
+        )
+
+    async def create_initial_state(
+        self,
+        config: ReferenceValidationV2WorkflowConfig,
+        existing_states: List[WorkflowState],
+        revision: int,
+    ) -> ReferenceValidationV2State:
+        return ReferenceValidationV2State(
+            type=WorkflowRunType.REFERENCE_VALIDATION_V2,
+            config=config,
+        )
+
+    def convert_state_to_issues(
+        self, state: ReferenceValidationV2State, other_states: List[WorkflowState]
+    ) -> List[DocumentIssue]:
+        """Convert ReferenceValidationV2State to issues."""
+
+        issues: List[DocumentIssue] = []
+
+        ref_extraction_state = get_state_by_type(
+            WorkflowRunType.REFERENCE_EXTRACTION, other_states
+        )
+        ref_extraction_state = (
+            cast(ReferenceExtractionState, ref_extraction_state)
+            if ref_extraction_state
+            else None
+        )
+
+        ref_by_id = (
+            {ref.id: ref for ref in ref_extraction_state.extracted_references}
+            if ref_extraction_state
+            else {}
+        )
+
+        for validation in state.reference_validations:
+            if validation.status != ReferenceValidationV2Status.COMPLETED:
+                continue
+
+            if validation.validation_result is None:
+                continue
+
+            result = validation.validation_result
+            ref = ref_by_id.get(validation.reference_id)
+            severity = _FINAL_RESULT_SEVERITY[result.final_result]
+            title = _FINAL_RESULT_TITLE[result.final_result]
+
+            field_validations = "\n\n".join(
+                [
+                    f"- **{item.category.value.capitalize()}**: {item.problem_type.value.capitalize()}\n\n\t*Current*: {item.current_value or "-"}\n\n\t*Suggested*: {item.suggested_value}"
+                    for item in result.bibliography_field_validations
+                ]
+            )
+
+            issue = DocumentIssue(
+                title=title,
+                description=f"> {result.original_reference}\n\n{result.suggested_action}",
+                severity=severity,
+                type=self.type,
+                start_line=ref.start_line if ref else None,
+                end_line=ref.end_line if ref else None,
+                long_description=f"{f'### Suggested updated reference\n\n> {result.updated_reference}' if result.updated_reference else ''}\n\n### Field validations\n\n{field_validations}\n\n### Reasoning\n\n{result.reasoning}",
+            )
+            issues.append(issue)
+
+        return issues

--- a/lib/workflows/reference_validation_v2/nodes/reference_validation.py
+++ b/lib/workflows/reference_validation_v2/nodes/reference_validation.py
@@ -1,0 +1,100 @@
+import logging
+from typing import List
+
+from langchain_core.messages import BaseMessage
+from langgraph.runtime import Runtime
+from langgraph.types import Overwrite, Send
+
+from lib.agents.reference_validator_v2 import ReferenceValidatorV2Agent
+from lib.workflows.context import ContextSchema
+from lib.workflows.decorators import register_node
+from lib.workflows.reference_validation_v2.state import (
+    ReferenceValidationV2Item,
+    ReferenceValidationV2State,
+    ReferenceValidationV2Status,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@register_node("Initialize validations")
+async def initialize_validations(
+    state: ReferenceValidationV2State, runtime: Runtime[ContextSchema]
+):
+    """Initialize all references with PENDING status immediately."""
+    file_artifacts_service = runtime.context.file_artifacts_service
+    references = await file_artifacts_service.get_extracted_references()
+
+    pending_results = [
+        ReferenceValidationV2Item(
+            reference_id=ref.id,
+            input_reference=ref.text,
+            status=ReferenceValidationV2Status.PENDING,
+        )
+        for ref in references
+    ]
+
+    return {"reference_validations": Overwrite(pending_results)}
+
+
+@register_node("Distribute validations")
+async def distribute_validations(
+    state: ReferenceValidationV2State, runtime: Runtime[ContextSchema]
+):
+    """Fan-out node: creates a Send for each reference."""
+    return [
+        Send(
+            "validate_single_reference",
+            {
+                "reference_id": item.reference_id,
+                "input_reference": item.input_reference,
+            },
+        )
+        for item in state.reference_validations
+    ]
+
+
+@register_node("Validate reference")
+async def validate_single_reference(state: dict, runtime: Runtime[ContextSchema]):
+    """Process a single reference and return status update."""
+    reference_id = state["reference_id"]
+    input_reference = state["input_reference"]
+
+    agent = ReferenceValidatorV2Agent(runtime.context)
+
+    validation_result = None
+    error = None
+    status = ReferenceValidationV2Status.COMPLETED
+    agent_messages: List[BaseMessage] = []
+
+    try:
+        validation_result, agent_messages = await agent.ainvoke(
+            {"reference": input_reference}
+        )
+    except Exception as e:
+        logger.error(
+            f"Error validating reference '{input_reference}': {e}", exc_info=True
+        )
+        status = ReferenceValidationV2Status.ERROR
+        error = str(e)
+
+    return {
+        "reference_validations": [
+            ReferenceValidationV2Item(
+                reference_id=reference_id,
+                input_reference=input_reference,
+                status=status,
+                validation_result=validation_result,
+                error=error,
+                messages=agent_messages,
+            )
+        ]
+    }
+
+
+@register_node("Finalize validations")
+async def finalize_validations(
+    state: ReferenceValidationV2State, runtime: Runtime[ContextSchema]
+):
+    """Finalize validation results after all parallel validations complete."""
+    return {}

--- a/lib/workflows/reference_validation_v2/state.py
+++ b/lib/workflows/reference_validation_v2/state.py
@@ -1,0 +1,78 @@
+from enum import Enum
+from typing import Annotated, List, Literal, Optional
+
+from langchain_core.messages import BaseMessage
+from pydantic import BaseModel, Field, field_serializer
+
+from lib.agents.reference_validator_v2 import BibliographyItemValidationV2
+from lib.workflows.models import BaseWorkflowConfig, BaseWorkflowState, WorkflowRunType
+
+
+class ReferenceValidationV2Status(str, Enum):
+    """Status of a reference validation operation"""
+
+    PENDING = "pending"
+    COMPLETED = "completed"
+    ERROR = "error"
+    CANCELLED = "cancelled"
+
+
+class ReferenceValidationV2WorkflowConfig(BaseWorkflowConfig):
+    """Configuration model for the reference validation v2 workflow."""
+
+    type: Literal[WorkflowRunType.REFERENCE_VALIDATION_V2] = Field(
+        WorkflowRunType.REFERENCE_VALIDATION_V2
+    )
+
+
+class ReferenceValidationV2Item(BaseModel):
+    """Item for tracking individual reference validation with status"""
+
+    reference_id: str = Field(description="The ID of the reference to validate.")
+    input_reference: str = Field(description="The original reference text.")
+    status: ReferenceValidationV2Status = Field(
+        default=ReferenceValidationV2Status.PENDING,
+        description="Current status of this reference validation.",
+    )
+    validation_result: Optional[BibliographyItemValidationV2] = Field(
+        default=None,
+        description="The validation result for the reference, present on success.",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message, present on failure.",
+    )
+    messages: List[BaseMessage] = Field(
+        default_factory=list,
+        description="LLM conversation messages from the agent invocation.",
+    )
+
+    @field_serializer("messages")
+    @classmethod
+    def _serialize_messages(cls, messages: List[BaseMessage]) -> list[dict]:
+        return [m.model_dump() for m in messages]
+
+
+def merge_validation_results(
+    existing: List[ReferenceValidationV2Item],
+    new: List[ReferenceValidationV2Item],
+) -> List[ReferenceValidationV2Item]:
+    """Reducer to merge results by reference_id, preserving order."""
+    results_by_id = {r.reference_id: r for r in existing}
+
+    for item in new:
+        results_by_id[item.reference_id] = item
+
+    return list(results_by_id.values())
+
+
+class ReferenceValidationV2State(BaseWorkflowState):
+    """State for the reference validation v2 workflow."""
+
+    type: Literal[WorkflowRunType.REFERENCE_VALIDATION_V2] = Field(
+        WorkflowRunType.REFERENCE_VALIDATION_V2
+    )
+    config: ReferenceValidationV2WorkflowConfig
+    reference_validations: Annotated[
+        List[ReferenceValidationV2Item], merge_validation_results
+    ] = Field(default_factory=list)

--- a/lib/workflows/registry.py
+++ b/lib/workflows/registry.py
@@ -92,6 +92,9 @@ def register_all_workflow_manifests():
         ReferenceFileMatchingManifest,
     )
     from lib.workflows.reference_validation.manifest import ReferenceValidationManifest
+    from lib.workflows.reference_validation_v2.manifest import (
+        ReferenceValidationV2Manifest,
+    )
     from lib.workflows.results_extraction.manifest import ResultsExtractionManifest
     from lib.workflows.reviewer_2.manifest import Reviewer2Manifest
 
@@ -115,6 +118,7 @@ def register_all_workflow_manifests():
         MethodologicalAlignmentManifest(),
         ReferenceDownloaderManifest(),
         ReferenceValidationManifest(),
+        ReferenceValidationV2Manifest(),
         ResultsExtractionManifest(),
         AdvocacyToneManifest(),
         AboutThisGerManifest(),

--- a/lib/workflows/workflow_types.py
+++ b/lib/workflows/workflow_types.py
@@ -83,6 +83,10 @@ from lib.workflows.reference_validation.state import (
     ReferenceValidationState,
     ReferenceValidationWorkflowConfig,
 )
+from lib.workflows.reference_validation_v2.state import (
+    ReferenceValidationV2State,
+    ReferenceValidationV2WorkflowConfig,
+)
 from lib.workflows.results_extraction.state import (
     ResultsExtractionState,
     ResultsExtractionWorkflowConfig,
@@ -111,6 +115,7 @@ WorkflowState = (
     | LiteratureReviewState
     | LiveReportsState
     | ReferenceValidationState
+    | ReferenceValidationV2State
     | CitationSuggesterState
     | ResultsExtractionState
     | InferenceValidationV2State
@@ -138,6 +143,7 @@ WorkflowConfig = (
     | LiteratureReviewWorkflowConfig
     | LiveReportsWorkflowConfig
     | ReferenceValidationWorkflowConfig
+    | ReferenceValidationV2WorkflowConfig
     | CitationSuggesterWorkflowConfig
     | ResultsExtractionWorkflowConfig
     | InferenceValidationV2WorkflowConfig


### PR DESCRIPTION
## Summary

Introduces `reference_validation_v2`, a new version of the Reference Error Checker workflow that adopts the 3-tier severity scheme decided at the Apr 17 demo (red = incorrect fields, yellow = missing fields, green = all correct) and refined field-match rules. The legacy v1 workflow is kept registered so existing projects keep loading, but is hidden from the workflow picker. New projects only see v2. The v2 agent defaults to `gpt-5.5`.

Linear: [RANDZ-539](https://linear.app/ae-studio/issue/RANDZ-539/reference-validator-new-severity-tiers-redyellowgreen-refined-field)

## Motivation

Users read red as "must fix" and yellow as "suggestion," but v1 grouped *incorrect fields* (reputational risk) with merely *missing fields* under one yellow tier. Splitting them required a new agent enum and a new severity mapping. Doing this as a v2 (rather than mutating v1 in place) was needed because old stored workflow state still references the old enum values and would otherwise fail to deserialize.

The new tiers are derived mechanically from per-field `problem_type`s in Step 6, with all leniency moved to the field level in Step 5:
- **Year**: ±1 year (covers arXiv-vs-conference off-by-one and minor in-press disagreements).
- **Publisher**: substring matches and well-known abbreviations are CORRECT (e.g. "ACM" = "Association for Computing Machinery").
- **Title / Author / Identifier**: existing v1 leniency preserved.
- `not_found` is folded into red (`incorrect_fields`) — a reference we cannot locate is treated as a substantive issue.

## Eval results

A 70-sample / 1-epoch comparison of model defaults:

| Scorer | gpt-5.4 | gpt-5.5 |
|---|---|---|
| structured_output_scorer (exact `final_result` match) | 0.729 ± 0.054 | 0.757 ± 0.052 |
| model_graded_check (qualitative) | 0.750 ± 0.038 | 0.793 ± 0.034 |

Per-tier (gpt-5.5): green 26/41 (63%), yellow 4/4 (100%), red 23/25 (92%). Token cost and latency identical between the two models. The remaining green-tier gap matches pre-known false-positive samples already flagged in the dataset notes — to be addressed in a follow-up tuning pass. The v2 agent now defaults to `gpt-5.5`.

## What's Changed

### Backend
- `lib/workflows/models.py` — adds `WorkflowRunType.REFERENCE_VALIDATION_V2`.
- `lib/agents/reference_validator_v2.py` — new agent class (`gpt-5.5` default) with `BibliographyItemValidationV2`, `ReferenceValidationFinalResultV2` (correct / missing_fields / incorrect_fields), and the rewritten Step 5/6 prompt (year ±1, publisher substring, mechanical result derivation).
- `lib/config/llm_models.py` — registers `gpt_5_5_model`.
- `lib/workflows/reference_validation_v2/` (state, manifest, graph, nodes) — mirrors v1 but typed against the v2 enum and state, with severity mapping NONE / MEDIUM / HIGH for green / yellow / red.
- `lib/workflows/registry.py` — registers `ReferenceValidationV2Manifest` alongside v1.
- `lib/workflows/categories.py` — Citation Check now lists v2; v1 is commented out (still registered, just not pickable).
- `lib/workflows/workflow_types.py` — adds the v2 state + config to the `WorkflowState` / `WorkflowConfig` unions so the OpenAPI schema exports them.

### Frontend
- `frontend/lib/generated-api/types.gen.ts` — regenerated; adds `ReferenceValidationFinalResultV2`, `BibliographyItemValidationV2`, `ReferenceValidationV2State`, etc., next to the unchanged v1 types.
- `frontend/components/results/tabs/reference-review/validation-results-box-v2.tsx` — new component with 3-tier color/badge mapping and per-field problem-type colors (red for incorrect, yellow for missing).
- `frontend/components/workflows/results/reference-validation-v2-results.tsx` — new results page; filters/badges named Correct / Missing Fields / Incorrect Fields.
- `frontend/components/results/tabs/workflow-results-renderer.tsx` — dispatches `ReferenceValidationV2` to the new component; v1 keeps rendering through the unchanged `ReferenceValidationResults`.
- `frontend/components/workflows/workflow-type-checkbox.tsx` — adds an icon entry for `ReferenceValidationV2`.

### Evals
- `evals_inspectai/internal/reference_validation/reference_validation.py` — imports `ReferenceValidatorV2Agent` / `BibliographyItemValidationV2`.
- `evals_inspectai/e2e/reference_validation/reference_validation_e2e.py` — solver targets `"reference_validation_v2"`.
- `evals_inspectai/e2e/reference_validation/dataset.json` — `target_final_result` translated to the new vocabulary (41 correct / 4 missing_fields / 25 incorrect_fields).

## Risks and Mitigations

- **Old projects failing to load** — the original motivation for the v2 split. Mitigated by leaving `lib/workflows/reference_validation/`, the v1 agent, and the v1 frontend components untouched. Old stored states deserialize through the unchanged v1 enum; the workflow-results-renderer still dispatches them to the v1 component.
- **OpenAPI schema duplication** — both v1 and v2 schemas are now exported. Verified with `pnpm tsc --noEmit` (clean) and `pnpm run openapi-generate` (both enums present).
- **Dataset target labels** — translated mechanically; a couple of "year is incorrect" labels (e.g. Vermeer RAND 2019 off by exactly 1) may now be more correctly labeled `missing_fields` under the new ±1 rule, which would surface as eval misses against the conservative `incorrect_fields` target. Worth reviewing in a follow-up tuning pass.
- **Picker visibility** — v1 is removed from `categories.py` so it can't be chosen for new runs, but the manifest stays registered. If we later want to fully retire v1, that can be a separate cleanup PR.
- **Model upgrade to gpt-5.5** — only affects v2; v1 still uses gpt-5.4. Eval comparison showed +3pp on both scorers with identical cost/latency.

## Test plan

- [ ] `uv run mypy .` — clean (verified locally, 347 files)
- [ ] `pnpm tsc --noEmit` — clean (verified locally)
- [ ] `uv run pytest tests/unit/workflows/` — passing (30/30 verified locally)
- [ ] Open an old project that already has `reference_validation` results and confirm they load and render with the legacy yellow-inconsistencies UI
- [ ] Create a new project, pick "Reference Error Checker", confirm it runs `reference_validation_v2` and renders red/yellow/green tiers
- [ ] Run a reference with one incorrect field → red; reference with only missing fields → yellow; valid reference → green
- [ ] Run `uv run inspect eval evals_inspectai/e2e/reference_validation/reference_validation_e2e.py --limit=3` against a dev backend to verify v2 e2e wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)