### PR TITLE
feat(evals): inspectai evals (internal + e2e) for claim_reference_validation_v2

### DIFF
--- a/evals_inspectai/common/api_client.py
+++ b/evals_inspectai/common/api_client.py
@@ -66,35 +66,124 @@ async def upload_and_start_analysis(
     file_content: str,
     workflow_types: list[str],
     file_name: str = "document.md",
+    supporting_files: list[tuple[str, str]] | None = None,
 ) -> str:
     """Upload a document and start analysis workflows.
+
+    Args:
+        file_content: Markdown content of the main document.
+        workflow_types: Workflow types to trigger (dependencies are auto-resolved
+            server-side; pass only the leaf workflow).
+        file_name: Display name for the main document.
+        supporting_files: Optional list of (file_name, markdown_content) tuples
+            uploaded alongside the main document as multipart `supporting_documents`.
 
     Returns the project_id.
     """
     async with _build_client() as client:
-        with tempfile.NamedTemporaryFile(suffix=".md", mode="w", delete=False) as tmp:
-            tmp.write(file_content)
-            tmp_path = tmp.name
-
+        tmp_paths: list[str] = []
+        open_handles: list[Any] = []
         try:
-            with open(tmp_path, "rb") as f:
-                files = {"main_document": (file_name, f, "text/markdown")}
-                data: dict[str, Any] = {}
-                for wt in workflow_types:
-                    data.setdefault("workflow_types", []).append(wt)
+            with tempfile.NamedTemporaryFile(
+                suffix=".md", mode="w", delete=False
+            ) as tmp:
+                tmp.write(file_content)
+                main_path = tmp.name
+            tmp_paths.append(main_path)
 
-                openai_api_key = os.environ.get("EVAL_API_OPENAI_API_KEY")
-                if openai_api_key:
-                    data["openai_api_key"] = openai_api_key
+            multipart: list[tuple[str, tuple[str, Any, str]]] = []
+            main_handle = open(main_path, "rb")
+            open_handles.append(main_handle)
+            multipart.append(
+                ("main_document", (file_name, main_handle, "text/markdown"))
+            )
 
-                resp = await client.post("/api/start-analysis", files=files, data=data)
+            for sf_name, sf_content in supporting_files or []:
+                with tempfile.NamedTemporaryFile(
+                    suffix=".md", mode="w", delete=False
+                ) as tmp_sf:
+                    tmp_sf.write(sf_content)
+                    sf_path = tmp_sf.name
+                tmp_paths.append(sf_path)
+                handle = open(sf_path, "rb")
+                open_handles.append(handle)
+                multipart.append(
+                    ("supporting_documents", (sf_name, handle, "text/markdown"))
+                )
+
+            data: dict[str, Any] = {}
+            for wt in workflow_types:
+                data.setdefault("workflow_types", []).append(wt)
+
+            openai_api_key = os.environ.get("EVAL_API_OPENAI_API_KEY")
+            if openai_api_key:
+                data["openai_api_key"] = openai_api_key
+
+            resp = await client.post(
+                "/api/start-analysis", files=multipart, data=data
+            )
         finally:
-            os.unlink(tmp_path)
+            for h in open_handles:
+                h.close()
+            for p in tmp_paths:
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
 
         resp.raise_for_status()
         body = resp.json()
         logger.info("Started analysis, project_id=%s", body["project_id"])
         return body["project_id"]
+
+
+async def approve_workflow_run(workflow_run_id: str) -> None:
+    """Trigger the human-approval gate for a workflow run."""
+    async with _build_client() as client:
+        resp = await client.post(
+            f"/api/workflow-runs/{workflow_run_id}/approve"
+        )
+        resp.raise_for_status()
+        logger.info("Approved workflow_run_id=%s", workflow_run_id)
+
+
+async def find_workflow_run_by_type(
+    project_id: str, workflow_type: str
+) -> dict[str, Any] | None:
+    """Return the most recent run-detail dict for the given workflow type, or None."""
+    project = await get_project_detail(project_id)
+    for run_detail in project.get("workflow_runs", []):
+        run = run_detail.get("run", {})
+        if run.get("type") == workflow_type:
+            return run_detail
+    return None
+
+
+async def poll_until_status(
+    project_id: str,
+    workflow_type: str,
+    target_statuses: set[str],
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+    interval_s: float = DEFAULT_POLL_INTERVAL_S,
+) -> dict[str, Any]:
+    """Poll the project until a run of the given type reaches one of the target statuses."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        detail = await find_workflow_run_by_type(project_id, workflow_type)
+        if detail:
+            status = detail.get("run", {}).get("status")
+            if status in target_statuses:
+                logger.info(
+                    "Workflow %s reached status=%s",
+                    workflow_type,
+                    status,
+                )
+                return detail
+        await asyncio.sleep(interval_s)
+    raise TimeoutError(
+        f"Workflow '{workflow_type}' did not reach any of {target_statuses} "
+        f"within {timeout_s}s for project {project_id}"
+    )
 
 
 async def _fetch_project_detail(

--- a/evals_inspectai/e2e/claim_reference_validation_v2/claim_reference_validation_v2_e2e.py
+++ b/evals_inspectai/e2e/claim_reference_validation_v2/claim_reference_validation_v2_e2e.py
@@ -1,0 +1,219 @@
+"""End-to-end eval for the claim_reference_validation_v2 workflow.
+
+Drives the full API path: upload main + supporting files, wait for the
+human-approval gate to become PENDING, approve it, then poll for the v2
+workflow to complete and score against the same dataset used by the
+internal eval.
+
+Backend must be running (`uv run dev.py`).
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, json_dataset
+from inspect_ai.model import ModelOutput
+from inspect_ai.scorer import (
+    CORRECT,
+    INCORRECT,
+    Score,
+    Target,
+    mean,
+    scorer,
+    stderr,
+)
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+
+from evals_inspectai.common.api_client import (
+    approve_workflow_run,
+    poll_until_complete,
+    poll_until_status,
+    upload_and_start_analysis,
+)
+from evals_inspectai.common.errors import WorkflowCompletionError
+from evals_inspectai.common.scorers import model_graded_check
+
+logger = logging.getLogger(__name__)
+
+# Shared dataset — single source of truth used by both the e2e and internal evals.
+_DATASET_PATH = Path(__file__).parent / "dataset.json"
+
+_TARGET_WORKFLOW = "claim_reference_validation_v2"
+_HUMAN_APPROVAL_WORKFLOW = "human_approval"
+
+
+@task
+def claim_reference_validation_v2_e2e():
+    dataset = json_dataset(str(_DATASET_PATH), _record_to_sample)
+    # Filter out samples that don't make sense for full-document analysis
+    # (e.g. section-bound tests that rely on a manual section range).
+    dataset = dataset.filter(lambda s: not s.metadata.get("skip_e2e"))
+
+    return Task(
+        dataset=dataset,
+        fail_on_error=0.2,
+        solver=claim_reference_validation_v2_e2e_solver(),
+        scorer=[
+            citation_alignment_match(),
+            citation_count_match(),
+            model_graded_check(
+                target_from_metadata="target_answer", partial_credit=True
+            ),
+        ],
+    )
+
+
+def _record_to_sample(record: dict[str, Any]) -> Sample:
+    metadata = {
+        "main_doc": record["main_doc"],
+        "supporting_files": record.get("supporting_files", []),
+        "references": record.get("references", []),
+        "expected_issues": record.get("expected_issues", []),
+        "target_answer": record.get("target_answer", ""),
+        "skip_e2e": record.get("skip_e2e", False),
+    }
+
+    return Sample(
+        id=record.get("id"),
+        input=f"{len(record.get('references', []))} references, "
+        f"{len(record.get('expected_issues', []))} expected issues",
+        target="",
+        metadata=metadata,
+    )
+
+
+@solver
+def claim_reference_validation_v2_e2e_solver(
+    timeout_s: float = 600,
+    poll_interval_s: float = 5,
+) -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        meta = state.metadata or {}
+
+        supporting = [
+            (sf.get("file_name", f"{sf['file_id']}.md"), sf["markdown"])
+            for sf in meta.get("supporting_files", [])
+        ]
+
+        project_id = await upload_and_start_analysis(
+            file_content=meta["main_doc"],
+            file_name="main.md",
+            workflow_types=[_TARGET_WORKFLOW],
+            supporting_files=supporting,
+        )
+
+        # Wait for the human-approval gate to be ready (PENDING means upstream
+        # deps have completed and the gate is awaiting trigger).
+        approval_detail = await poll_until_status(
+            project_id=project_id,
+            workflow_type=_HUMAN_APPROVAL_WORKFLOW,
+            target_statuses={"pending", "running", "completed"},
+            timeout_s=timeout_s,
+            interval_s=poll_interval_s,
+        )
+        approval_run_id = approval_detail["run"]["id"]
+        if approval_detail["run"]["status"] != "completed":
+            await approve_workflow_run(approval_run_id)
+
+        try:
+            run_detail = await poll_until_complete(
+                project_id=project_id,
+                workflow_type=_TARGET_WORKFLOW,
+                timeout_s=timeout_s,
+                interval_s=poll_interval_s,
+            )
+        except TimeoutError as e:
+            raise WorkflowCompletionError(str(e)) from e
+
+        workflow_state = run_detail.get("state") or {}
+        state.output = ModelOutput(
+            completion=json.dumps(workflow_state),
+            model="api",
+        )
+        return state
+
+    return solve
+
+
+def _parse_citation_issues(completion: str) -> list[dict[str, Any]]:
+    """Extract the citation_issues list from the v2 workflow state."""
+    workflow_state = json.loads(completion)
+    return workflow_state.get("citation_issues", []) or []
+
+
+def _evidence_alignment(issue: dict[str, Any]) -> str:
+    val = issue.get("evidence_alignment")
+    if isinstance(val, dict):
+        return val.get("value", "")
+    return val or ""
+
+
+@scorer(metrics=[mean(), stderr()])
+def citation_alignment_match():
+    """Fraction of expected_issues that match a produced issue by quoted-text
+    substring AND have the expected evidence_alignment value."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        try:
+            issues = _parse_citation_issues(state.output.completion)
+        except Exception as e:  # noqa: BLE001
+            return Score(value=INCORRECT, explanation=f"Parse error: {e}")
+
+        expected: list[dict[str, Any]] = state.metadata.get("expected_issues", []) or []
+        if not expected:
+            return Score(value=CORRECT, explanation="No expected_issues declared")
+
+        matches = 0
+        notes: list[str] = []
+        for exp in expected:
+            needle = exp["quoted_contains"].lower()
+            found = next(
+                (i for i in issues if needle in (i.get("quoted_text") or "").lower()),
+                None,
+            )
+            if not found:
+                notes.append(f"missing citation containing '{exp['quoted_contains']}'")
+                continue
+            actual = _evidence_alignment(found)
+            if actual != exp["alignment"]:
+                notes.append(
+                    f"'{exp['quoted_contains']}' got {actual}, expected {exp['alignment']}"
+                )
+                continue
+            matches += 1
+
+        score_value = matches / len(expected)
+        if score_value == 1.0:
+            return Score(
+                value=CORRECT, explanation=f"All {matches} expected issues matched"
+            )
+        return Score(
+            value=score_value if score_value > 0 else INCORRECT,
+            explanation="; ".join(notes) or "no expected issues matched",
+        )
+
+    return score
+
+
+@scorer(metrics=[mean(), stderr()])
+def citation_count_match():
+    """1.0 if the workflow produced exactly the expected number of issues."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        try:
+            issues = _parse_citation_issues(state.output.completion)
+        except Exception as e:  # noqa: BLE001
+            return Score(value=INCORRECT, explanation=f"Parse error: {e}")
+
+        expected = state.metadata.get("expected_issues", []) or []
+        if len(issues) == len(expected):
+            return Score(value=CORRECT, explanation=f"Issue count matches: {len(issues)}")
+        return Score(
+            value=INCORRECT,
+            explanation=f"Got {len(issues)} issues, expected {len(expected)}",
+        )
+
+    return score

--- a/evals_inspectai/e2e/claim_reference_validation_v2/dataset.json
+++ b/evals_inspectai/e2e/claim_reference_validation_v2/dataset.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "supported_author_year",
-    "main_doc": "# Introduction\n\nRemote work has reshaped how teams collaborate. A 2020 industry survey found that fully remote employees reported a 30% increase in self-reported productivity compared to in-office baselines (Smith, 2020). This shift has prompted firms to rethink office footprints.\n\n## Methods\n\nWe synthesize three industry surveys to estimate the directional effect of remote work on weekly output.\n",
+    "main_doc": "# Introduction\n\nRemote work has reshaped how teams collaborate. A 2020 industry survey found that fully remote employees reported a 30% increase in self-reported productivity compared to in-office baselines (Smith, 2020). This shift has prompted firms to rethink office footprints.\n\n## Methods\n\nWe synthesize three industry surveys to estimate the directional effect of remote work on weekly output.\n\n## References\n\n1. Smith, J. (2020). Remote work productivity survey 2020. Journal of Workplace Studies.\n",
     "supporting_files": [
       {
         "file_id": "ref-smith-2020",
@@ -32,7 +32,7 @@
   },
   {
     "id": "unsupported_contradicts_source",
-    "main_doc": "# Findings\n\nOur analysis indicates that remote work doubles the rate of cross-team collaboration in large enterprises (Doe, 2019). This contrasts with prior assumptions that distributed teams collaborate less.\n",
+    "main_doc": "# Findings\n\nOur analysis indicates that remote work doubles the rate of cross-team collaboration in large enterprises (Doe, 2019). This contrasts with prior assumptions that distributed teams collaborate less.\n\n## References\n\n1. Doe, A. (2019). Cross-team collaboration in distributed organizations. Journal of Org Studies.\n",
     "supporting_files": [
       {
         "file_id": "ref-doe-2019",
@@ -63,7 +63,7 @@
   },
   {
     "id": "partially_supported_scope_mismatch",
-    "main_doc": "# Discussion\n\nMicroplastic contamination is now ubiquitous: prior work has shown that 93% of bottled water samples worldwide contain detectable microplastic particles (Patel et al., 2018). This finding motivates global regulatory action.\n",
+    "main_doc": "# Discussion\n\nMicroplastic contamination is now ubiquitous: prior work has shown that 93% of bottled water samples worldwide contain detectable microplastic particles (Patel et al., 2018). This finding motivates global regulatory action.\n\n## References\n\n1. Patel, R., et al. (2018). Microplastic contamination in bottled water: a North American survey.\n",
     "supporting_files": [
       {
         "file_id": "ref-patel-2018",
@@ -94,7 +94,7 @@
   },
   {
     "id": "unverifiable_no_supporting_file",
-    "main_doc": "# Methods\n\nWe used a lateral flow assay protocol that achieves approximately 95% sensitivity for influenza A detection (Wong, 2021). This sensitivity threshold is sufficient for our screening purposes.\n",
+    "main_doc": "# Methods\n\nWe used a lateral flow assay protocol that achieves approximately 95% sensitivity for influenza A detection (Wong, 2021). This sensitivity threshold is sufficient for our screening purposes.\n\n## References\n\n1. Wong, L. (2021). Diagnostic accuracy of lateral flow assays for respiratory viruses.\n",
     "supporting_files": [],
     "references": [
       {
@@ -117,7 +117,7 @@
   },
   {
     "id": "footnote_citation_supported",
-    "main_doc": "# Performance\n\nIncremental dependency analysis has been shown to reduce end-to-end build times by 40% on average across large open-source monorepos, with per-repo speedups ranging from 32% to 47%[1].\n\n## Footnotes\n\n1. Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n",
+    "main_doc": "# Performance\n\nIncremental dependency analysis has been shown to reduce end-to-end build times by 40% on average across large open-source monorepos, with per-repo speedups ranging from 32% to 47%[1].\n\n## Footnotes\n\n1. Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n\n## References\n\n1. Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n",
     "supporting_files": [
       {
         "file_id": "ref-lee-2021",
@@ -148,7 +148,7 @@
   },
   {
     "id": "footnote_commentary_skipped",
-    "main_doc": "# Results\n\nOur initial hypothesis turned out to be incorrect[1], but recent published benchmarks report a consensus throughput ceiling of approximately 1.2 million operations per second for Raft-based coordination[2].\n\n## Footnotes\n\n1. We initially believed throughput would degrade under load; see Section 3 for the corrected reasoning.\n2. Garcia, M. (2022). Modern benchmarks for distributed systems. SIGOPS.\n",
+    "main_doc": "# Results\n\nOur initial hypothesis turned out to be incorrect[1], but recent published benchmarks report a consensus throughput ceiling of approximately 1.2 million operations per second for Raft-based coordination[2].\n\n## Footnotes\n\n1. We initially believed throughput would degrade under load; see Section 3 for the corrected reasoning.\n2. Garcia, M. (2022). Modern benchmarks for distributed systems. SIGOPS.\n\n## References\n\n1. Garcia, M. (2022). Modern benchmarks for distributed systems. SIGOPS.\n",
     "supporting_files": [
       {
         "file_id": "ref-garcia-2022",
@@ -179,7 +179,8 @@
   },
   {
     "id": "section_bounds_excludes_outside",
-    "main_doc": "# Background\n\nEarlier work by Adams (2015) demonstrated initial promise for the technique.\n\n## Methods\n\nWe extended this approach with two key modifications.\nOur experiments demonstrate that the new method outperforms prior baselines on standard benchmarks (Brown, 2021).\n\nResults were validated across three datasets.\n",
+    "skip_e2e": true,
+    "main_doc": "# Background\n\nEarlier work by Adams (2015) demonstrated initial promise for the technique.\n\n## Methods\n\nWe extended this approach with two key modifications.\nOur experiments demonstrate that the new method outperforms prior baselines on standard benchmarks (Brown, 2021).\n\nResults were validated across three datasets.\n\n## References\n\n1. Adams, P. (2015). Initial exploration of the technique.\n2. Brown, T. (2021). Benchmarking the new method.\n",
     "supporting_files": [
       {
         "file_id": "ref-adams-2015",
@@ -221,13 +222,8 @@
   },
   {
     "id": "all_branches_combined",
-    "main_doc": "# Background\n\nEarlier work suggested initial promise for the technique (Adams, 2015).\n\n## Methods\n\nA 2020 industry survey found that fully remote employees reported a 30% increase in self-reported productivity compared to in-office baselines (Smith, 2020).\n\nWe also note that remote work doubles the rate of cross-team collaboration in large enterprises (Doe, 2019).\n\nMicroplastic contamination has been observed in 93% of bottled water samples worldwide (Patel et al., 2018).\n\nThe lateral flow assay we use achieves approximately 95% sensitivity for influenza A detection (Wong, 2021).\n\nIncremental dependency analysis reduces build times by 40% on average across large open-source monorepos, with per-repo speedups ranging from 32% to 47%[^1].\n\nOur initial hypothesis turned out to be incorrect[^2], but later results held up.\n\n## Footnotes\n\n[^1]: Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n[^2]: We initially believed throughput would degrade under load; see Section 3 for the corrected reasoning.\n",
+    "main_doc": "# Background\n\nThis topic has been examined across multiple sub-fields with mixed empirical findings.\n\n## Methods\n\nA 2020 industry survey found that fully remote employees reported a 30% increase in self-reported productivity compared to in-office baselines (Smith, 2020).\n\nWe also note that remote work doubles the rate of cross-team collaboration in large enterprises (Doe, 2019).\n\nMicroplastic contamination has been observed in 93% of bottled water samples worldwide (Patel et al., 2018).\n\nThe lateral flow assay we use achieves approximately 95% sensitivity for influenza A detection (Wong, 2021).\n\nIncremental dependency analysis reduces build times by 40% on average across large open-source monorepos, with per-repo speedups ranging from 32% to 47%[^1].\n\nOur initial hypothesis turned out to be incorrect[^2], but later results held up.\n\n## Footnotes\n\n[^1]: Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n[^2]: We initially believed throughput would degrade under load; see Section 3 for the corrected reasoning.\n\n## References\n\n1. Smith, J. (2020). Remote work productivity survey 2020. Journal of Workplace Studies.\n2. Doe, A. (2019). Cross-team collaboration in distributed organizations. Journal of Org Studies.\n3. Patel, R., et al. (2018). Microplastic contamination in bottled water: a North American survey.\n4. Wong, L. (2021). Diagnostic accuracy of lateral flow assays for respiratory viruses.\n5. Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n",
     "supporting_files": [
-      {
-        "file_id": "ref-adams-2015",
-        "file_name": "adams_2015.md",
-        "markdown": "# Initial Exploration of the Technique (2015)\n\nThis paper introduces the technique and reports promising preliminary results on synthetic benchmarks.\n"
-      },
       {
         "file_id": "ref-smith-2020",
         "file_name": "smith_2020_remote_productivity.md",
@@ -251,27 +247,21 @@
     ],
     "references": [
       {
-        "text": "Adams, P. (2015). Initial exploration of the technique.",
-        "supporting_file_id": "ref-adams-2015",
-        "supporting_index": 1,
-        "supporting_file_name": "adams_2015.md"
-      },
-      {
         "text": "Smith, J. (2020). Remote work productivity survey 2020. Journal of Workplace Studies.",
         "supporting_file_id": "ref-smith-2020",
-        "supporting_index": 2,
+        "supporting_index": 1,
         "supporting_file_name": "smith_2020_remote_productivity.md"
       },
       {
         "text": "Doe, A. (2019). Cross-team collaboration in distributed organizations. Journal of Org Studies.",
         "supporting_file_id": "ref-doe-2019",
-        "supporting_index": 3,
+        "supporting_index": 2,
         "supporting_file_name": "doe_2019_collab.md"
       },
       {
         "text": "Patel, R., et al. (2018). Microplastic contamination in bottled water: a North American survey.",
         "supporting_file_id": "ref-patel-2018",
-        "supporting_index": 4,
+        "supporting_index": 3,
         "supporting_file_name": "patel_2018_microplastics.md"
       },
       {
@@ -281,7 +271,7 @@
       {
         "text": "Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.",
         "supporting_file_id": "ref-lee-2021",
-        "supporting_index": 5,
+        "supporting_index": 4,
         "supporting_file_name": "lee_2021_build_systems.md"
       }
     ],
@@ -312,6 +302,6 @@
         "quoted_contains": "32% to 47%"
       }
     ],
-    "target_answer": "This sample exercises every branch of the prompt at once. The agent must report exactly five issues: (1) Smith (2020) at line 7 → 'supported' (verbatim 30% productivity match); (2) Doe (2019) at line 9 → 'unsupported' (source reports no significant difference, contradicting the doubling claim); (3) Patel et al. (2018) at line 11 → 'partially_supported' (93% figure matches but the source's geographic scope is North America, not 'worldwide'); (4) Wong (2021) at line 13 → 'unverifiable' (no supporting file in the bibliography mapping); (5) Lee (2021) via footnote [^1] at line 15 → 'supported' (both 40% average and 32-47% range appear verbatim in the source — agent must resolve the footnote marker through the [^1] entry to the file). The Adams (2015) citation on line 3 must NOT be reported because line 3 is outside the assigned section (lines 5-18). The [^2] footnote at line 17 must NOT be reported because its footnote entry is author commentary, not a bibliographic reference."
+    "target_answer": "This sample exercises every alignment-level and citation-format branch of the prompt at once. The agent must report exactly five issues: (1) Smith (2020) at line 7 → 'supported' (verbatim 30% productivity match); (2) Doe (2019) at line 9 → 'unsupported' (source reports no significant difference, contradicting the doubling claim); (3) Patel et al. (2018) at line 11 → 'partially_supported' (93% figure matches but the source's geographic scope is North America, not 'worldwide'); (4) Wong (2021) at line 13 → 'unverifiable' (no supporting file in the bibliography mapping); (5) Lee (2021) via footnote [^1] at line 15 → 'supported' (both 40% average and 32-47% range appear verbatim in the source — agent must resolve the footnote marker through the [^1] entry to the file). The [^2] footnote at line 17 must NOT be reported because its footnote entry is author commentary, not a bibliographic reference."
   }
 ]

--- a/evals_inspectai/internal/claim_reference_validation_v2/claim_reference_validation_v2.py
+++ b/evals_inspectai/internal/claim_reference_validation_v2/claim_reference_validation_v2.py
@@ -1,0 +1,138 @@
+"""Internal eval for the CitationValidatorAgent (claim_reference_validation_v2).
+
+Runs the agent directly against a single document section with mocked
+file artifacts. Use this layer to grow coverage of citation-validation
+behavior cheaply; the e2e flavor (still TODO) covers the full workflow.
+"""
+
+from pathlib import Path
+from typing import Any, List
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, json_dataset
+from inspect_ai.scorer import CORRECT, INCORRECT, Score, Target, mean, scorer, stderr
+from inspect_ai.solver import TaskState
+
+from evals_inspectai.common.scorers import model_graded_check, structured_output_scorer
+from evals_inspectai.internal.claim_reference_validation_v2.solver import (
+    citation_validator_solver,
+)
+from evals_inspectai.internal.common.config import get_model_or_agent_default
+from lib.agents.citation_validator import CitationValidatorAgent, SectionValidationResult
+
+
+@task
+def claim_reference_validation_v2():
+    dataset = json_dataset(
+        str(Path(__file__).parent / "dataset.json"),
+        _record_to_sample,
+    )
+
+    return Task(
+        dataset=dataset,
+        model=get_model_or_agent_default(CitationValidatorAgent),
+        solver=citation_validator_solver(),
+        scorer=[
+            structured_output_scorer(SectionValidationResult, _grade_alignment),
+            issue_count_match(),
+            model_graded_check(
+                target_from_metadata="target_answer", partial_credit=True
+            ),
+        ],
+    )
+
+
+def _record_to_sample(record: dict[str, Any]) -> Sample:
+    section = record["section"]
+    headings = " > ".join(section.get("headings", [])) or "Document root"
+    input_summary = (
+        f"Section {headings} (lines {section['start_line']}–{section['end_line']}) "
+        f"with {len(record.get('references', []))} references."
+    )
+
+    metadata = {
+        "main_doc": record["main_doc"],
+        "supporting_files": record.get("supporting_files", []),
+        "references": record.get("references", []),
+        "section": section,
+        "domain": record.get("domain"),
+        "target_audience": record.get("target_audience"),
+        "expected_issues": record.get("expected_issues", []),
+        "target_answer": record.get("target_answer", ""),
+    }
+
+    return Sample(
+        id=record.get("id"),
+        input=input_summary,
+        target="",  # actual grading uses metadata; target is unused here
+        metadata=metadata,
+    )
+
+
+def _grade_alignment(output: SectionValidationResult, state: TaskState) -> Score:
+    """Match each expected issue to a produced one and check evidence_alignment.
+
+    Matching is by substring of `quoted_text` (case-insensitive). The score is
+    the fraction of expected issues that were both found and tagged with the
+    expected alignment level.
+    """
+    expected: List[dict[str, Any]] = state.metadata.get("expected_issues", []) or []
+    if not expected:
+        # Nothing to grade against — treat as CORRECT so this scorer doesn't
+        # punish samples that only rely on the model-graded rubric.
+        return Score(value=CORRECT, explanation="No expected_issues declared")
+
+    matches = 0
+    notes: list[str] = []
+    for exp in expected:
+        needle = exp["quoted_contains"].lower()
+        found = next(
+            (
+                issue
+                for issue in output.issues
+                if needle in issue.quoted_text.lower()
+            ),
+            None,
+        )
+        if not found:
+            notes.append(f"missing citation containing '{exp['quoted_contains']}'")
+            continue
+        if found.evidence_alignment.value != exp["alignment"]:
+            notes.append(
+                f"'{exp['quoted_contains']}' got {found.evidence_alignment.value}, "
+                f"expected {exp['alignment']}"
+            )
+            continue
+        matches += 1
+
+    score_value = matches / len(expected)
+    if score_value == 1.0:
+        return Score(value=CORRECT, explanation=f"All {matches} expected issues matched")
+    return Score(
+        value=score_value if score_value > 0 else INCORRECT,
+        explanation="; ".join(notes) or "no expected issues matched",
+    )
+
+
+@scorer(metrics=[mean(), stderr()])
+def issue_count_match():
+    """Score 1.0 if the produced issue count equals the expected count, else 0."""
+
+    async def score(state: TaskState, target: Target) -> Score:
+        try:
+            result = SectionValidationResult.model_validate_json(
+                state.output.completion
+            )
+        except Exception as e:  # noqa: BLE001 — surface parse errors as INCORRECT
+            return Score(value=INCORRECT, explanation=f"Parse error: {e}")
+
+        expected = state.metadata.get("expected_issues", []) or []
+        actual = len(result.issues)
+        if actual == len(expected):
+            return Score(value=CORRECT, explanation=f"Issue count matches: {actual}")
+        return Score(
+            value=INCORRECT,
+            explanation=f"Got {actual} issues, expected {len(expected)}",
+        )
+
+    return score

--- a/evals_inspectai/internal/claim_reference_validation_v2/claim_reference_validation_v2.py
+++ b/evals_inspectai/internal/claim_reference_validation_v2/claim_reference_validation_v2.py
@@ -24,7 +24,12 @@ from lib.agents.citation_validator import CitationValidatorAgent, SectionValidat
 @task
 def claim_reference_validation_v2():
     dataset = json_dataset(
-        str(Path(__file__).parent / "dataset.json"),
+        str(
+            Path(__file__).parent.parent.parent
+            / "e2e"
+            / "claim_reference_validation_v2"
+            / "dataset.json"
+        ),
         _record_to_sample,
     )
 

--- a/evals_inspectai/internal/claim_reference_validation_v2/dataset.json
+++ b/evals_inspectai/internal/claim_reference_validation_v2/dataset.json
@@ -218,5 +218,100 @@
       }
     ],
     "target_answer": "Only the Brown (2021) citation falls within the assigned section (lines 5-10). The Adams (2015) citation on line 3 is outside the section range and must not be reported (per the 'avoid duplicates from adjacent sections' rule). Exactly one issue should be reported, for Brown (2021), with alignment 'supported'."
+  },
+  {
+    "id": "all_branches_combined",
+    "main_doc": "# Background\n\nEarlier work suggested initial promise for the technique (Adams, 2015).\n\n## Methods\n\nA 2020 industry survey found that fully remote employees reported a 30% increase in self-reported productivity compared to in-office baselines (Smith, 2020).\n\nWe also note that remote work doubles the rate of cross-team collaboration in large enterprises (Doe, 2019).\n\nMicroplastic contamination has been observed in 93% of bottled water samples worldwide (Patel et al., 2018).\n\nThe lateral flow assay we use achieves approximately 95% sensitivity for influenza A detection (Wong, 2021).\n\nIncremental dependency analysis reduces build times by 40% on average across large open-source monorepos, with per-repo speedups ranging from 32% to 47%[^1].\n\nOur initial hypothesis turned out to be incorrect[^2], but later results held up.\n\n## Footnotes\n\n[^1]: Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n[^2]: We initially believed throughput would degrade under load; see Section 3 for the corrected reasoning.\n",
+    "supporting_files": [
+      {
+        "file_id": "ref-adams-2015",
+        "file_name": "adams_2015.md",
+        "markdown": "# Initial Exploration of the Technique (2015)\n\nThis paper introduces the technique and reports promising preliminary results on synthetic benchmarks.\n"
+      },
+      {
+        "file_id": "ref-smith-2020",
+        "file_name": "smith_2020_remote_productivity.md",
+        "markdown": "# Remote Work Productivity Survey 2020\n\n## Key Findings\n\nAcross 4,200 respondents, fully remote employees reported a 30% increase in self-reported productivity relative to their pre-pandemic in-office baselines.\n"
+      },
+      {
+        "file_id": "ref-doe-2019",
+        "file_name": "doe_2019_collab.md",
+        "markdown": "# Cross-Team Collaboration in Distributed Organizations (2019)\n\nWe find that the volume of cross-team Slack messages was roughly comparable between co-located and distributed teams, with no statistically significant difference (p = 0.42).\n"
+      },
+      {
+        "file_id": "ref-patel-2018",
+        "file_name": "patel_2018_microplastics.md",
+        "markdown": "# Microplastic Contamination in Bottled Water: A North American Survey (2018)\n\nWe analyzed 259 bottled water samples sourced exclusively from retailers in the United States and Canada. 93% of samples contained at least one detectable microplastic particle. Sampling was restricted to North American distribution channels; brands sold in Europe, Asia, Africa, South America, and Oceania were not included.\n"
+      },
+      {
+        "file_id": "ref-lee-2021",
+        "file_name": "lee_2021_build_systems.md",
+        "markdown": "# Throughput Improvements in Modern Build Systems (2021)\n\nAcross five large open-source monorepos, the proposed incremental dependency analyzer reduced end-to-end build times by 40% on average. Per-repository speedups ranged from 32% to 47%.\n"
+      }
+    ],
+    "references": [
+      {
+        "text": "Adams, P. (2015). Initial exploration of the technique.",
+        "supporting_file_id": "ref-adams-2015",
+        "supporting_index": 1,
+        "supporting_file_name": "adams_2015.md"
+      },
+      {
+        "text": "Smith, J. (2020). Remote work productivity survey 2020. Journal of Workplace Studies.",
+        "supporting_file_id": "ref-smith-2020",
+        "supporting_index": 2,
+        "supporting_file_name": "smith_2020_remote_productivity.md"
+      },
+      {
+        "text": "Doe, A. (2019). Cross-team collaboration in distributed organizations. Journal of Org Studies.",
+        "supporting_file_id": "ref-doe-2019",
+        "supporting_index": 3,
+        "supporting_file_name": "doe_2019_collab.md"
+      },
+      {
+        "text": "Patel, R., et al. (2018). Microplastic contamination in bottled water: a North American survey.",
+        "supporting_file_id": "ref-patel-2018",
+        "supporting_index": 4,
+        "supporting_file_name": "patel_2018_microplastics.md"
+      },
+      {
+        "text": "Wong, L. (2021). Diagnostic accuracy of lateral flow assays for respiratory viruses.",
+        "supporting_file_id": null
+      },
+      {
+        "text": "Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.",
+        "supporting_file_id": "ref-lee-2021",
+        "supporting_index": 5,
+        "supporting_file_name": "lee_2021_build_systems.md"
+      }
+    ],
+    "section": {
+      "start_line": 5,
+      "end_line": 18,
+      "headings": ["Methods"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "supported",
+        "quoted_contains": "30% increase in self-reported productivity"
+      },
+      {
+        "alignment": "unsupported",
+        "quoted_contains": "doubles the rate of cross-team collaboration"
+      },
+      {
+        "alignment": "partially_supported",
+        "quoted_contains": "93% of bottled water samples worldwide"
+      },
+      {
+        "alignment": "unverifiable",
+        "quoted_contains": "95% sensitivity"
+      },
+      {
+        "alignment": "supported",
+        "quoted_contains": "32% to 47%"
+      }
+    ],
+    "target_answer": "This sample exercises every branch of the prompt at once. The agent must report exactly five issues: (1) Smith (2020) at line 7 → 'supported' (verbatim 30% productivity match); (2) Doe (2019) at line 9 → 'unsupported' (source reports no significant difference, contradicting the doubling claim); (3) Patel et al. (2018) at line 11 → 'partially_supported' (93% figure matches but the source's geographic scope is North America, not 'worldwide'); (4) Wong (2021) at line 13 → 'unverifiable' (no supporting file in the bibliography mapping); (5) Lee (2021) via footnote [^1] at line 15 → 'supported' (both 40% average and 32-47% range appear verbatim in the source — agent must resolve the footnote marker through the [^1] entry to the file). The Adams (2015) citation on line 3 must NOT be reported because line 3 is outside the assigned section (lines 5-18). The [^2] footnote at line 17 must NOT be reported because its footnote entry is author commentary, not a bibliographic reference."
   }
 ]

--- a/evals_inspectai/internal/claim_reference_validation_v2/dataset.json
+++ b/evals_inspectai/internal/claim_reference_validation_v2/dataset.json
@@ -1,0 +1,222 @@
+[
+  {
+    "id": "supported_author_year",
+    "main_doc": "# Introduction\n\nRemote work has reshaped how teams collaborate. A 2020 industry survey found that fully remote employees reported a 30% increase in self-reported productivity compared to in-office baselines (Smith, 2020). This shift has prompted firms to rethink office footprints.\n\n## Methods\n\nWe synthesize three industry surveys to estimate the directional effect of remote work on weekly output.\n",
+    "supporting_files": [
+      {
+        "file_id": "ref-smith-2020",
+        "file_name": "smith_2020_remote_productivity.md",
+        "markdown": "# Remote Work Productivity Survey 2020\n\n## Key Findings\n\nAcross 4,200 respondents, fully remote employees reported a 30% increase in self-reported productivity relative to their pre-pandemic in-office baselines. The effect was strongest among engineering and design roles, where deep-focus time rose substantially.\n\n## Methodology\n\nThe survey was conducted between March and August 2020. Respondents were drawn from 12 industries.\n"
+      }
+    ],
+    "references": [
+      {
+        "text": "Smith, J. (2020). Remote work productivity survey 2020. Journal of Workplace Studies.",
+        "supporting_file_id": "ref-smith-2020",
+        "supporting_index": 1,
+        "supporting_file_name": "smith_2020_remote_productivity.md"
+      }
+    ],
+    "section": {
+      "start_line": 1,
+      "end_line": 8,
+      "headings": ["Introduction"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "supported",
+        "quoted_contains": "30% increase in self-reported productivity"
+      }
+    ],
+    "target_answer": "The Smith (2020) citation should be classified as 'supported' because the supporting document directly states that fully remote employees reported a 30% increase in self-reported productivity, matching the claim's scope and magnitude."
+  },
+  {
+    "id": "unsupported_contradicts_source",
+    "main_doc": "# Findings\n\nOur analysis indicates that remote work doubles the rate of cross-team collaboration in large enterprises (Doe, 2019). This contrasts with prior assumptions that distributed teams collaborate less.\n",
+    "supporting_files": [
+      {
+        "file_id": "ref-doe-2019",
+        "file_name": "doe_2019_collab.md",
+        "markdown": "# Cross-Team Collaboration in Distributed Organizations (2019)\n\nThis study examines collaboration patterns in distributed software organizations. We find that the volume of cross-team Slack messages was roughly comparable between co-located and distributed teams, with no statistically significant difference (p = 0.42). We did not measure changes in collaboration over time as remote work was adopted.\n"
+      }
+    ],
+    "references": [
+      {
+        "text": "Doe, A. (2019). Cross-team collaboration in distributed organizations. Journal of Org Studies.",
+        "supporting_file_id": "ref-doe-2019",
+        "supporting_index": 1,
+        "supporting_file_name": "doe_2019_collab.md"
+      }
+    ],
+    "section": {
+      "start_line": 1,
+      "end_line": 4,
+      "headings": ["Findings"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "unsupported",
+        "quoted_contains": "doubles the rate of cross-team collaboration"
+      }
+    ],
+    "target_answer": "The Doe (2019) citation should be classified as 'unsupported' because the supporting document explicitly reports no statistically significant difference in cross-team collaboration between co-located and distributed teams, which contradicts the doubling claim."
+  },
+  {
+    "id": "partially_supported_scope_mismatch",
+    "main_doc": "# Discussion\n\nMicroplastic contamination is now ubiquitous: prior work has shown that 93% of bottled water samples worldwide contain detectable microplastic particles (Patel et al., 2018). This finding motivates global regulatory action.\n",
+    "supporting_files": [
+      {
+        "file_id": "ref-patel-2018",
+        "file_name": "patel_2018_microplastics.md",
+        "markdown": "# Microplastic Contamination in Bottled Water: A North American Survey (2018)\n\n## Abstract\n\nWe analyzed 259 bottled water samples sourced exclusively from retailers in the United States and Canada. 93% of samples contained at least one detectable microplastic particle.\n\n## Geographic scope\n\nSampling was restricted to North American distribution channels. Brands sold in Europe, Asia, Africa, South America, and Oceania were not included. We make no claims about contamination rates in other regions.\n"
+      }
+    ],
+    "references": [
+      {
+        "text": "Patel, R., et al. (2018). Microplastic contamination in bottled water: a North American survey.",
+        "supporting_file_id": "ref-patel-2018",
+        "supporting_index": 1,
+        "supporting_file_name": "patel_2018_microplastics.md"
+      }
+    ],
+    "section": {
+      "start_line": 1,
+      "end_line": 4,
+      "headings": ["Discussion"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "partially_supported",
+        "quoted_contains": "93% of bottled water samples worldwide"
+      }
+    ],
+    "target_answer": "The Patel et al. (2018) citation should be classified as 'partially_supported' because the 93% figure matches the source but the document's scope is restricted to North America, not 'worldwide' as the citing claim implies. The rationale should call out the geographic-scope mismatch."
+  },
+  {
+    "id": "unverifiable_no_supporting_file",
+    "main_doc": "# Methods\n\nWe used a lateral flow assay protocol that achieves approximately 95% sensitivity for influenza A detection (Wong, 2021). This sensitivity threshold is sufficient for our screening purposes.\n",
+    "supporting_files": [],
+    "references": [
+      {
+        "text": "Wong, L. (2021). Diagnostic accuracy of lateral flow assays for respiratory viruses.",
+        "supporting_file_id": null
+      }
+    ],
+    "section": {
+      "start_line": 1,
+      "end_line": 4,
+      "headings": ["Methods"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "unverifiable",
+        "quoted_contains": "95% sensitivity"
+      }
+    ],
+    "target_answer": "The Wong (2021) citation should be classified as 'unverifiable' because no supporting file was provided for that reference in the bibliography-to-file mapping, making it impossible to check the 95% sensitivity claim against the source."
+  },
+  {
+    "id": "footnote_citation_supported",
+    "main_doc": "# Performance\n\nIncremental dependency analysis has been shown to reduce end-to-end build times by 40% on average across large open-source monorepos, with per-repo speedups ranging from 32% to 47%[1].\n\n## Footnotes\n\n1. Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.\n",
+    "supporting_files": [
+      {
+        "file_id": "ref-lee-2021",
+        "file_name": "lee_2021_build_systems.md",
+        "markdown": "# Throughput Improvements in Modern Build Systems (2021)\n\n## Results\n\nAcross five large open-source monorepos, the proposed incremental dependency analyzer reduced end-to-end build times by 40% on average compared to the baseline whole-graph compiler. Per-repository speedups ranged from 32% to 47%.\n"
+      }
+    ],
+    "references": [
+      {
+        "text": "Lee, K. (2021). Throughput improvements in modern build systems. ACM Transactions on Software Engineering.",
+        "supporting_file_id": "ref-lee-2021",
+        "supporting_index": 1,
+        "supporting_file_name": "lee_2021_build_systems.md"
+      }
+    ],
+    "section": {
+      "start_line": 1,
+      "end_line": 4,
+      "headings": ["Performance"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "supported",
+        "quoted_contains": "32% to 47%"
+      }
+    ],
+    "target_answer": "The footnote-style citation [1] resolves to Lee (2021). The citing sentence quotes both the 40% average and the 32%-to-47% per-repo speedup range, both of which appear verbatim in the supporting document. Exactly one issue should be reported, with alignment 'supported'. The agent must successfully resolve the footnote marker through the footnote entry to the correct file."
+  },
+  {
+    "id": "footnote_commentary_skipped",
+    "main_doc": "# Results\n\nOur initial hypothesis turned out to be incorrect[1], but recent published benchmarks report a consensus throughput ceiling of approximately 1.2 million operations per second for Raft-based coordination[2].\n\n## Footnotes\n\n1. We initially believed throughput would degrade under load; see Section 3 for the corrected reasoning.\n2. Garcia, M. (2022). Modern benchmarks for distributed systems. SIGOPS.\n",
+    "supporting_files": [
+      {
+        "file_id": "ref-garcia-2022",
+        "file_name": "garcia_2022_benchmarks.md",
+        "markdown": "# Modern Benchmarks for Distributed Systems (2022)\n\n## Findings\n\nAcross three coordination protocols, Raft-based implementations sustained a peak throughput of 1.2 million operations per second on the standard YCSB workload, consistent with prior reports. We treat this 1.2M ops/sec figure as the practical ceiling for well-tuned Raft deployments.\n"
+      }
+    ],
+    "references": [
+      {
+        "text": "Garcia, M. (2022). Modern benchmarks for distributed systems. SIGOPS.",
+        "supporting_file_id": "ref-garcia-2022",
+        "supporting_index": 1,
+        "supporting_file_name": "garcia_2022_benchmarks.md"
+      }
+    ],
+    "section": {
+      "start_line": 1,
+      "end_line": 3,
+      "headings": ["Results"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "supported",
+        "quoted_contains": "1.2 million operations per second"
+      }
+    ],
+    "target_answer": "Footnote [1] is author commentary (not a bibliographic reference) and must be skipped per the prompt's footnote rules. Footnote [2] is a real citation to Garcia (2022); the supporting document explicitly reports the 1.2M ops/sec Raft throughput figure. Exactly one issue should be reported, for the [2] citation, with alignment 'supported'."
+  },
+  {
+    "id": "section_bounds_excludes_outside",
+    "main_doc": "# Background\n\nEarlier work by Adams (2015) demonstrated initial promise for the technique.\n\n## Methods\n\nWe extended this approach with two key modifications.\nOur experiments demonstrate that the new method outperforms prior baselines on standard benchmarks (Brown, 2021).\n\nResults were validated across three datasets.\n",
+    "supporting_files": [
+      {
+        "file_id": "ref-adams-2015",
+        "file_name": "adams_2015.md",
+        "markdown": "# Initial Exploration of the Technique (2015)\n\nThis paper introduces the technique and reports promising preliminary results on synthetic benchmarks.\n"
+      },
+      {
+        "file_id": "ref-brown-2021",
+        "file_name": "brown_2021.md",
+        "markdown": "# Benchmarking the New Method (2021)\n\nWe compare the proposed method against three baselines on standard benchmarks. The new method outperforms all baselines by 8-15% across metrics.\n"
+      }
+    ],
+    "references": [
+      {
+        "text": "Adams, P. (2015). Initial exploration of the technique.",
+        "supporting_file_id": "ref-adams-2015",
+        "supporting_index": 1,
+        "supporting_file_name": "adams_2015.md"
+      },
+      {
+        "text": "Brown, T. (2021). Benchmarking the new method.",
+        "supporting_file_id": "ref-brown-2021",
+        "supporting_index": 2,
+        "supporting_file_name": "brown_2021.md"
+      }
+    ],
+    "section": {
+      "start_line": 5,
+      "end_line": 10,
+      "headings": ["Methods"]
+    },
+    "expected_issues": [
+      {
+        "alignment": "supported",
+        "quoted_contains": "outperforms prior baselines"
+      }
+    ],
+    "target_answer": "Only the Brown (2021) citation falls within the assigned section (lines 5-10). The Adams (2015) citation on line 3 is outside the section range and must not be reported (per the 'avoid duplicates from adjacent sections' rule). Exactly one issue should be reported, for Brown (2021), with alignment 'supported'."
+  }
+]

--- a/evals_inspectai/internal/claim_reference_validation_v2/solver.py
+++ b/evals_inspectai/internal/claim_reference_validation_v2/solver.py
@@ -1,0 +1,112 @@
+"""Inspect AI solver that runs the CitationValidatorAgent against a single section.
+
+The solver builds a `MockFileArtifactsService` populated with the sample's main
+document, supporting files, and bibliography items, then invokes the agent with
+the same `prompt_kwargs` shape that `validate_section` uses in production.
+"""
+
+from typing import Any
+
+from inspect_ai.model import ModelOutput
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+
+from evals_inspectai.common.converters import messages_from_langchain
+from evals_inspectai.internal.common.config import (
+    apply_inspectai_config_to_agent,
+    get_runnable_config,
+)
+from lib.agents.citation_validator import CitationValidatorAgent
+from lib.agents.formatting_utils import format_audience_context, format_domain_context
+from lib.models.bibliography_item import BibliographyItem
+from lib.services.file import FileDocument
+from lib.services.file_artifacts_service.mock import MockFileArtifactsService
+from lib.workflows.claim_reference_validation_v2.citation_mapping import (
+    build_reference_file_map,
+)
+from tests.conftest import create_test_context
+
+MAIN_FILE_ID = "eval-main"
+
+
+@solver
+def citation_validator_solver() -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        meta: dict[str, Any] = state.metadata or {}
+
+        main_file = _build_main_file(meta["main_doc"])
+        supporting_files = [
+            _build_supporting_file(sf) for sf in meta.get("supporting_files", [])
+        ]
+        references = [_build_reference(ref) for ref in meta.get("references", [])]
+
+        file_artifacts_service = MockFileArtifactsService(
+            main_file=main_file,
+            supporting_files=supporting_files,
+            references=references,
+        )
+        context = create_test_context(file_artifacts_service=file_artifacts_service)
+
+        lc_agent = CitationValidatorAgent(context)
+        apply_inspectai_config_to_agent(lc_agent)
+
+        section = meta["section"]
+        headings = section.get("headings", [])
+        prompt_kwargs = {
+            "main_file_id": main_file.file_id,
+            "start_line": section["start_line"],
+            "end_line": section["end_line"],
+            "section_headings": " > ".join(headings) if headings else "Document root",
+            "reference_file_map": build_reference_file_map(references, supporting_files),
+            "domain_context": format_domain_context(meta.get("domain")),
+            "audience_context": format_audience_context(meta.get("target_audience")),
+            "headings": headings,
+        }
+
+        result, lc_messages = await lc_agent.ainvoke(
+            prompt_kwargs, config=get_runnable_config()
+        )
+
+        state.output = ModelOutput(
+            completion=result.model_dump_json(),
+            model=lc_agent.model.get_model_name_for_inspectai(),
+        )
+        state.messages = messages_from_langchain(lc_messages)
+        return state
+
+    return solve
+
+
+def _build_main_file(markdown: str) -> FileDocument:
+    return FileDocument(
+        file_id=MAIN_FILE_ID,
+        file_name="main.md",
+        file_path="main.md",
+        file_type="text/markdown",
+        markdown=markdown,
+        markdown_token_count=len(markdown.split()),
+    )
+
+
+def _build_supporting_file(spec: dict[str, Any]) -> FileDocument:
+    markdown = spec["markdown"]
+    return FileDocument(
+        file_id=spec["file_id"],
+        file_name=spec.get("file_name", f"{spec['file_id']}.md"),
+        file_path=spec.get("file_name", f"{spec['file_id']}.md"),
+        file_type="text/markdown",
+        markdown=markdown,
+        markdown_token_count=len(markdown.split()),
+    )
+
+
+def _build_reference(spec: dict[str, Any]) -> BibliographyItem:
+    file_id = spec.get("supporting_file_id")
+    return BibliographyItem(
+        text=spec["text"],
+        has_associated_supporting_document=file_id is not None,
+        index_of_associated_supporting_document=spec.get("supporting_index", -1),
+        name_of_associated_supporting_document=spec.get(
+            "supporting_file_name", ""
+        ),
+        file_id=file_id,
+    )

--- a/lib/agents/citation_validator.py
+++ b/lib/agents/citation_validator.py
@@ -3,7 +3,7 @@
 from typing import List, Optional
 
 from langchain.agents import create_agent
-from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langgraph.graph.state import RunnableConfig
 from pydantic import BaseModel, Field
 
@@ -11,7 +11,7 @@ from lib.agents.claim_verifier import ClaimEvidenceSource, EvidenceAlignmentLeve
 from lib.agents.tools.read_document import read_document
 from lib.agents.tools.search_document import search_document
 from lib.agents.tools.vector_search import vector_search
-from lib.config.llm_models import gpt_5_4_model
+from lib.config.llm_models import gpt_5_5_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 
@@ -41,7 +41,12 @@ class CitationIssueItem(BaseModel):
     )
     citation_to_file_mapping: Optional[str] = Field(
         default=None,
-        description="The bibliography-to-file mapping used when checking this citation. Omit file IDs.",
+        description=(
+            "Display-friendly summary of which bibliography entry was matched to "
+            "which supporting file when checking this citation, e.g. "
+            "'Smith (2020) → smith_2020.pdf'. Do not include file_id UUIDs in this "
+            "string; the file_id belongs in each entry of evidence_sources."
+        ),
     )
 
 
@@ -132,7 +137,7 @@ _USER_MESSAGE = "Please validate all citations in your assigned section."
 class CitationValidatorAgent(LangChainAgent):
     name = "Citation Validator"
     description = "Validate citations in a document section against reference files"
-    model = gpt_5_4_model
+    model = gpt_5_5_model
     temperature = 0.0
     reasoning = {"effort": "medium", "summary": "auto"}
 
@@ -140,7 +145,7 @@ class CitationValidatorAgent(LangChainAgent):
         self,
         prompt_kwargs: dict,
         config: Optional[RunnableConfig] = None,
-    ) -> SectionValidationResult:
+    ) -> tuple[SectionValidationResult, List[BaseMessage]]:
         agent = create_agent(
             self.llm,
             [vector_search, search_document, read_document],
@@ -161,4 +166,4 @@ class CitationValidatorAgent(LangChainAgent):
             context=self.context,
         )
 
-        return result["structured_response"]
+        return result["structured_response"], result["messages"]

--- a/lib/agents/citation_validator.py
+++ b/lib/agents/citation_validator.py
@@ -95,6 +95,11 @@ Documents use citations in two main formats:
 2. **Footnote markers**: e.g., `[2]`, `[^2]`, superscript `²`. These are *indirect* — the marker points to a footnote entry elsewhere in the document (often at the bottom of the page/section or at the end of the document, like `2. Smith, 2020, Title of the work`). The footnote entry then points to the actual bibliography entry.
    - **Important**: Not every footnote is a citation. Footnotes are also used for author notes, clarifications, side commentary, disclaimers, etc. Only treat a footnote as a citation if its content is a bibliographic reference (author, year, title, or similar metadata pointing to an external work). If the footnote is commentary or a note, skip it — do not report it.
    - To resolve a footnote citation: use `search_document(main_file_id, ...)` to find the footnote entry (e.g., search for `^\\s*2\\.` or `\\[\\^2\\]`), read the footnote text, and then match it against the bibliography-to-file mapping to find the real supporting file.
+   - **Validate the in-text marker, not the footnote entry.** A footnote entry line (e.g., `[^1]: Smith, 2020. Title of the work` or `1. Smith, 2020. Title of the work`) is the *target* of a marker, not a standalone in-text claim. Do NOT report a citation issue for the footnote entry itself, even if your assigned section happens to contain that entry. Footnote entries are validated only via the `[^N]`/`[N]` markers that reference them in the body of the document.
+
+## Bibliography sections
+
+Lines inside a `## References`, `## Bibliography`, or similar dedicated bibliography section are reference *entries*, not in-text citations. Do not report a citation issue for any line inside such a section, even if your assigned section overlaps with it.
 
 ## Workflow
 

--- a/lib/workflows/claim_reference_validation_v2/nodes/validate_sections.py
+++ b/lib/workflows/claim_reference_validation_v2/nodes/validate_sections.py
@@ -106,7 +106,7 @@ async def validate_section(state: dict, runtime: Runtime[ContextSchema]):
         )
 
         agent = CitationValidatorAgent(runtime.context)
-        result = await agent.ainvoke(
+        result, _ = await agent.ainvoke(
             {
                 "main_file_id": main_file.file_id,
                 "start_line": start_line,


### PR DESCRIPTION
## Summary

Adds Inspect AI evals for `claim_reference_validation_v2` in two flavors:
- **Internal** — invokes `CitationValidatorAgent` directly with a mocked `file_artifacts_service` (8 samples).
- **E2E** — drives the full API path through DOCUMENT_PROCESSING → REFERENCE_EXTRACTION → REFERENCE_FILE_MATCHING → HUMAN_APPROVAL → CLAIM_REFERENCE_VALIDATION_V2 (7 samples — section-bound test is internal-only).

Both flavors share a single dataset file. Stable at 1.000 across all scorers, 24 internal runs and 21 e2e runs.

Linear: [RANDZ-532](https://linear.app/ae-studio/issue/RANDZ-532/create-inspectai-evals-for-claim-ref-validation-v2)

## Motivation

`claim_reference_validation_v2` is the most expensive workflow we have — it calls a tool-using LLM agent per section, with citation-resolution logic that depends on bibliography matching, footnote handling, and section-aware filtering. We want a regression baseline that catches both individual-agent quality drift (internal) and full-pipeline integration breakage (e2e).

## What's Changed

### Backend

- **`evals_inspectai/internal/claim_reference_validation_v2/`** (new)
  - `solver.py` — `@solver`-decorated solver that builds a `MockFileArtifactsService` populated from sample metadata and invokes `CitationValidatorAgent.ainvoke` with the same `prompt_kwargs` the production `validate_section` node uses.
  - `claim_reference_validation_v2.py` — task definition with three scorers: per-issue alignment match, exact issue-count match, and LLM-graded rationale rubric.
- **`evals_inspectai/e2e/claim_reference_validation_v2/`** (new)
  - `claim_reference_validation_v2_e2e.py` — `@solver` that uploads main + supporting files via `/api/start-analysis`, polls until the `human_approval` workflow run is ready, calls `/approve`, then polls until v2 completes. Custom scorers read `citation_issues` from the workflow state; samples flagged `skip_e2e: true` are filtered out.
  - `dataset.json` — 8 samples covering all four evidence-alignment levels (`supported`, `unsupported`, `partially_supported`, `unverifiable`), both citation formats (author-year, footnote markers), the commentary-vs-bibliography footnote distinction, section-bound filtering (internal-only), plus an `all_branches_combined` smoke test that exercises every alignment-level and citation-format branch in one document. Lives next to the e2e task and is shared with the internal eval as the single source of truth.
- **`evals_inspectai/common/api_client.py`** —
  - `upload_and_start_analysis` extended with optional `supporting_files: list[tuple[str, str]]` (each tuple is `(file_name, markdown_content)`); writes them to temp files and posts them as multipart `supporting_documents`.
  - New `approve_workflow_run(workflow_run_id)` POSTing to `/api/workflow-runs/{id}/approve`.
  - New `find_workflow_run_by_type` and `poll_until_status` helpers used by the e2e solver to coordinate the approval gate.
- **`lib/agents/citation_validator.py`** —
  - `ainvoke` now returns `tuple[SectionValidationResult, list[BaseMessage]]`, mirroring `ReferenceValidatorV2Agent` so tool-call traces surface in the Inspect AI viewer.
  - Default model bumped from `gpt_5_4_model` to `gpt_5_5_model` (variance on borderline alignment calls dropped from ~6% to 0% across our runs).
  - Clarified `citation_to_file_mapping` field description: previously said only "Omit file IDs" which read as a global instruction, now explicitly notes the file_id belongs in `evidence_sources` entries.
  - Added explicit prompt directives: footnote-entry lines (e.g., `[^1]: Smith, 2020. ...`) are bibliography targets, not in-text claims to validate; lines inside a `## References`/`## Bibliography` section are reference entries, not in-text citations. Both directives surfaced from analyzing e2e reasoning traces where the agent re-flagged footnote definitions as standalone citations.
- **`lib/workflows/claim_reference_validation_v2/nodes/validate_sections.py`** — unpacks the new tuple return shape from `CitationValidatorAgent.ainvoke`.

### Frontend

None.

## Risks and Mitigations

- **Model default change (`gpt-5.4` → `gpt-5.5`) affects production runs.** Cost per section is roughly comparable; quality is equal-or-better in our eval. Mitigation: rollback is a one-line revert if monitoring shows regressions.
- **`ainvoke` return-shape change is breaking for any caller.** Only one production caller exists (`validate_section`), already updated. mypy passes across the agent, the production caller, and both eval modules.
- **Prompt directive change for footnote/bibliography entries.** This is a strict suppression of false-positive citation issues that the agent occasionally produced when its assigned section overlapped a Footnotes or References block. No legitimate citations should now be missed — in-text markers (`(Smith, 2020)`, `[^1]`, etc.) still resolve and validate normally.
- **E2E eval requires a running backend.** Documented in the eval module's docstring.
- **Internal eval doesn't pre-ingest a vector store.** `vector_search` calls fall through to empty results; the agent reliably uses `read_document`/`search_document` instead.

## Test plan

- [x] `uv run mypy .` — clean
- [x] `uv run inspect eval evals_inspectai/internal/claim_reference_validation_v2/claim_reference_validation_v2.py --epochs=3` → 1.000 / 1.000 / 1.000 across 24 runs
- [x] `uv run inspect eval evals_inspectai/e2e/claim_reference_validation_v2/claim_reference_validation_v2_e2e.py --epochs=3` (with `uv run dev.py` running) → 1.000 / 1.000 / 1.000 across 21 runs
- [ ] Reviewer spot-check: open one Inspect log to confirm tool-call traces render in the viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)