### PR TITLE
fix(ci): grant claude-review write access to PRs and issues

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## Summary

- Bumps `pull-requests` and `issues` from `read` to `write` in the `claude-review` workflow so the action can actually publish its review back to the PR.

## Motivation

On PR #533 the `claude-review` job reports success but no review or comments appear on the PR (`gh pr view 533 --json reviews,comments` → `{"comments":[],"reviews":[]}`). The Claude run itself completes cleanly (14 turns, ~4m, `is_error: false`), but the SDK result shows **`permission_denials_count: 16`** and the follow-up step logs **`No buffered inline comments`** — every attempted write to the PR was blocked.

The cause is the workflow's own permission block: with `pull-requests: read` and `issues: read`, the GITHUB_TOKEN cannot create reviews, post review comments, or add issue comments. The action runs Claude fine, but has no scope to write the output back. Granting `write` on both lets the post step publish the review.

`contents` stays at `read` (the action only needs to read code), and `id-token: write` is unchanged.

## What's Changed

### CI

- `.github/workflows/claude-code-review.yml` — `pull-requests: read` → `write`, `issues: read` → `write`.

## Risks and Mitigations

- **Risk:** Wider token scope on PR events. **Mitigation:** the job is already gated by `author_association` (OWNER/MEMBER/COLLABORATOR), so external contributors' PRs do not run it. The action uses the standard GITHUB_TOKEN, scoped to this repo only.
- **Risk:** The action posts unwanted comments. **Mitigation:** this is exactly the intended behavior of `claude-code-action@v1` for code review; the previous read-only config was a misconfiguration that silently suppressed all output.

## Test plan

- [ ] Merge and confirm a follow-up PR shows a Claude review summary and/or inline comments posted by the action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)