### PR TITLE
fix(evals): handle solver timeouts gracefully across all e2e evals

### DIFF
--- a/evals_inspectai/common/api_solver.py
+++ b/evals_inspectai/common/api_solver.py
@@ -12,6 +12,7 @@ from evals_inspectai.common.api_client import (
     upload_and_start_analysis,
 )
 from evals_inspectai.common.converters import messages_from_langchain
+from evals_inspectai.common.errors import WorkflowCompletionError
 
 logger = logging.getLogger(__name__)
 
@@ -40,12 +41,15 @@ def api_workflow_agent(
             workflow_types=[workflow_type],
         )
 
-        run_detail = await poll_until_complete(
-            project_id=project_id,
-            workflow_type=workflow_type,
-            timeout_s=timeout_s,
-            interval_s=poll_interval_s,
-        )
+        try:
+            run_detail = await poll_until_complete(
+                project_id=project_id,
+                workflow_type=workflow_type,
+                timeout_s=timeout_s,
+                interval_s=poll_interval_s,
+            )
+        except TimeoutError as e:
+            raise WorkflowCompletionError(str(e)) from e
 
         workflow_state = run_detail.get("state") or {}
 

--- a/evals_inspectai/e2e/abbreviation_checker/abbreviation_checker_e2e.py
+++ b/evals_inspectai/e2e/abbreviation_checker/abbreviation_checker_e2e.py
@@ -46,6 +46,7 @@ def abbreviation_checker_e2e():
     return Task(
         # TODO: allow model to be specified dynamically / via api config
         dataset=dataset,
+        fail_on_error=0.2,
         solver=api_workflow_agent("abbreviation_scan_v2"),
         scorer=[
             structured_output_scorer(

--- a/evals_inspectai/e2e/citation_detection/citation_detection_e2e.py
+++ b/evals_inspectai/e2e/citation_detection/citation_detection_e2e.py
@@ -58,6 +58,7 @@ def citation_detection_e2e():
 
     return Task(
         dataset=dataset,
+        fail_on_error=0.2,
         solver=api_workflow_agent("citation_detection"),
         scorer=structured_output_scorer(CitationDetectionOutput, _compare_citations),
     )

--- a/evals_inspectai/e2e/document_structure/document_structure_e2e.py
+++ b/evals_inspectai/e2e/document_structure/document_structure_e2e.py
@@ -29,6 +29,7 @@ def document_structure_e2e():
 
     return Task(
         dataset=dataset,
+        fail_on_error=0.2,
         solver=api_workflow_agent("document_structure"),
         scorer=[
             structured_output_scorer(SimpleDeepAgentOutput, _compare_issue_titles),

--- a/evals_inspectai/e2e/figures_tables_check/figures_tables_check_e2e.py
+++ b/evals_inspectai/e2e/figures_tables_check/figures_tables_check_e2e.py
@@ -29,7 +29,8 @@ def figures_tables_check_e2e():
 
     return Task(
         dataset=dataset,
-        solver=api_workflow_agent("figures_tables_check"),
+        fail_on_error=0.2,
+        solver=api_workflow_agent("figures_tables_check", timeout_s=600),
         scorer=[
             structured_output_scorer(SimpleDeepAgentOutput, _compare_issue_titles),
             model_graded_check(partial_credit=True),

--- a/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
+++ b/evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py
@@ -61,6 +61,7 @@ def reference_downloader_e2e():
 
     return Task(
         dataset=dataset,
+        fail_on_error=0.2,
         solver=_reference_downloader_api_agent(),
         scorer=structured_output_scorer(
             ReferenceDownloaderOutput, _compare_final_conclusion
@@ -92,11 +93,14 @@ def _reference_downloader_api_agent(
             }
         )
 
-        run_detail = await poll_workflow_run_until_complete(
-            workflow_run_id,
-            timeout_s=timeout_s,
-            interval_s=poll_interval_s,
-        )
+        try:
+            run_detail = await poll_workflow_run_until_complete(
+                workflow_run_id,
+                timeout_s=timeout_s,
+                interval_s=poll_interval_s,
+            )
+        except TimeoutError as e:
+            raise WorkflowCompletionError(str(e)) from e
 
         workflow_state = run_detail.get("state") or {}
         _check_item_errors(workflow_state)

--- a/evals_inspectai/e2e/reference_text_extractor/reference_text_extractor_e2e.py
+++ b/evals_inspectai/e2e/reference_text_extractor/reference_text_extractor_e2e.py
@@ -45,6 +45,7 @@ def reference_text_extractor_e2e():
 
     return Task(
         dataset=dataset,
+        fail_on_error=0.2,
         solver=api_workflow_agent("reference_extraction"),
         scorer=[
             structured_output_scorer(ReferenceExtractionOutput, _compare_references),

--- a/evals_inspectai/e2e/reference_validation/reference_validation_e2e.py
+++ b/evals_inspectai/e2e/reference_validation/reference_validation_e2e.py
@@ -69,6 +69,7 @@ def reference_validation_e2e():
 
     return Task(
         dataset=dataset,
+        fail_on_error=0.2,
         solver=api_workflow_agent(
             "reference_validation",
         ),


### PR DESCRIPTION
## Summary
- Timeout errors in e2e eval solvers now surface as recorded sample errors instead of crashing the whole eval or producing a cryptic warning.
- All e2e evals will now continue running when up to 20% of samples fail.

## Motivation
Running e2e evals against longer eval cases was producing an "Unexpected timeout error reached top of sample stack" warning from Inspect AI, and any timed-out sample would abort the entire eval task. This made evals fragile for slow workflows and gave no signal about which samples actually failed.

## What's Changed

### Backend
- `evals_inspectai/common/api_solver.py`: Catch `TimeoutError` from `poll_until_complete` and re-raise as `WorkflowCompletionError`, so Inspect AI records it as a sample error rather than propagating it as an unhandled exception
- `evals_inspectai/e2e/reference_downloader/reference_downloader_e2e.py`: Same fix applied to `_reference_downloader_api_agent`, which has its own custom polling loop using `poll_workflow_run_until_complete`
- `evals_inspectai/e2e/figures_tables_check/figures_tables_check_e2e.py`: Increased solver `timeout_s` from 300s to 600s, as figures/tables workflows on real documents regularly exceed the previous limit
- All 7 e2e eval `Task` definitions: Added `fail_on_error=0.2`, so evals continue running when up to 20% of samples error out, and only abort if errors exceed that threshold

### Frontend
No frontend changes.

## Risks and Mitigations
- `fail_on_error=0.2` can still be overridden per-run from the CLI with `--fail-on-error` if stricter or looser behavior is needed.
- The 600s timeout for figures/tables is a conservative estimate; if workflows consistently exceed it, it can be raised further.