### PR TITLE
chore(agents): upgrade agents to gpt-5.4 and simple deep agent to gpt-5.5

### DIFF
--- a/lib/agents/addendum_report_generator.py
+++ b/lib/agents/addendum_report_generator.py
@@ -7,7 +7,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
-from lib.config.llm_models import gpt_5_model
+from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 
 
@@ -205,7 +205,7 @@ class AddendumReportGeneratorAgent(LangChainAgent):
     description = (
         "Aggregate live reports and produce a markdown formatted addendum report"
     )
-    model = gpt_5_model
+    model = gpt_5_4_model
     temperature = 0.2
     output_schema = ReportOutput
 

--- a/lib/agents/claim_verifier.py
+++ b/lib/agents/claim_verifier.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from lib.agents.tools.read_document import read_document
 from lib.agents.tools.search_document import search_document
 from lib.agents.tools.vector_search import vector_search
-from lib.config.llm_models import gpt_5_2_model
+from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 
@@ -121,7 +121,7 @@ For each claim, output an evidence alignment level based on the following defini
 class ClaimVerifierAgent(LangChainAgent):
     name = "Claim Verifier"
     description = "Verify claims in a paragraph by searching supporting documents"
-    model = gpt_5_2_model
+    model = gpt_5_4_model
     temperature = 0.2
 
     async def ainvoke(

--- a/lib/agents/document_chunker.py
+++ b/lib/agents/document_chunker.py
@@ -5,7 +5,7 @@ from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
 from lib.agents.models import ValidatedDocument
-from lib.config.llm_models import gpt_4_1_model
+from lib.config.llm_models import gpt_5_mini_model
 from lib.models.agent import LangChainAgent
 
 
@@ -70,7 +70,7 @@ I will send the markdown document that you need to chunk as my next message.
 class DocumentChunkerAgent(LangChainAgent):
     name = "Document Chunker"
     description = "Chunk a document into paragraphs and each paragraph into reasonable sentence-level chunks"
-    model = gpt_4_1_model
+    model = gpt_5_mini_model
     temperature = 0.2
     output_schema = DocumentChunkerResponse
 

--- a/lib/agents/footnote_extractor.py
+++ b/lib/agents/footnote_extractor.py
@@ -6,7 +6,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
-from lib.config.llm_models import gpt_5_2_model, gpt_5_mini_model
+from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.models.footnote_item import FootnoteItem
 
@@ -51,7 +51,7 @@ class FootnoteExtractorAgent(LangChainAgent):
 
     name = "Footnote Extractor"
     description = "Extract structured footnotes from document text"
-    model = gpt_5_2_model
+    model = gpt_5_4_model
     temperature = 0.0
     output_schema = FootnoteExtractorResponse
 

--- a/lib/agents/literature_review.py
+++ b/lib/agents/literature_review.py
@@ -8,7 +8,7 @@ from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
-from lib.config.llm_models import gpt_5_2_model
+from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 
@@ -179,7 +179,7 @@ When generating responses, remove or replace all internal citation tokens such a
 class LiteratureReviewAgent(LangChainAgent):
     name = "Literature Review Researcher"
     description = "Review a document paragraph against the article bibliography and recent literature to propose citation updates"
-    model = gpt_5_2_model
+    model = gpt_5_4_model
     temperature = 0.5
     timeout = 600
     reasoning = {"effort": "low", "summary": "auto"}

--- a/lib/agents/methodology_comparator.py
+++ b/lib/agents/methodology_comparator.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from lib.agents.literature_review import ReferenceType
 from lib.agents.methodology_extractor import ReproducibilityCategoryResponse
-from lib.config.llm_models import gpt_5_2_model
+from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 
@@ -198,7 +198,7 @@ class MethodologyComparisonAgent(LangChainAgent):
         "Compare an extracted paper methodology to typical methods used in the broader field, "
         "using web search to find field methods context, and return a structured text comparison."
     )
-    model = gpt_5_2_model
+    model = gpt_5_4_model
     temperature = 0.3
     timeout = 600
     reasoning = {"effort": "low", "summary": "auto"}

--- a/lib/agents/reference_text_extractor_v2.py
+++ b/lib/agents/reference_text_extractor_v2.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from lib.agents.tools.read_main_document import read_document
 from lib.agents.tools.search_main_document import search_document
-from lib.config.llm_models import gpt_5_2_model
+from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 
@@ -108,7 +108,7 @@ class ReferenceExtractorV2Agent(LangChainAgent):
 
     name = "Reference Extractor v2"
     description = "Extract bibliographic references using intelligent document search"
-    model = gpt_5_2_model
+    model = gpt_5_4_model
     temperature = 0.0
     reasoning = {"effort": "low", "summary": "auto"}
 

--- a/lib/config/llm_models.py
+++ b/lib/config/llm_models.py
@@ -50,11 +50,7 @@ class LLMModel(BaseModel):
 
 
 # OpenAI models
-gpt_5_model = LLMModel(provider="openai", name="gpt-5")
-gpt_5_mini_model = LLMModel(provider="openai", name="gpt-5-mini")
-gpt_5_1_model = LLMModel(provider="openai", name="gpt-5.1")
-gpt_4_1_model = LLMModel(provider="openai", name="gpt-4.1")
-gpt_5_2_model = LLMModel(provider="openai", name="gpt-5.2")
+gpt_5_mini_model = LLMModel(provider="openai", name="gpt-5.4-mini")
 gpt_5_4_model = LLMModel(provider="openai", name="gpt-5.4")
 gpt_5_5_model = LLMModel(provider="openai", name="gpt-5.5")
 
@@ -70,11 +66,7 @@ gemini_2_flash_model = LLMModel(provider="google_genai", name="gemini-2.5-flash-
 # Registry of all available models for testing and comparison
 # Key: model.name, Value: model instance
 ALL_MODELS = {
-    "gpt-5": gpt_5_model,
     "gpt-5-mini": gpt_5_mini_model,
-    "gpt-5.1": gpt_5_1_model,
-    "gpt-5.2": gpt_5_2_model,
-    "gpt-4.1": gpt_4_1_model,
     "gpt-5.4": gpt_5_4_model,
     "gpt-5.5": gpt_5_5_model,
     "claude-sonnet-4-5-20250929": claude_3_5_sonnet_model,

--- a/lib/workflows/simple_deep_agent/agent.py
+++ b/lib/workflows/simple_deep_agent/agent.py
@@ -12,7 +12,7 @@ from langchain.agents.structured_output import AutoStrategy
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_core.runnables import RunnableConfig
 
-from lib.config.llm_models import gpt_5_4_model
+from lib.config.llm_models import gpt_5_5_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
 from lib.workflows.simple_deep_agent.agent_types import AgentCheckResult
@@ -43,7 +43,7 @@ class SimpleDeepAgent(LangChainAgent):
 
     name = "Simple Deep Agent"
     description = "Runs a deep-agent validation pass and returns structured issues"
-    model = gpt_5_4_model
+    model = gpt_5_5_model
     temperature = 0.0
     reasoning = {"effort": "medium", "summary": "auto"}
 


### PR DESCRIPTION
## Summary

Consolidate most agents on `gpt-5.4` and bump `SimpleDeepAgent` to `gpt-5.5`. Switch `DocumentChunker` from `gpt-4.1` to `gpt-5.4-mini`, and remove unused legacy model entries (`gpt-5`, `gpt-5.1`, `gpt-5.2`, `gpt-4.1`) from the registry. Repoint `gpt_5_mini_model` at `gpt-5.4-mini`.

## Motivation

The codebase had a mix of `gpt-5`, `gpt-5.2`, `gpt-4.1`, and `gpt-5.4` references across agents. Standardizing on the newer `gpt-5.4` family simplifies model management and ensures we're using the latest capabilities.

## What's Changed

### Backend

- `lib/config/llm_models.py` — remove unused `gpt_5_model`, `gpt_5_1_model`, `gpt_5_2_model`, and `gpt_4_1_model`; repoint `gpt_5_mini_model` to `gpt-5.4-mini`; clean up `ALL_MODELS`.
- `lib/agents/addendum_report_generator.py` — switch from `gpt_5_model` to `gpt_5_4_model`.
- `lib/agents/claim_verifier.py` — switch from `gpt_5_2_model` to `gpt_5_4_model`.
- `lib/agents/document_chunker.py` — switch from `gpt_4_1_model` to `gpt_5_mini_model` (now `gpt-5.4-mini`).
- `lib/agents/footnote_extractor.py` — switch from `gpt_5_2_model` to `gpt_5_4_model`.
- `lib/agents/literature_review.py` — switch from `gpt_5_2_model` to `gpt_5_4_model`.
- `lib/agents/methodology_comparator.py` — switch from `gpt_5_2_model` to `gpt_5_4_model`.
- `lib/agents/reference_text_extractor_v2.py` — switch from `gpt_5_2_model` to `gpt_5_4_model`.
- `lib/workflows/simple_deep_agent/agent.py` — bump from `gpt_5_4_model` to `gpt_5_5_model`.

### Frontend

No frontend changes.

## Risks and Mitigations

- **Behavioral drift from model upgrades**: agent outputs may differ slightly under the new models. Mitigated by existing eval suites under `evals_inspectai/` — recommend running affected workflows' evals before merging.
- **Removed model references**: any external code or configs referencing the deleted `gpt-5`/`gpt-5.1`/`gpt-5.2`/`gpt-4.1` entries would break. Verified no remaining usages in this repo.
- **`gpt_5_mini_model` semantics changed**: the variable now points to `gpt-5.4-mini` instead of `gpt-5-mini`. Any agent using it will pick up the new model automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)