### PR TITLE
feat(mcp): support human-approval workflows and stop wizard redirect

### DIFF
--- a/frontend/app/(authenticated)/new/page.tsx
+++ b/frontend/app/(authenticated)/new/page.tsx
@@ -2,12 +2,11 @@
 
 import { useMemo } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
-import { WizardProvider, useWizard, WizardStep } from '@/components/analysis-wizard/wizard-context';
+import { WizardProvider, useWizard } from '@/components/analysis-wizard/wizard-context';
 import { StepIndicator } from '@/components/analysis-wizard/step-indicator';
 import { StepUpload } from '@/components/analysis-wizard/step-upload';
 import { StepAnalyses } from '@/components/analysis-wizard/step-analyses';
 import { StepApiKeyConfig } from '@/components/analysis-wizard/step-api-key-config';
-import { useSearchParams } from 'next/navigation';
 import { useUserMe } from '@/lib/hooks/use-user-me';
 import { Loader2 } from 'lucide-react';
 
@@ -63,15 +62,8 @@ function WizardContent() {
 }
 
 export default function New() {
-  const searchParams = useSearchParams();
-  const projectIdFromUrl = searchParams.get('projectId');
-  const stepFromUrl = searchParams.get('step');
-
-  const initialStep: WizardStep | undefined =
-    stepFromUrl && ['1', '2'].includes(stepFromUrl) ? (parseInt(stepFromUrl, 10) as WizardStep) : undefined;
-
   return (
-    <WizardProvider initialProjectId={projectIdFromUrl} initialStep={initialStep}>
+    <WizardProvider>
       <WizardContent />
     </WizardProvider>
   );

--- a/frontend/app/(authenticated)/projects/[projectId]/page.tsx
+++ b/frontend/app/(authenticated)/projects/[projectId]/page.tsx
@@ -5,23 +5,17 @@ import { useWorkflowProgressToast } from '@/hooks/use-workflow-progress-toast';
 import { getErrorMessage, isApiError } from '@/lib/api-error';
 import { AccessLevel, ProjectDetailed, updateProjectEndpointApiProjectProjectIdPatch } from '@/lib/generated-api';
 import { useProjectDetails } from '@/lib/hooks/use-project-details';
-import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
-import { isAnyWorkflowProcessing, needsHumanApproval, needsWizardCompletion } from '@/lib/workflow-state';
+import { isAnyWorkflowProcessing, needsHumanApproval } from '@/lib/workflow-state';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FileXIcon, LockIcon } from 'lucide-react';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
 export default function ResultsPage() {
   const params = useParams();
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const projectId = params.projectId as string;
   const queryClient = useQueryClient();
-
-  // Skip redirect check if coming from wizard (prevents race condition)
-  const fromWizard = searchParams.get('fromWizard') === 'true';
 
   // Revision state: null means "latest" (default)
   const [selectedRevision, setSelectedRevision] = useState<number | null>(null);
@@ -35,33 +29,12 @@ export default function ResultsPage() {
   const handleRevisionChange = useCallback((rev: number) => {
     setSelectedRevision(rev);
   }, []);
-  const { workflowTypes } = useWorkflowTypes();
 
   const isProcessing = isAnyWorkflowProcessing(workflowDetails);
   const awaitingHumanApproval = needsHumanApproval(workflowDetails);
   // HumanApproval stays Pending/Running until the user approves, which keeps isProcessing true even though
   // the pipeline is intentionally paused. The progress API then has no active step → "Going to next step...".
   const showWorkflowProgressToast = isProcessing && !awaitingHumanApproval;
-
-  // Build internal types set from API data
-  const internalTypes = useMemo(() => {
-    return new Set(workflowTypes.filter((wt) => wt.is_internal).map((wt) => wt.type));
-  }, [workflowTypes]);
-
-  // Redirect to wizard step 2 if project only has document processing started
-  // Skip if we just came from the wizard (workflows may not be in DB yet)
-  // Skip if the project has multiple revisions (user already chose analyses before)
-  const hasMultipleRevisions = (project?.project?.current_revision ?? 1) > 1;
-  useEffect(() => {
-    if (fromWizard || isLoading || workflowDetails.length === 0 || hasMultipleRevisions) {
-      return;
-    }
-
-    if (needsWizardCompletion(workflowDetails, internalTypes)) {
-      router.replace(`/new?projectId=${projectId}`);
-      return;
-    }
-  }, [fromWizard, isLoading, workflowDetails, projectId, router, internalTypes, hasMultipleRevisions]);
 
   // Show progress in toast when automated workflows are running (not while waiting on reference review / approve)
   useWorkflowProgressToast(projectId, showWorkflowProgressToast);

--- a/frontend/components/analysis-wizard/step-analyses.tsx
+++ b/frontend/components/analysis-wizard/step-analyses.tsx
@@ -63,7 +63,7 @@ export function StepAnalyses() {
     },
     onSuccess: () => {
       toast.success('Assessment started! Redirecting to your project...');
-      router.push(`/projects/${wizard.projectId}?fromWizard=true`);
+      router.push(`/projects/${wizard.projectId}`);
     },
     onError: (error) => {
       toast.error(getErrorMessage(error, 'Failed to start assessment'));
@@ -154,7 +154,7 @@ export function StepAnalyses() {
           variant="outline"
           size="lg"
           className="w-full"
-          onClick={() => router.push(`/projects/${wizard.projectId}?fromWizard=true`)}
+          onClick={() => router.push(`/projects/${wizard.projectId}`)}
         >
           Skip for now
         </Button>

--- a/frontend/components/analysis-wizard/wizard-context.tsx
+++ b/frontend/components/analysis-wizard/wizard-context.tsx
@@ -22,24 +22,20 @@ interface WizardContextValue extends WizardState {
   setPreflightStatus: (status: Partial<WizardState['preflightStatus']>) => void;
   setSelectedWorkflowTypes: (types: WorkflowRunType[]) => void;
   nextStep: () => void;
-  goToStep: (step: WizardStep) => void;
 }
 
 const WizardContext = createContext<WizardContextValue | null>(null);
 
 interface WizardProviderProps {
   children: ReactNode;
-  initialProjectId?: string | null;
-  initialStep?: WizardStep;
 }
 
-export function WizardProvider({ children, initialProjectId = null, initialStep }: WizardProviderProps) {
-  // If initialStep is provided, use it. Otherwise, default to step 2 if we have a projectId, else step 1
-  const [currentStep, setCurrentStep] = useState<WizardStep>(initialStep ?? (initialProjectId ? 2 : 1));
+export function WizardProvider({ children }: WizardProviderProps) {
+  const [currentStep, setCurrentStep] = useState<WizardStep>(1);
   const [mainDocument, setMainDocument] = useState<File | null>(null);
-  const [projectId, setProjectId] = useState<string | null>(initialProjectId);
+  const [projectId, setProjectId] = useState<string | null>(null);
   const [preflightStatus, setPreflightStatusState] = useState<WizardState['preflightStatus']>({
-    format: initialProjectId ? 'valid' : 'idle',
+    format: 'idle',
   });
   const [selectedWorkflowTypes, setSelectedWorkflowTypes] = useState<WorkflowRunType[]>([]);
 
@@ -56,10 +52,6 @@ export function WizardProvider({ children, initialProjectId = null, initialStep 
     setCurrentStep((prev) => (prev < 2 ? ((prev + 1) as WizardStep) : prev));
   }, []);
 
-  const goToStep = useCallback((step: WizardStep) => {
-    setCurrentStep(step);
-  }, []);
-
   const value = useMemo(
     () => ({
       currentStep,
@@ -73,7 +65,6 @@ export function WizardProvider({ children, initialProjectId = null, initialStep 
       setPreflightStatus,
       setSelectedWorkflowTypes,
       nextStep,
-      goToStep,
     }),
     [
       currentStep,
@@ -84,7 +75,6 @@ export function WizardProvider({ children, initialProjectId = null, initialStep 
       needsReferencesStep,
       setPreflightStatus,
       nextStep,
-      goToStep,
     ],
   );
 

--- a/frontend/lib/workflow-state.ts
+++ b/frontend/lib/workflow-state.ts
@@ -155,27 +155,6 @@ export function isAnyWorkflowProcessing(workflowRuns: WorkflowRunDetail[]): bool
 }
 
 /**
- * Checks if a project needs wizard completion (step 2).
- *
- * A project needs completion when:
- * - It has DOCUMENT_PROCESSING workflow (started via step 1)
- * - It has NO other user-visible analysis workflows started
- *
- * This indicates the user created a project in step 1 but didn't complete step 2.
- *
- * @param workflowRuns - The workflow runs to check
- * @param internalTypes - Set of workflow types that are internal (from API)
- */
-export function needsWizardCompletion(workflowRuns: WorkflowRunDetail[], internalTypes: Set<WorkflowRunType>): boolean {
-  if (workflowRuns.length === 0) return false;
-
-  const hasDocProcessing = workflowRuns.some((w) => w.run.type === WorkflowRunType.DocumentProcessing);
-  const hasUserWorkflows = workflowRuns.some((w) => !internalTypes.has(w.run.type));
-
-  return hasDocProcessing && !hasUserWorkflows;
-}
-
-/**
  * Checks if a project is waiting for human approval (step 3).
  *
  * A project needs human approval when:

--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -240,6 +240,14 @@ async def run_workflow(
     (e.g. "go ahead and start"), call this tool again with the same arguments
     plus approve_human_steps=True to record the approval and run the workflow.
 
+    When the gate triggers, also offer the user two options for filling in
+    missing supporting files:
+      1. Have Draft Detective auto-fetch them from the web — include
+         "reference_downloader" in workflow_types on the retry call.
+      2. Provide/upload the files directly — use get_tus_upload_credentials
+         with role="support" and the matching reference_id (look it up via
+         get_project) for each file, upload, then retry.
+
     Returns full project details including all workflow results, detected issues,
     and a project_url link to view the project in the web UI.
 
@@ -280,9 +288,19 @@ async def run_workflow(
                     "mappings before it can run. Share the project_url with the user "
                     "so they can review references in the web UI, or offer to list "
                     "the references and supporting-file mappings here (use "
-                    "get_project to fetch them). Once the user confirms (e.g. they "
-                    "reply with something like 'go ahead and start'), call run_workflow "
-                    "again with the same arguments plus approve_human_steps=true."
+                    "get_project to fetch them).\n\n"
+                    "Offer the user these options for filling in missing supporting "
+                    "files before approving:\n"
+                    "  1. Have Draft Detective auto-fetch them from the web — add "
+                    "'reference_downloader' to workflow_types on the retry call.\n"
+                    "  2. Provide/upload the files yourself — call "
+                    "get_tus_upload_credentials with role='support' and the "
+                    "matching reference_id (from get_project) for each file, then "
+                    "upload via the returned TUS endpoint before retrying.\n\n"
+                    "Once the user confirms (e.g. 'go ahead and start'), call "
+                    "run_workflow again with the same arguments plus "
+                    "approve_human_steps=true (and 'reference_downloader' in "
+                    "workflow_types if they opted into option 1)."
                 ),
             }
         )

--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -15,7 +15,10 @@ from mcp.types import ToolAnnotations
 
 from lib.api.mcp_auth import create_mcp_auth
 from lib.api.models import StartMultipleWorkflowsRequest
-from lib.api.services.workflow_runner import run_multiple_workflows_blocking
+from lib.api.services.workflow_runner import (
+    HumanApprovalRequiredError,
+    run_multiple_workflows_blocking,
+)
 from lib.config.env import config as env_config
 from lib.models.file import File as FileModel, FileRole
 from lib.models.project import AccessLevel
@@ -212,6 +215,7 @@ async def create_project(
 async def run_workflow(
     project_id: str,
     workflow_types: list[str],
+    approve_human_steps: bool = False,
     token: AccessToken = CurrentAccessToken(),
 ) -> str:
     """
@@ -227,6 +231,14 @@ async def run_workflow(
 
     workflow_types must be a list of type values returned by list_workflow_types
     (e.g. ["claim_extraction", "reference_validation"]).
+
+    Some workflows (e.g. claim_reference_validation_v2) gate on a human review
+    of the reference→file mappings before running. On the first call, leave
+    approve_human_steps=False (the default): the tool returns a JSON response
+    with status="human_approval_required" pointing the user at the project URL
+    so they can review references first. After the user explicitly confirms
+    (e.g. "go ahead and start"), call this tool again with the same arguments
+    plus approve_human_steps=True to record the approval and run the workflow.
 
     Returns full project details including all workflow results, detected issues,
     and a project_url link to view the project in the web UI.
@@ -250,7 +262,30 @@ async def run_workflow(
         workflow_types=parsed_types,
     )
 
-    await run_multiple_workflows_blocking(parsed_types, request, user)
+    try:
+        await run_multiple_workflows_blocking(
+            parsed_types, request, user, approve_human_steps=approve_human_steps
+        )
+    except HumanApprovalRequiredError as exc:
+        return json.dumps(
+            {
+                "status": "human_approval_required",
+                "project_id": exc.project_id,
+                "project_url": _build_project_url(exc.project_id),
+                "pending_workflow_types": [
+                    w.value for w in exc.pending_workflow_types
+                ],
+                "message": (
+                    "This workflow requires the user to review the reference→file "
+                    "mappings before it can run. Share the project_url with the user "
+                    "so they can review references in the web UI, or offer to list "
+                    "the references and supporting-file mappings here (use "
+                    "get_project to fetch them). Once the user confirms (e.g. they "
+                    "reply with something like 'go ahead and start'), call run_workflow "
+                    "again with the same arguments plus approve_human_steps=true."
+                ),
+            }
+        )
 
     return await _get_project_details_json(project_id, AccessLevel.WRITE, user)
 

--- a/lib/api/services/workflow_runner.py
+++ b/lib/api/services/workflow_runner.py
@@ -37,6 +37,24 @@ class AutoRunWorkflowItem(BaseModel):
     workflow_run_id: str
 
 
+class HumanApprovalRequiredError(Exception):
+    """Raised when a blocking workflow run hits an unsatisfied human-trigger gate.
+
+    Carries the project_id and the human-trigger workflow types that still
+    need approval so callers (e.g. the MCP tool) can render a useful prompt.
+    """
+
+    def __init__(
+        self, project_id: str, pending_workflow_types: List[WorkflowRunType]
+    ):
+        self.project_id = project_id
+        self.pending_workflow_types = pending_workflow_types
+        super().__init__(
+            f"Human approval required for project {project_id}: "
+            f"{[w.value for w in pending_workflow_types]}"
+        )
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -56,7 +74,16 @@ async def _prepare_workflow_items(
     workflow_types: List[WorkflowRunType],
     request: StartMultipleWorkflowsRequest,
     user: User,
-) -> tuple[Project, int, List[str], List[AutoRunWorkflowItem]]:
+    *,
+    approve_human_steps: bool = False,
+    raise_on_pending_human_steps: bool = False,
+) -> tuple[
+    Project,
+    int,
+    List[str],
+    List[AutoRunWorkflowItem],
+    List[WorkflowRunType],
+]:
     """
     Resolve dependencies, apply skip logic, create run records, and build the
     list of items ready for execution.
@@ -86,6 +113,11 @@ async def _prepare_workflow_items(
 
     workflow_run_ids: List[str] = []
     auto_run_items: List[AutoRunWorkflowItem] = []
+    pending_human_triggers: List[WorkflowRunType] = []
+    # Workflows blocked behind an unsatisfied human-trigger gate (the gate
+    # itself plus anything downstream of it). resolved_workflow_types is in
+    # topological order, so a single forward pass is sufficient.
+    blocked_set: set[WorkflowRunType] = set()
 
     revision = project.current_revision
 
@@ -112,6 +144,36 @@ async def _prepare_workflow_items(
             )
             continue
 
+        # If any required dep is blocked behind a pending human-trigger gate,
+        # this workflow is downstream and must be deferred to the post-approval
+        # retry. Don't create a PENDING record either — the next call will.
+        if any(dep in blocked_set for dep in manifest.required_dependencies):
+            logger.info(
+                f"Deferring {workflow_type.value} - depends on a workflow blocked by human approval"
+            )
+            blocked_set.add(workflow_type)
+            continue
+
+        run_as_approved = False
+        if manifest.requires_human_trigger:
+            previously_approved = await has_completed_workflow_run_any_revision(
+                request.project_id, workflow_type
+            )
+            if not previously_approved and not approve_human_steps:
+                if raise_on_pending_human_steps:
+                    pending_human_triggers.append(workflow_type)
+                    blocked_set.add(workflow_type)
+                    # Don't create a PENDING record — the caller is about to
+                    # be told to retry with approval, not to use the UI.
+                    continue
+                # UI path: create the PENDING record below so the UI can show
+                # the approve button, but don't add to auto_run_items.
+            else:
+                run_as_approved = True
+                logger.info(
+                    f"Workflow {workflow_type.value} {'auto-approved by caller' if approve_human_steps and not previously_approved else 'previously approved'} - auto-running"
+                )
+
         workflow_config = create_workflow_config(
             project, workflow_type, request.openai_api_key
         )
@@ -127,20 +189,11 @@ async def _prepare_workflow_items(
 
         workflow_run_ids.append(workflow_run_id)
 
-        if manifest.requires_human_trigger:
-            # If the user already approved this workflow in a prior run (any revision),
-            # treat it as cached and auto-complete instead of waiting for another click.
-            previously_approved = await has_completed_workflow_run_any_revision(
-                request.project_id, workflow_type
-            )
-            if not previously_approved:
-                logger.info(
-                    f"Workflow {workflow_type.value} requires human trigger - skipping auto-run"
-                )
-                continue
+        if manifest.requires_human_trigger and not run_as_approved:
             logger.info(
-                f"Workflow {workflow_type.value} previously approved - auto-running"
+                f"Workflow {workflow_type.value} requires human trigger - skipping auto-run"
             )
+            continue
 
         auto_run_items.append(
             AutoRunWorkflowItem(
@@ -150,7 +203,13 @@ async def _prepare_workflow_items(
             )
         )
 
-    return project, revision, workflow_run_ids, auto_run_items
+    return (
+        project,
+        revision,
+        workflow_run_ids,
+        auto_run_items,
+        pending_human_triggers,
+    )
 
 
 async def start_workflow_run(
@@ -227,7 +286,7 @@ async def start_multiple_workflow_runs(
     Raises:
         HTTPException: If project_id is missing or project doesn't exist
     """
-    _, revision, workflow_run_ids, auto_run_items = await _prepare_workflow_items(
+    _, revision, workflow_run_ids, auto_run_items, _ = await _prepare_workflow_items(
         workflow_types, request, user
     )
 
@@ -253,6 +312,8 @@ async def run_multiple_workflows_blocking(
     workflow_types: List[WorkflowRunType],
     request: StartMultipleWorkflowsRequest,
     user: User,
+    *,
+    approve_human_steps: bool = False,
 ) -> tuple[Project, List[str]]:
     """
     Prepare and run multiple workflows sequentially, blocking until all complete.
@@ -265,14 +326,35 @@ async def run_multiple_workflows_blocking(
         workflow_types: List of workflow types to run (dependencies resolved automatically)
         request: Request containing project_id and optional openai_api_key
         user: User running the workflows
+        approve_human_steps: When True, treat any unsatisfied human-trigger
+            dependency as approved by the caller and run it inline. When False
+            (default), raises HumanApprovalRequiredError so the caller can
+            prompt the user to confirm before retrying with approval.
 
     Returns:
         A tuple of (project, list of workflow_run_ids for all created runs)
+
+    Raises:
+        HumanApprovalRequiredError: when approve_human_steps is False and a
+            resolved dependency requires human approval.
     """
-    project, revision, workflow_run_ids, auto_run_items = await _prepare_workflow_items(
-        workflow_types, request, user
+    (
+        project,
+        revision,
+        workflow_run_ids,
+        auto_run_items,
+        pending_human_triggers,
+    ) = await _prepare_workflow_items(
+        workflow_types,
+        request,
+        user,
+        approve_human_steps=approve_human_steps,
+        raise_on_pending_human_steps=not approve_human_steps,
     )
 
+    # Run upstream prep (e.g. document_processing, reference_extraction,
+    # reference_file_matching) before raising — the user needs those results
+    # in order to review the references and decide whether to approve.
     for item in auto_run_items:
         await run_workflow_from_config(
             config=item.config,
@@ -280,6 +362,12 @@ async def run_multiple_workflows_blocking(
             workflow_run_id=item.workflow_run_id,
             user=user,
             revision=revision,
+        )
+
+    if pending_human_triggers:
+        raise HumanApprovalRequiredError(
+            project_id=str(project.id),
+            pending_workflow_types=pending_human_triggers,
         )
 
     return project, workflow_run_ids

--- a/lib/models/bibliography_item.py
+++ b/lib/models/bibliography_item.py
@@ -25,6 +25,10 @@ class BibliographyItem(BaseModel):
         default=None,
         description="The UUID of the associated supporting document file in the database (if matched)",
     )
+    reference_id: Optional[str] = Field(
+        default=None,
+        description="The ID of the underlying ExtractedReference, when available.",
+    )
 
 
 def get_associated_supporting_file(

--- a/lib/services/file_artifacts_service/file_artifacts_service.py
+++ b/lib/services/file_artifacts_service/file_artifacts_service.py
@@ -345,6 +345,7 @@ class FileArtifactsService(FileArtifactsServiceType):
                         file_names.get(file_id, "") if file_id else ""
                     ),
                     file_id=file_id,
+                    reference_id=ref.id,
                 )
             )
 

--- a/lib/services/markdown_conversion.py
+++ b/lib/services/markdown_conversion.py
@@ -1,0 +1,88 @@
+"""Convert files to markdown and persist them as cached DB artifacts.
+
+Used by any workflow that needs the cached `File.markdown` column populated —
+either as part of normal document processing, or after introducing new files
+mid-pipeline (e.g. files downloaded by `reference_downloader`).
+"""
+
+import logging
+import os
+import shutil
+
+from langchain_core.messages.utils import count_tokens_approximately
+
+from lib.services.converters.base import convert_to_markdown as convert_to_markdown_fn
+from lib.services.converters.docx_preprocessor import docx_preprocessor
+from lib.services.file import FileDocument
+from lib.services.files import (
+    get_file_by_id,
+    load_file_document,
+    update_file_artifacts,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def convert_file_document_to_markdown(
+    file_document: FileDocument,
+) -> FileDocument:
+    """Return a copy of ``file_document`` with its markdown content populated.
+
+    Handles legacy ``.doc`` files by first converting them to ``.docx``. If
+    the document already has markdown set, returns it unchanged.
+    """
+    if file_document.markdown:
+        logger.info(
+            f"Using cached markdown for file {file_document.file_name} ({file_document.file_id})"
+        )
+        return file_document
+
+    file_path = file_document.file_path.lower()
+    is_legacy_doc_mime = file_document.file_type == "application/msword"
+    is_legacy_doc_extension = file_path.endswith(".doc")
+
+    if is_legacy_doc_mime:
+        docx_file_path = await docx_preprocessor.convert_doc_to_docx(file_path)
+        logger.info(f"Converted {file_path} to DOCX: {docx_file_path}")
+        markdown = await convert_to_markdown_fn(docx_file_path, converter="markitdown")
+        os.remove(docx_file_path)
+    elif is_legacy_doc_extension:
+        docx_file_path = file_path.replace(".doc", ".docx")
+        shutil.copy(file_path, docx_file_path)
+        logger.info(f"Copied {file_path} to {docx_file_path}")
+        markdown = await convert_to_markdown_fn(docx_file_path, converter="markitdown")
+        os.remove(docx_file_path)
+    else:
+        markdown = await convert_to_markdown_fn(file_path, converter="markitdown")
+
+    return file_document.model_copy(
+        update={
+            "markdown": markdown,
+            "markdown_token_count": count_tokens_approximately([markdown]),
+        }
+    )
+
+
+async def convert_and_cache_file_markdown(file_id: str) -> None:
+    """Convert a file to markdown (if not already cached) and persist to DB.
+
+    Loads the file by id, runs markdown conversion when ``has_cached_markdown``
+    is False, and writes the result back via ``update_file_artifacts`` so
+    consumers reading via ``file_artifacts_service.get_supporting_files()``
+    take the live-DB path instead of the stale ``DocumentProcessingState``
+    fallback.
+    """
+    file = await get_file_by_id(file_id)
+    if file.has_cached_markdown:
+        return
+
+    file_document = await load_file_document(file, use_cached_artifacts=False)
+    converted = await convert_file_document_to_markdown(file_document)
+    if not converted.markdown:
+        logger.warning(
+            "Markdown conversion produced empty content for file %s; skipping cache write",
+            file_id,
+        )
+        return
+
+    await update_file_artifacts(file_id=file_id, markdown=converted.markdown)

--- a/lib/workflows/claim_reference_validation_v2/manifest.py
+++ b/lib/workflows/claim_reference_validation_v2/manifest.py
@@ -115,7 +115,7 @@ class ClaimReferenceValidationV2Manifest(
         WorkflowRunType.HUMAN_APPROVAL,
     ]
     optional_dependencies = [
-        WorkflowRunType.CHUNK_SPLITTING,
+        WorkflowRunType.REFERENCE_DOWNLOADER,
     ]
 
     def get_state_type(self) -> Type[ClaimReferenceValidationV2State]:

--- a/lib/workflows/document_processing/nodes/convert_to_markdown.py
+++ b/lib/workflows/document_processing/nodes/convert_to_markdown.py
@@ -1,18 +1,14 @@
 import logging
-import os
-import shutil
 
-from langchain_core.messages.utils import count_tokens_approximately
 from langgraph.runtime import Runtime
 
 from lib.run_utils import run_tasks
-from lib.services.converters.base import convert_to_markdown as convert_to_markdown_fn
-from lib.services.converters.docx_preprocessor import docx_preprocessor
 from lib.services.file import FileDocument
+from lib.services.files import update_file_artifacts
+from lib.services.markdown_conversion import convert_file_document_to_markdown
 from lib.workflows.context import ContextSchema
 from lib.workflows.decorators import register_node
 from lib.workflows.document_processing.state import DocumentProcessingState
-from lib.services.files import update_file_artifacts
 
 logger = logging.getLogger(__name__)
 
@@ -76,64 +72,4 @@ async def _convert_to_markdown_task(
     Returns:
         FileDocument with converted markdown content and metadata
     """
-
-    if file_document.markdown:
-        logger.info(
-            f"Using cached markdown for file {file_document.file_name} ({file_document.file_id})"
-        )
-        return file_document
-
-    return await _convert_to_markdown_using_markitdown(file_document)
-
-
-async def _convert_to_markdown_using_markitdown(
-    file_document: FileDocument,
-) -> FileDocument:
-    """
-    Convert document to markdown using markitdown converter.
-
-    Handles legacy .doc files by first converting them to .docx format.
-    Calculates token count for the resulting markdown content.
-
-    Args:
-        file_document: The document to convert
-
-    Returns:
-        FileDocument with markdown content and token count
-    """
-
-    file_path = file_document.file_path.lower()
-    is_legacy_doc_mime = file_document.file_type == "application/msword"
-    is_legacy_doc_extension = file_path.endswith(".doc")
-
-    if is_legacy_doc_mime:
-        docx_file_path = await docx_preprocessor.convert_doc_to_docx(file_path)
-        logger.info(f"Converted {file_path} to DOCX: {docx_file_path}")
-        markdown = await convert_to_markdown_fn(docx_file_path, converter="markitdown")
-        os.remove(docx_file_path)
-    elif is_legacy_doc_extension:
-        docx_file_path = await _copy_doc_to_docx(file_path)
-        logger.info(f"Copied {file_path} to {docx_file_path}")
-        markdown = await convert_to_markdown_fn(docx_file_path, converter="markitdown")
-        os.remove(docx_file_path)
-    else:
-        markdown = await convert_to_markdown_fn(file_path, converter="markitdown")
-
-    markdown_token_count = count_tokens_approximately([markdown])
-
-    return file_document.model_copy(
-        update={
-            "markdown": markdown,
-            "markdown_token_count": markdown_token_count,
-        }
-    )
-
-
-async def _copy_doc_to_docx(file_path: str) -> str:
-    """
-    Copy a .doc file to a .docx file in the same directory.
-    """
-
-    docx_file_path = file_path.replace(".doc", ".docx")
-    shutil.copy(file_path, docx_file_path)
-    return docx_file_path
+    return await convert_file_document_to_markdown(file_document)

--- a/lib/workflows/reference_downloader/manifest.py
+++ b/lib/workflows/reference_downloader/manifest.py
@@ -8,9 +8,9 @@ from lib.workflows.manifest import WorkflowManifest
 from lib.workflows.models import DocumentIssue, WorkflowRunType
 from lib.workflows.reference_downloader.graph import build_reference_downloader_graph
 from lib.workflows.reference_downloader.state import (
-    ReferenceFetchStatus,
     ReferenceDownloaderState,
     ReferenceDownloaderWorkflowConfig,
+    ReferenceFetchStatus,
 )
 from lib.workflows.workflow_types import WorkflowState
 
@@ -23,7 +23,14 @@ class ReferenceDownloaderManifest(
     description = "Search the web for each reference and download the related full-text when available (PDF or Markdown)."
     needs_web_search = True
     is_internal = True
-    optional_dependencies = []
+    # Required so callers triggering this workflow without an explicit
+    # `references` list (e.g. via /api/workflows/start-multiple or MCP) have
+    # the upstream extraction available to derive the default "all unmatched"
+    # reference set. File matching is only optional — it doesn't have to have
+    # run, but if it is currently running we wait so the unmatched set is
+    # accurate.
+    required_dependencies = [WorkflowRunType.REFERENCE_EXTRACTION]
+    optional_dependencies = [WorkflowRunType.REFERENCE_FILE_MATCHING]
 
     def get_state_type(self) -> Type[ReferenceDownloaderState]:
         """Get the type of the workflow state."""

--- a/lib/workflows/reference_downloader/nodes/fetch_references.py
+++ b/lib/workflows/reference_downloader/nodes/fetch_references.py
@@ -13,6 +13,7 @@ from lib.services.files import (
     get_supporting_candidate_files,
     update_files_role,
 )
+from lib.services.markdown_conversion import convert_and_cache_file_markdown
 from lib.workflows.context import ContextSchema
 from lib.workflows.decorators import register_node
 from lib.workflows.reference_downloader.agents.reference_fetcher import (
@@ -122,6 +123,20 @@ async def fetch_single_reference(state: dict, runtime: Runtime[ContextSchema]):
         if status == ReferenceFetchStatus.COMPLETED and result and result.file_id:
             # Promote file immediately (from SUPPORTING_CANDIDATE to SUPPORT)
             await update_files_role([result.file_id], FileRole.SUPPORT)
+            # Convert and cache markdown so file_artifacts_service.get_supporting_files()
+            # serves the new file via the live-DB path. Without this,
+            # claim_reference_validation_v2 falls back to the stale
+            # DocumentProcessingState (which predates this download) and
+            # reports every claim as "unverifiable".
+            try:
+                await convert_and_cache_file_markdown(result.file_id)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to cache markdown for downloaded file %s: %s",
+                    result.file_id,
+                    exc,
+                    exc_info=True,
+                )
             # Update the reference file matching in the ReferenceExtraction workflow state
             await _update_reference_file_matching(
                 project_id, result.file_id, reference_id, runtime.context.revision

--- a/lib/workflows/reference_downloader/nodes/fetch_references.py
+++ b/lib/workflows/reference_downloader/nodes/fetch_references.py
@@ -5,6 +5,9 @@ from langgraph.runtime import Runtime
 from langgraph.types import Send
 
 from lib.models.file import FileRole
+from lib.services.file_artifacts_service.file_artifacts_service_type import (
+    FileArtifactsServiceType,
+)
 from lib.services.files import (
     delete_project_files,
     get_supporting_candidate_files,
@@ -18,6 +21,7 @@ from lib.workflows.reference_downloader.agents.reference_fetcher import (
     ReferenceFetcherAgentInput,
 )
 from lib.workflows.reference_downloader.state import (
+    ReferenceDownloaderInputItem,
     ReferenceDownloaderState,
     ReferenceFetchResult,
     ReferenceFetchStatus,
@@ -34,8 +38,16 @@ async def initialize_references(
 
     This allows the frontend to display all references right away
     before any fetching has started.
+
+    When the caller did not supply an explicit `references` list, default to
+    every extracted reference that does not yet have a matched supporting
+    file.
     """
-    references = state.config.references or []
+    references = state.config.references
+    if references is None:
+        references = await _load_unmatched_references(
+            runtime.context.file_artifacts_service
+        )
 
     pending_results = [
         ReferenceFetchResult(
@@ -51,21 +63,31 @@ async def initialize_references(
     return {"fetched_references": pending_results}
 
 
+async def _load_unmatched_references(
+    file_artifacts_service: FileArtifactsServiceType,
+) -> List[ReferenceDownloaderInputItem]:
+    """Fetch every extracted reference that does not yet have a matched file."""
+    references = await file_artifacts_service.get_references()
+
+    return [
+        ReferenceDownloaderInputItem(reference_id=ref.reference_id, text=ref.text)
+        for ref in references
+        if not ref.has_associated_supporting_document and ref.reference_id is not None
+    ]
+
+
 @register_node("Distribute references")
 async def distribute_references(
     state: ReferenceDownloaderState, runtime: Runtime[ContextSchema]
 ):
-    """Fan-out node: creates a Send for each reference.
-
-    This node dispatches parallel fetch operations for each reference.
-    """
-    references = state.config.references or []
+    """Fan-out node: creates a Send for each reference initialized as PENDING."""
     return [
         Send(
             "fetch_single_reference",
-            {"reference": ref.text, "reference_id": ref.reference_id},
+            {"reference": ref.input_reference, "reference_id": ref.reference_id},
         )
-        for ref in references
+        for ref in state.fetched_references
+        if ref.status == ReferenceFetchStatus.PENDING
     ]
 
 

--- a/lib/workflows/reference_downloader/state.py
+++ b/lib/workflows/reference_downloader/state.py
@@ -71,8 +71,13 @@ class ReferenceDownloaderWorkflowConfig(BaseWorkflowConfig):
     type: Literal[WorkflowRunType.REFERENCE_DOWNLOADER] = Field(
         WorkflowRunType.REFERENCE_DOWNLOADER
     )
-    references: List[ReferenceDownloaderInputItem] = Field(
-        description="The references to fetch from the internet",
+    references: Optional[List[ReferenceDownloaderInputItem]] = Field(
+        default=None,
+        description=(
+            "The references to fetch from the internet. When omitted, the "
+            "workflow defaults to every extracted reference that does not yet "
+            "have a matched supporting file."
+        ),
     )
 
 

--- a/tests/unit/services/test_markdown_conversion.py
+++ b/tests/unit/services/test_markdown_conversion.py
@@ -1,0 +1,190 @@
+"""Unit tests for `lib.services.markdown_conversion`.
+
+DB and converter dependencies are mocked; the file under test is just a thin
+orchestrator over them, so the value is in pinning down its branching:
+cached-markdown short-circuit, legacy `.doc` MIME / extension handling, and
+the cache-write path in ``convert_and_cache_file_markdown``.
+"""
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.services.file import FileDocument
+from lib.services.markdown_conversion import (
+    convert_and_cache_file_markdown,
+    convert_file_document_to_markdown,
+)
+
+MODULE = "lib.services.markdown_conversion"
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+def _file_document(
+    *,
+    file_path: str = "/uploads/abc.docx",
+    file_type: str = DOCX_MIME,
+    markdown: str = "",
+) -> FileDocument:
+    return FileDocument(
+        file_id=str(uuid.uuid4()),
+        file_path=file_path,
+        file_name="main_document.docx",
+        file_type=file_type,
+        markdown=markdown,
+        markdown_token_count=0,
+    )
+
+
+# --- convert_file_document_to_markdown ---
+
+
+@pytest.mark.asyncio
+async def test_returns_cached_markdown_unchanged():
+    cached = _file_document(markdown="# already converted")
+
+    with patch(f"{MODULE}.convert_to_markdown_fn") as convert_mock:
+        result = await convert_file_document_to_markdown(cached)
+
+    assert result is cached
+    convert_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_converts_modern_docx_via_markitdown():
+    doc = _file_document(file_path="/uploads/abc.docx")
+
+    with patch(
+        f"{MODULE}.convert_to_markdown_fn",
+        new=AsyncMock(return_value="# converted"),
+    ) as convert_mock:
+        result = await convert_file_document_to_markdown(doc)
+
+    convert_mock.assert_awaited_once_with("/uploads/abc.docx", converter="markitdown")
+    assert result is not doc
+    assert result.markdown == "# converted"
+    assert result.markdown_token_count > 0
+    assert doc.markdown == ""  # original untouched (model_copy)
+
+
+@pytest.mark.asyncio
+async def test_legacy_doc_mime_is_preprocessed_to_docx():
+    """`application/msword` triggers libreoffice conversion before markitdown."""
+    doc = _file_document(file_path="/uploads/legacy.doc", file_type="application/msword")
+    converted_path = "/uploads/legacy.docx"
+
+    preprocessor = MagicMock()
+    preprocessor.convert_doc_to_docx = AsyncMock(return_value=converted_path)
+
+    with (
+        patch(f"{MODULE}.docx_preprocessor", preprocessor),
+        patch(
+            f"{MODULE}.convert_to_markdown_fn",
+            new=AsyncMock(return_value="# legacy"),
+        ) as convert_mock,
+        patch(f"{MODULE}.os.remove") as remove_mock,
+    ):
+        result = await convert_file_document_to_markdown(doc)
+
+    preprocessor.convert_doc_to_docx.assert_awaited_once_with("/uploads/legacy.doc")
+    convert_mock.assert_awaited_once_with(converted_path, converter="markitdown")
+    remove_mock.assert_called_once_with(converted_path)
+    assert result.markdown == "# legacy"
+
+
+@pytest.mark.asyncio
+async def test_legacy_doc_extension_without_msword_mime_uses_copy_path():
+    """`.doc` extension (with non-msword MIME) is handled by copying to `.docx`."""
+    doc = _file_document(
+        file_path="/uploads/legacy.doc",
+        file_type="application/octet-stream",
+    )
+
+    with (
+        patch(f"{MODULE}.shutil.copy") as copy_mock,
+        patch(
+            f"{MODULE}.convert_to_markdown_fn",
+            new=AsyncMock(return_value="# copied"),
+        ) as convert_mock,
+        patch(f"{MODULE}.os.remove") as remove_mock,
+    ):
+        result = await convert_file_document_to_markdown(doc)
+
+    copy_mock.assert_called_once_with("/uploads/legacy.doc", "/uploads/legacy.docx")
+    convert_mock.assert_awaited_once_with(
+        "/uploads/legacy.docx", converter="markitdown"
+    )
+    remove_mock.assert_called_once_with("/uploads/legacy.docx")
+    assert result.markdown == "# copied"
+
+
+# --- convert_and_cache_file_markdown ---
+
+
+def _file_row(*, has_cached: bool, file_id: str | None = None) -> SimpleNamespace:
+    """Lightweight stand-in for a SQLModel `File` row."""
+    return SimpleNamespace(
+        id=file_id or str(uuid.uuid4()),
+        has_cached_markdown=has_cached,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cache_skip_when_file_already_has_markdown():
+    file_id = str(uuid.uuid4())
+    file_row = _file_row(has_cached=True, file_id=file_id)
+
+    with (
+        patch(f"{MODULE}.get_file_by_id", new=AsyncMock(return_value=file_row)),
+        patch(f"{MODULE}.load_file_document") as load_mock,
+        patch(f"{MODULE}.update_file_artifacts") as update_mock,
+    ):
+        await convert_and_cache_file_markdown(file_id)
+
+    load_mock.assert_not_called()
+    update_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cache_persists_converted_markdown():
+    file_id = str(uuid.uuid4())
+    file_row = _file_row(has_cached=False, file_id=file_id)
+    loaded = _file_document(markdown="")
+    converted = loaded.model_copy(update={"markdown": "# fresh", "markdown_token_count": 2})
+
+    with (
+        patch(f"{MODULE}.get_file_by_id", new=AsyncMock(return_value=file_row)),
+        patch(f"{MODULE}.load_file_document", new=AsyncMock(return_value=loaded)),
+        patch(
+            f"{MODULE}.convert_file_document_to_markdown",
+            new=AsyncMock(return_value=converted),
+        ),
+        patch(f"{MODULE}.update_file_artifacts", new=AsyncMock()) as update_mock,
+    ):
+        await convert_and_cache_file_markdown(file_id)
+
+    update_mock.assert_awaited_once_with(file_id=file_id, markdown="# fresh")
+
+
+@pytest.mark.asyncio
+async def test_cache_skips_write_when_conversion_yields_empty_markdown():
+    """Empty markdown shouldn't overwrite the DB cache (logged + skipped)."""
+    file_id = str(uuid.uuid4())
+    file_row = _file_row(has_cached=False, file_id=file_id)
+    loaded = _file_document(markdown="")
+    empty_converted = loaded.model_copy(update={"markdown": "", "markdown_token_count": 0})
+
+    with (
+        patch(f"{MODULE}.get_file_by_id", new=AsyncMock(return_value=file_row)),
+        patch(f"{MODULE}.load_file_document", new=AsyncMock(return_value=loaded)),
+        patch(
+            f"{MODULE}.convert_file_document_to_markdown",
+            new=AsyncMock(return_value=empty_converted),
+        ),
+        patch(f"{MODULE}.update_file_artifacts", new=AsyncMock()) as update_mock,
+    ):
+        await convert_and_cache_file_markdown(file_id)
+
+    update_mock.assert_not_called()

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -362,6 +362,69 @@ async def test_run_workflow_delegates_to_blocking_runner():
 
 
 @pytest.mark.asyncio
+async def test_run_workflow_passes_approve_human_steps_to_runner():
+    user = _make_user()
+    project_json = json.dumps({"id": "p1", "project_url": "http://x/projects/p1"})
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch(
+            "lib.api.mcp.run_multiple_workflows_blocking", new=AsyncMock()
+        ) as mock_run,
+        patch(
+            "lib.api.mcp._get_project_details_json",
+            new=AsyncMock(return_value=project_json),
+        ),
+    ):
+        await run_workflow(
+            project_id="p1",
+            workflow_types=["document_processing"],
+            approve_human_steps=True,
+            token=_make_token(),
+        )
+
+    mock_run.assert_awaited_once()
+    assert mock_run.await_args.kwargs["approve_human_steps"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_returns_human_approval_required_payload():
+    from lib.api.services.workflow_runner import HumanApprovalRequiredError
+    from lib.models.workflow_run import WorkflowRunType
+
+    user = _make_user()
+    err = HumanApprovalRequiredError(
+        project_id="p1",
+        pending_workflow_types=[WorkflowRunType.HUMAN_APPROVAL],
+    )
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch(
+            "lib.api.mcp.run_multiple_workflows_blocking",
+            new=AsyncMock(side_effect=err),
+        ),
+        patch(
+            "lib.api.mcp._get_project_details_json",
+            new=AsyncMock(),
+        ) as mock_details,
+    ):
+        result = await run_workflow(
+            project_id="p1",
+            workflow_types=["claim_reference_validation_v2"],
+            token=_make_token(),
+        )
+
+    data = json.loads(result)
+    assert data["status"] == "human_approval_required"
+    assert data["project_id"] == "p1"
+    assert "p1" in data["project_url"]
+    assert data["pending_workflow_types"] == [WorkflowRunType.HUMAN_APPROVAL.value]
+    assert "approve_human_steps=true" in data["message"]
+    mock_details.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_run_workflow_raises_when_no_api_key():
     user = _make_user()
     user.encrypted_openai_api_key = None


### PR DESCRIPTION
## Summary

- Adds an `approve_human_steps` argument to the MCP `run_workflow` tool so workflows gated on a human review (e.g. `claim_reference_validation_v2`) can run end-to-end from an MCP client.
- Removes the project-page → wizard redirect, so projects created via MCP (or any path that doesn't go through the wizard) land on the project page as expected.
- Makes the `reference_downloader` workflow's `references` input optional. When omitted (e.g. an MCP-triggered run), it now defaults to every extracted reference without a matched supporting file — mirroring the **Fetch from web** header action in the References tab.

Closes [RANDZ-550](https://linear.app/ae-studio/issue/RANDZ-550/human-approval-mcp).

## Motivation

`claim_reference_validation_v2` and similar workflows pause for a human approval step where the user reviews the reference→file mappings before validation runs. Previously, an MCP client invoking `run_workflow` would silently leave the human-trigger step pending, returning a "completed" response while the workflow was actually stuck. Combined with the legacy redirect that sent any project without a user-visible workflow back to wizard step 2, MCP-created projects were also unreachable in the UI without bouncing through the wizard.

Separately, `reference_downloader` couldn't be triggered through the generic `/api/workflows/start-multiple` (or MCP `run_workflow`) path because its config required a caller-supplied `references` list — `create_workflow_config` only knows the common workflow fields and would raise `ValidationError`. This blocked a natural MCP flow ("download every reference that doesn't have a source yet") that already exists as a button in the UI.

## What's Changed

### Backend

- `lib/api/services/workflow_runner.py`
  - Adds `HumanApprovalRequiredError`, raised by `run_multiple_workflows_blocking` when a resolved dependency needs approval and the caller didn't pre-approve it.
  - Adds an `approve_human_steps` flag and a `raise_on_pending_human_steps` mode to `_prepare_workflow_items`. When approval is granted inline, the gate workflow is auto-run instead of left pending; when approval is missing, the gate (and anything downstream of it) is deferred so the caller can be prompted.
  - Upstream prep workflows (document processing, reference extraction, reference→file matching) still run before the error is raised so the user has the data they need to review references.
- `lib/api/mcp.py`
  - Threads `approve_human_steps` through `run_workflow`, defaulting to `False`.
  - Catches `HumanApprovalRequiredError` and returns a structured `human_approval_required` JSON payload with the project URL, pending workflow types, and a message instructing the agent to confirm with the user before retrying with `approve_human_steps=true`.
  - Updates the tool docstring to document the two-call pattern.
- `lib/workflows/reference_downloader/state.py` — `ReferenceDownloaderWorkflowConfig.references` is now `Optional[List[ReferenceDownloaderInputItem]] = None`.
- `lib/workflows/reference_downloader/manifest.py` — declares `REFERENCE_EXTRACTION` as a required dependency (needed to derive the default reference set when the caller omits it) and `REFERENCE_FILE_MATCHING` as an optional dependency (so a concurrently running matching pass is awaited but isn't required to have ever run).
- `lib/workflows/reference_downloader/nodes/fetch_references.py` — `initialize_references` now resolves the reference list from `runtime.context.file_artifacts_service.get_references()` (filtered to entries without an associated supporting document) when `state.config.references` is `None`. `distribute_references` fans out from the `PENDING` entries that `initialize_references` just emitted, so it no longer needs `state.config.references` at all.
- `lib/models/bibliography_item.py` + `lib/services/file_artifacts_service/file_artifacts_service.py` — `BibliographyItem` now carries an optional `reference_id` so consumers can correlate matching results back to the underlying `ExtractedReference`. `FileArtifactsService.get_references()` populates it.
- `tests/unit/test_mcp_tools.py` — two new tests covering the `approve_human_steps` forwarding and the `human_approval_required` JSON payload returned when `HumanApprovalRequiredError` is raised.

### Frontend

- `frontend/app/(authenticated)/projects/[projectId]/page.tsx` — Removes the `useEffect` that redirected projects without a user-visible workflow back to `/new?projectId=…`. Drops the now-unused `fromWizard` query param read along with the `useWorkflowTypes`, `useRouter`, `useSearchParams`, `useEffect`, and `useMemo` imports.
- `frontend/components/analysis-wizard/step-analyses.tsx` — Drops the `?fromWizard=true` query param from both wizard navigations (it only existed to bypass the now-removed redirect).
- `frontend/lib/workflow-state.ts` — Removes the now-unused `needsWizardCompletion` helper.
- `frontend/app/(authenticated)/new/page.tsx` — Removes `useSearchParams` parsing of `projectId`/`step` query params; nothing in the app links to that resume URL anymore.
- `frontend/components/analysis-wizard/wizard-context.tsx` — Removes the `initialProjectId`/`initialStep` props from `WizardProvider` and the unused `goToStep` action that was exposed but never called. The wizard now always starts at step 1 with no project.

## Risks and Mitigations

- **Risk:** A pre-existing project that genuinely had no user-visible workflow will now land on an empty results view instead of being shepherded back to step 2. **Mitigation:** users can still trigger workflows from the project page; the previous redirect was a UX shortcut, not a correctness requirement.
- **Risk:** MCP callers that ignore the `human_approval_required` response could think the workflow finished. **Mitigation:** the response is a structured JSON payload with `status="human_approval_required"` and an explicit message instructing the agent to confirm with the user before retrying.
- **Risk:** `approve_human_steps=true` lets an MCP client skip the human review entirely. **Mitigation:** the docstring requires the model to obtain explicit user confirmation before passing the flag, and the project URL is always returned so the user can review references first.
- **Risk:** The `references` field on the `reference_downloader` request schema went from required to optional, so the regenerated Hey API client types will reflect that. The two existing call sites (`mutations.ts`) keep passing it explicitly, so behavior is unchanged. Run `pnpm run openapi-generate` to refresh the generated types.
- **Risk:** Adding `BibliographyItem.reference_id` could in theory affect serializers downstream; the field is `Optional[str]` defaulting to `None`, so existing payloads remain valid.