### PR TITLE
feat(workflows): self-healing for stuck workflow runs [RANDZ-551]

### DIFF
--- a/alembic/versions/6f5eebe4f144_add_workflow_run_failure_heartbeat_.py
+++ b/alembic/versions/6f5eebe4f144_add_workflow_run_failure_heartbeat_.py
@@ -1,0 +1,47 @@
+"""add workflow run failure + heartbeat fields
+
+Revision ID: 6f5eebe4f144
+Revises: f4ef6e0d9708
+Create Date: 2026-05-04 10:54:20.375734
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+from alembic_postgresql_enum import TableReference
+
+# revision identifiers, used by Alembic.
+revision: str = '6f5eebe4f144'
+down_revision: Union[str, None] = 'f4ef6e0d9708'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    sa.Enum('TIMEOUT', 'DEPENDENCY_TIMEOUT', 'NO_HEARTBEAT', 'UNHANDLED_EXCEPTION', name='workflowrunfailurereason').create(op.get_bind())
+    op.sync_enum_values(
+        enum_schema='public',
+        enum_name='workflowrunstatus',
+        new_values=['PENDING', 'RUNNING', 'COMPLETED', 'CANCELLED', 'FAILED'],
+        affected_columns=[TableReference(table_schema='public', table_name='workflow_runs', column_name='status', existing_server_default="'COMPLETED'::workflowrunstatus")],
+        enum_values_to_rename=[],
+    )
+    op.add_column('workflow_runs', sa.Column('heartbeat_at', sa.DateTime(timezone=True), nullable=True))
+    op.add_column('workflow_runs', sa.Column('failure_reason', sa.Enum('TIMEOUT', 'DEPENDENCY_TIMEOUT', 'NO_HEARTBEAT', 'UNHANDLED_EXCEPTION', name='workflowrunfailurereason'), nullable=True))
+    op.add_column('workflow_runs', sa.Column('failure_message', sa.String(length=2000), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('workflow_runs', 'failure_message')
+    op.drop_column('workflow_runs', 'failure_reason')
+    op.drop_column('workflow_runs', 'heartbeat_at')
+    op.sync_enum_values(
+        enum_schema='public',
+        enum_name='workflowrunstatus',
+        new_values=['PENDING', 'RUNNING', 'COMPLETED', 'CANCELLED'],
+        affected_columns=[TableReference(table_schema='public', table_name='workflow_runs', column_name='status', existing_server_default="'COMPLETED'::workflowrunstatus")],
+        enum_values_to_rename=[],
+    )
+    sa.Enum('TIMEOUT', 'DEPENDENCY_TIMEOUT', 'NO_HEARTBEAT', 'UNHANDLED_EXCEPTION', name='workflowrunfailurereason').drop(op.get_bind())

--- a/frontend/components/results/tabs/workflow-list-sidebar.tsx
+++ b/frontend/components/results/tabs/workflow-list-sidebar.tsx
@@ -6,9 +6,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { WorkflowRunDetail, WorkflowRunType } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
 import { cn } from '@/lib/utils';
-import { getDisplayStatus, hasCurrentRunErrors } from '@/lib/workflow-state';
+import { getDisplayStatus, hasCurrentRunErrors, isWorkflowFailed } from '@/lib/workflow-state';
 import { formatDistanceToNow } from 'date-fns';
-import { AlertTriangleIcon, ChevronDownIcon, InfoIcon, PlusIcon } from 'lucide-react';
+import { AlertTriangleIcon, ChevronDownIcon, InfoIcon, PlusIcon, XCircleIcon } from 'lucide-react';
 import { useState } from 'react';
 
 interface WorkflowListItemProps {
@@ -20,6 +20,8 @@ interface WorkflowListItemProps {
 function WorkflowListItem({ workflowDetail, isSelected, onSelect }: WorkflowListItemProps) {
   const displayStatus = getDisplayStatus(workflowDetail);
   const hasErrors = hasCurrentRunErrors(workflowDetail);
+  const hasFailed = isWorkflowFailed(workflowDetail);
+  const failureMessage = workflowDetail.run.failure_message;
   const { getWorkflowTypeName } = useWorkflowTypes();
 
   return (
@@ -39,6 +41,16 @@ function WorkflowListItem({ workflowDetail, isSelected, onSelect }: WorkflowList
                 <AlertTriangleIcon className="w-4 h-4 text-destructive cursor-help" />
               </TooltipTrigger>
               <TooltipContent>This workflow completed with errors. Please check them and try again.</TooltipContent>
+            </Tooltip>
+          )}
+          {hasFailed && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <XCircleIcon className="w-4 h-4 text-destructive cursor-help" />
+              </TooltipTrigger>
+              <TooltipContent>
+                {failureMessage ?? 'This workflow failed before it could complete. Please retry it.'}
+              </TooltipContent>
             </Tooltip>
           )}
         </div>

--- a/frontend/components/workflows/results/about-this-ger-results.tsx
+++ b/frontend/components/workflows/results/about-this-ger-results.tsx
@@ -6,8 +6,8 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AboutThisGerState, AgentCheckResult, WorkflowRunDetail } from '@/lib/generated-api';
-import { isWorkflowCancelled, isWorkflowProcessing } from '@/lib/workflow-state';
-import { AlertTriangle, Ban, BookOpen, CheckCircle2, FileQuestion, Loader2, Users } from 'lucide-react';
+import { isWorkflowCancelled, isWorkflowFailed, isWorkflowProcessing } from '@/lib/workflow-state';
+import { AlertTriangle, Ban, BookOpen, CheckCircle2, FileQuestion, Loader2, Users, XCircle } from 'lucide-react';
 import { useState } from 'react';
 
 interface AboutThisGerResultsProps {
@@ -148,6 +148,19 @@ export function AboutThisGerResults({ workflowDetail }: AboutThisGerResultsProps
         icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
         message="Assessment Cancelled"
         description="The About This (GER) assessment was cancelled before it could complete."
+      />
+    );
+  }
+
+  if (isWorkflowFailed(workflowDetail)) {
+    return (
+      <EmptyState
+        icon={<XCircle className="h-8 w-8 text-red-600 mx-auto" />}
+        message="Assessment Failed"
+        description={
+          workflowDetail.run.failure_message ??
+          'The About This (GER) assessment failed before it could complete. Please retry it.'
+        }
       />
     );
   }

--- a/frontend/components/workflows/results/advocacy-tone-results.tsx
+++ b/frontend/components/workflows/results/advocacy-tone-results.tsx
@@ -13,7 +13,12 @@ import {
   ProjectDetailed,
   WorkflowRunType,
 } from '@/lib/generated-api';
-import { getWorkflowRunByType, isWorkflowCancelled, isWorkflowProcessing } from '@/lib/workflow-state';
+import {
+  getWorkflowRunByType,
+  isWorkflowCancelled,
+  isWorkflowFailed,
+  isWorkflowProcessing,
+} from '@/lib/workflow-state';
 import {
   AlertTriangle,
   Ban,
@@ -22,6 +27,7 @@ import {
   FileWarning,
   Loader2,
   MessageSquareWarning,
+  XCircle,
   type LucideIcon,
 } from 'lucide-react';
 import { useMemo, useState } from 'react';
@@ -258,6 +264,19 @@ export function AdvocacyToneResults({ project, onNavigateToDocumentExplorer }: A
         icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
         message="Assessment Cancelled"
         description="The Advocacy & Tone assessment was cancelled before it could complete."
+      />
+    );
+  }
+
+  if (isWorkflowFailed(advocacyToneRun)) {
+    return (
+      <EmptyState
+        icon={<XCircle className="h-8 w-8 text-red-600 mx-auto" />}
+        message="Assessment Failed"
+        description={
+          advocacyToneRun.run.failure_message ??
+          'The Advocacy & Tone assessment failed before it could complete. Please retry it.'
+        }
       />
     );
   }

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -6,10 +6,15 @@ import { EmptyState } from '@/components/shared/empty-state';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { AgentCheckResult, SimpleDeepAgentState } from '@/lib/generated-api';
-import { isWorkflowCancelled, isWorkflowProcessing, WorkflowRunDetailTyped } from '@/lib/workflow-state';
+import {
+  isWorkflowCancelled,
+  isWorkflowFailed,
+  isWorkflowProcessing,
+  WorkflowRunDetailTyped,
+} from '@/lib/workflow-state';
 import { AssistantRuntimeProvider, ThreadMessageLike, useExternalStoreRuntime } from '@assistant-ui/react';
 import { convertLangChainMessages, LangChainMessage } from '@assistant-ui/react-langgraph';
-import { AlertTriangle, Ban, CheckCircle2, ClipboardList, Loader2, MessageSquare } from 'lucide-react';
+import { AlertTriangle, Ban, CheckCircle2, ClipboardList, Loader2, MessageSquare, XCircle } from 'lucide-react';
 
 interface SimpleDeepAgentResultsProps {
   workflowDetail: WorkflowRunDetailTyped<SimpleDeepAgentState>;
@@ -87,6 +92,19 @@ export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleD
         icon={<Ban className="h-8 w-8 text-muted-foreground mx-auto" />}
         message="Assessment Cancelled"
         description={`The ${workflowName} assessment was cancelled before it could complete.`}
+      />
+    );
+  }
+
+  if (isWorkflowFailed(workflowDetail)) {
+    return (
+      <EmptyState
+        icon={<XCircle className="h-8 w-8 text-red-600 mx-auto" />}
+        message="Assessment Failed"
+        description={
+          workflowDetail.run.failure_message ??
+          `The ${workflowName} assessment failed before it could complete. Please retry it.`
+        }
       />
     );
   }

--- a/frontend/lib/generated-api/transformers.gen.ts
+++ b/frontend/lib/generated-api/transformers.gen.ts
@@ -50,6 +50,9 @@ const workflowRunSchemaResponseTransformer = (data: any) => {
   if (data.completed_at) {
     data.completed_at = new Date(data.completed_at);
   }
+  if (data.heartbeat_at) {
+    data.heartbeat_at = new Date(data.heartbeat_at);
+  }
   return data;
 };
 

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -971,7 +971,7 @@ export type CitationIssueItem = {
   /**
    * Citation To File Mapping
    *
-   * The bibliography-to-file mapping used when checking this citation. Omit file IDs.
+   * Display-friendly summary of which bibliography entry was matched to which supporting file when checking this citation, e.g. 'Smith (2020) → smith_2020.pdf'. Do not include file_id UUIDs in this string; the file_id belongs in each entry of evidence_sources.
    */
   citation_to_file_mapping?: string | null;
 };
@@ -4009,9 +4009,9 @@ export type ReferenceDownloaderWorkflowConfig = {
   /**
    * References
    *
-   * The references to fetch from the internet
+   * The references to fetch from the internet. When omitted, the workflow defaults to every extracted reference that does not yet have a matched supporting file.
    */
-  references: Array<ReferenceDownloaderInputItem>;
+  references?: Array<ReferenceDownloaderInputItem> | null;
 };
 
 /**
@@ -5544,6 +5544,22 @@ export type WorkflowRun = {
    * The project revision this workflow run belongs to
    */
   revision?: number;
+  /**
+   * Heartbeat At
+   *
+   * Updated on every node entry/exit; used by the reaper to detect stuck runs
+   */
+  heartbeat_at: Date | null;
+  /**
+   * Populated only when status == FAILED
+   */
+  failure_reason?: WorkflowRunFailureReason | null;
+  /**
+   * Failure Message
+   *
+   * Short human-readable detail of the failure. Populated only when status == FAILED.
+   */
+  failure_message?: string | null;
 };
 
 /**
@@ -5584,6 +5600,33 @@ export type WorkflowRunDetail = {
 };
 
 /**
+ * WorkflowRunFailureReason
+ *
+ * Reason a workflow run transitioned to FAILED.
+ *
+ * FAILED is reserved for unrecoverable workflow-level halts; node-level errors
+ * that the workflow recovers from are still represented via state.errors and
+ * leave the run in COMPLETED status.
+ */
+export const WorkflowRunFailureReason = {
+  Timeout: 'timeout',
+  DependencyTimeout: 'dependency_timeout',
+  NoHeartbeat: 'no_heartbeat',
+  UnhandledException: 'unhandled_exception',
+} as const;
+
+/**
+ * WorkflowRunFailureReason
+ *
+ * Reason a workflow run transitioned to FAILED.
+ *
+ * FAILED is reserved for unrecoverable workflow-level halts; node-level errors
+ * that the workflow recovers from are still represented via state.errors and
+ * leave the run in COMPLETED status.
+ */
+export type WorkflowRunFailureReason = (typeof WorkflowRunFailureReason)[keyof typeof WorkflowRunFailureReason];
+
+/**
  * WorkflowRunStatus
  */
 export const WorkflowRunStatus = {
@@ -5591,6 +5634,7 @@ export const WorkflowRunStatus = {
   Running: 'running',
   Completed: 'completed',
   Cancelled: 'cancelled',
+  Failed: 'failed',
 } as const;
 
 /**

--- a/frontend/lib/workflow-state.ts
+++ b/frontend/lib/workflow-state.ts
@@ -107,9 +107,10 @@ export function getCurrentRunErrors(workflowRun: WorkflowRunDetail): WorkflowErr
 }
 
 /**
- * Display status type that includes "failed" for completed runs with errors.
+ * Display status for a workflow run. Mirrors `WorkflowRunStatus`, but `Completed`
+ * runs that contain errors collapse to `Failed` for UI purposes.
  */
-export type DisplayStatus = WorkflowRunStatus | 'failed';
+export type DisplayStatus = WorkflowRunStatus;
 
 /**
  * Get the display status for a workflow run.
@@ -117,7 +118,7 @@ export type DisplayStatus = WorkflowRunStatus | 'failed';
  */
 export function getDisplayStatus(workflowRun: WorkflowRunDetail): DisplayStatus {
   if (workflowRun.run.status === WorkflowRunStatus.Completed && hasCurrentRunErrors(workflowRun)) {
-    return 'failed';
+    return WorkflowRunStatus.Failed;
   }
   return workflowRun.run.status;
 }
@@ -148,6 +149,11 @@ export function isWorkflowProcessing(workflowRun: WorkflowRunDetail | undefined)
 export function isWorkflowCancelled(workflowRun: WorkflowRunDetail | undefined): boolean {
   if (!workflowRun) return false;
   return workflowRun.run.status === WorkflowRunStatus.Cancelled;
+}
+
+export function isWorkflowFailed(workflowRun: WorkflowRunDetail | undefined): boolean {
+  if (!workflowRun) return false;
+  return workflowRun.run.status === WorkflowRunStatus.Failed;
 }
 
 export function isAnyWorkflowProcessing(workflowRuns: WorkflowRunDetail[]): boolean {

--- a/lib/api/main.py
+++ b/lib/api/main.py
@@ -34,6 +34,7 @@ from lib.api.routers import (
 )
 from lib.api.routers.tus_upload import tus_router
 from lib.config.logger import setup_logger
+from lib.services.workflow_reaper import run_reaper_loop
 
 setup_logger()
 
@@ -43,8 +44,10 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Seed default runtime configs on startup; close shared pools on shutdown."""
+    # `seed_all_defaults` and `close_checkpointer_pool` stay lazy to keep the
+    # import graph simple — they pull in services that don't need to load on
+    # every test that imports main.py.
     from lib.services.app_configs import seed_all_defaults
-    from lib.services.workflow_reaper import run_reaper_loop
     from lib.workflows.checkpointer import close_checkpointer_pool
 
     await seed_all_defaults()

--- a/lib/api/main.py
+++ b/lib/api/main.py
@@ -5,6 +5,7 @@ This module sets up the FastAPI application, middleware, and registers routers.
 Business logic is organized in separate routers under api/routers/.
 """
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 
@@ -43,12 +44,19 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     """Seed default runtime configs on startup; close shared pools on shutdown."""
     from lib.services.app_configs import seed_all_defaults
+    from lib.services.workflow_reaper import run_reaper_loop
     from lib.workflows.checkpointer import close_checkpointer_pool
 
     await seed_all_defaults()
+    reaper_task = asyncio.create_task(run_reaper_loop(), name="workflow-reaper")
     try:
         yield
     finally:
+        reaper_task.cancel()
+        try:
+            await reaper_task
+        except asyncio.CancelledError:
+            pass
         await close_checkpointer_pool()
 
 

--- a/lib/api/routers/workflows.py
+++ b/lib/api/routers/workflows.py
@@ -152,6 +152,12 @@ async def cancel_workflow_run_endpoint(
             detail="Cannot cancel a workflow that has already completed",
         )
 
+    if workflow_run.status == WorkflowRunStatus.FAILED:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot cancel a workflow that has already failed",
+        )
+
     if workflow_run.status == WorkflowRunStatus.CANCELLED:
         return CancelWorkflowResponse(
             message="Already cancelled",

--- a/lib/models/workflow_run.py
+++ b/lib/models/workflow_run.py
@@ -17,6 +17,28 @@ class WorkflowRunStatus(str, Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+TERMINAL_WORKFLOW_RUN_STATUSES = (
+    WorkflowRunStatus.COMPLETED,
+    WorkflowRunStatus.CANCELLED,
+    WorkflowRunStatus.FAILED,
+)
+
+
+class WorkflowRunFailureReason(str, Enum):
+    """Reason a workflow run transitioned to FAILED.
+
+    FAILED is reserved for unrecoverable workflow-level halts; node-level errors
+    that the workflow recovers from are still represented via state.errors and
+    leave the run in COMPLETED status.
+    """
+
+    TIMEOUT = "timeout"
+    DEPENDENCY_TIMEOUT = "dependency_timeout"
+    NO_HEARTBEAT = "no_heartbeat"
+    UNHANDLED_EXCEPTION = "unhandled_exception"
 
 
 class WorkflowRun(SQLModel, table=True):
@@ -75,6 +97,23 @@ class WorkflowRun(SQLModel, table=True):
         sa_column=Column(Integer, nullable=False, default=1),
         default=1,
         description="The project revision this workflow run belongs to",
+    )
+    heartbeat_at: Optional[datetime] = Field(
+        sa_column=Column(DateTime(timezone=True), nullable=True),
+        description="Updated on every node entry/exit; used by the reaper to detect stuck runs",
+    )
+    failure_reason: Optional[WorkflowRunFailureReason] = Field(
+        sa_column=Column(
+            SQLModelEnum(WorkflowRunFailureReason),
+            nullable=True,
+        ),
+        default=None,
+        description="Populated only when status == FAILED",
+    )
+    failure_message: Optional[str] = Field(
+        sa_column=Column(String(2000), nullable=True),
+        default=None,
+        description="Short human-readable detail of the failure. Populated only when status == FAILED.",
     )
 
     @field_validator("type", mode="before")

--- a/lib/services/workflow_orchestration.py
+++ b/lib/services/workflow_orchestration.py
@@ -1,16 +1,29 @@
 import asyncio
 import logging
+import time
 from typing import List, Optional
 
-from lib.models.workflow_run import WorkflowRunStatus
-from lib.services.workflow_runs import get_project_workflow_run_by_type, update_workflow_run_status
-from lib.workflows.models import WorkflowCancelledError, WorkflowRunType
+from lib.models.workflow_run import TERMINAL_WORKFLOW_RUN_STATUSES, WorkflowRunStatus
+from lib.services.workflow_runs import (
+    get_project_workflow_run_by_type,
+    update_workflow_run_status,
+)
+from lib.workflows.models import (
+    DependencyWaitTimeoutError,
+    WorkflowCancelledError,
+    WorkflowRunType,
+)
 from lib.workflows.registry import get_workflow_manifest
 
 logger = logging.getLogger(__name__)
 
 # How often to check dependency/lock status (in seconds)
 DEPENDENCY_CHECK_INTERVAL = 5.0
+
+# Maximum total time wait_for_dependencies will block before raising
+# DependencyWaitTimeoutError. Sized generously so legitimately-long parents
+# don't trip it; the reaper is the primary defense against truly stuck runs.
+DEPENDENCY_WAIT_TIMEOUT = 2 * 60 * 60  # 2 hours, in seconds
 
 
 async def wait_for_dependencies(
@@ -45,7 +58,14 @@ async def wait_for_dependencies(
         return
 
     first_check = True
+    started_at = time.monotonic()
     while True:
+        if time.monotonic() - started_at > DEPENDENCY_WAIT_TIMEOUT:
+            raise DependencyWaitTimeoutError(
+                f"Workflow {workflow_type.value} timed out after "
+                f"{DEPENDENCY_WAIT_TIMEOUT}s waiting for dependencies"
+            )
+
         blocking_reasons: List[str] = []
 
         # Check same-type lock (wait for previous runs of same workflow)
@@ -56,8 +76,7 @@ async def wait_for_dependencies(
             if (
                 same_type_run is not None
                 and str(same_type_run.id) != current_workflow_run_id
-                and same_type_run.status
-                not in (WorkflowRunStatus.COMPLETED, WorkflowRunStatus.CANCELLED)
+                and same_type_run.status not in TERMINAL_WORKFLOW_RUN_STATUSES
             ):
                 blocking_reasons.append(
                     f"previous {workflow_type.value} (run_id {str(same_type_run.id)[:8]}...)"
@@ -66,12 +85,18 @@ async def wait_for_dependencies(
         # Check dependencies
         if needs_dependency_wait:
             required_pending = await _get_pending_workflow_dependencies(
-                project_id, workflow_type, required_dependencies, True,
+                project_id,
+                workflow_type,
+                required_dependencies,
+                True,
                 current_workflow_run_id=current_workflow_run_id,
                 revision=revision,
             )
             optional_pending = await _get_pending_workflow_dependencies(
-                project_id, workflow_type, optional_dependencies, False,
+                project_id,
+                workflow_type,
+                optional_dependencies,
+                False,
                 revision=revision,
             )
             pending_deps = required_pending + optional_pending
@@ -125,7 +150,9 @@ async def _get_pending_workflow_dependencies(
     pending_dependencies: List[WorkflowRunType] = []
 
     for dep_type in dependencies:
-        dep_run = await get_project_workflow_run_by_type(project_id, dep_type, revision=revision)
+        dep_run = await get_project_workflow_run_by_type(
+            project_id, dep_type, revision=revision
+        )
 
         if dep_run is None:
             # Dependency hasn't been started yet or is not scheduled to run
@@ -135,15 +162,21 @@ async def _get_pending_workflow_dependencies(
                 raise ValueError(
                     f"{workflow_type} depends on required dependency {dep_type.value} which has not been started yet or is not scheduled to run"
                 )
-        elif dep_run.status == WorkflowRunStatus.CANCELLED and required:
-            # A required dependency was cancelled — cancel this run too (safety net
-            # for cases where cascade cancellation hasn't propagated yet)
+        elif (
+            dep_run.status in (WorkflowRunStatus.CANCELLED, WorkflowRunStatus.FAILED)
+            and required
+        ):
+            # A required dependency was cancelled or failed — cancel this run too
+            # (safety net for cases where cascade hasn't propagated yet). From a
+            # dependent's perspective there's no salvageable upstream output, so
+            # we mark CANCELLED rather than FAILED.
             if current_workflow_run_id:
                 await update_workflow_run_status(
                     current_workflow_run_id, WorkflowRunStatus.CANCELLED
                 )
             raise WorkflowCancelledError(
-                f"Required dependency {dep_type.value} for {workflow_type} was cancelled"
+                f"Required dependency {dep_type.value} for {workflow_type} "
+                f"ended in {dep_run.status.value}"
             )
         elif dep_run.status in (WorkflowRunStatus.PENDING, WorkflowRunStatus.RUNNING):
             # Dependency is pending or running, wait for it

--- a/lib/services/workflow_reaper.py
+++ b/lib/services/workflow_reaper.py
@@ -1,0 +1,215 @@
+"""Periodic sweep that marks heartbeat-less RUNNING and stale PENDING workflows as FAILED.
+
+The dominant cause of "stuck forever" workflow runs is a server restart or OOM
+kill that strands the row in RUNNING because the in-process background task
+died before the runner's terminal-status update could fire. The reaper is the
+self-healing path: any RUNNING row whose heartbeat goes stale is flipped to
+FAILED with failure_reason=no_heartbeat, and its dependents are cascade-
+cancelled, so dependent workflows don't wait indefinitely.
+
+The reaper also covers PENDING rows that were never picked up (the in-process
+background task died before run_workflow was reached, so no heartbeat ever
+ticked and wait_for_dependencies never had a chance to time the run out
+itself). PENDING rows older than DEPENDENCY_WAIT_TIMEOUT are mechanically
+stuck — by then a live runner would have either started them or raised
+DependencyWaitTimeoutError on its own.
+
+Wired into FastAPI lifespan in lib/api/main.py.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+
+from langchain_core.runnables.config import RunnableConfig
+from sqlalchemy import or_, select
+from sqlmodel import and_, col
+
+from lib.config.database import get_async_db_session
+from lib.models.workflow_run import (
+    WorkflowRun,
+    WorkflowRunFailureReason,
+    WorkflowRunStatus,
+)
+from lib.services.workflow_orchestration import DEPENDENCY_WAIT_TIMEOUT
+from lib.services.workflow_runs import (
+    fail_workflow_run,
+    get_workflow_run_state_by_thread_id,
+)
+from lib.workflows.checkpointer import get_checkpointer
+from lib.workflows.registry import create_graph, get_workflow_manifest
+
+logger = logging.getLogger(__name__)
+
+# How often to sweep.
+REAPER_INTERVAL_SECONDS = 30.0
+
+# How long a RUNNING row must go without a heartbeat before being reaped.
+# Heartbeats tick every CANCELLATION_CHECK_INTERVAL (5s) while any node runs,
+# so 60s is 12× the heartbeat interval — comfortable margin for between-node
+# gaps, DB blips, and GC pauses without false positives.
+REAPER_GRACE_SECONDS = 60.0
+
+# How long a PENDING row may sit before the reaper treats it as orphaned.
+# Aligned with DEPENDENCY_WAIT_TIMEOUT: a live runner waiting on dependencies
+# would itself raise DependencyWaitTimeoutError at this point and flip the run
+# to FAILED, so anything still PENDING past this window was never picked up.
+PENDING_GRACE_SECONDS = float(DEPENDENCY_WAIT_TIMEOUT)
+
+
+async def _find_stuck_runs(
+    running_grace_seconds: float,
+    pending_grace_seconds: float,
+) -> list[WorkflowRun]:
+    """Return RUNNING rows whose heartbeat is stale and PENDING rows that were
+    never picked up.
+
+    Three cases:
+      - RUNNING + heartbeat_at IS NULL: never ticked; use started_at as the reference.
+      - RUNNING + heartbeat_at < cutoff: ticked once and went silent.
+      - PENDING + created_at < pending_cutoff: orphaned before the runner could start it.
+    """
+    now = datetime.utcnow()
+    running_cutoff = now - timedelta(seconds=running_grace_seconds)
+    pending_cutoff = now - timedelta(seconds=pending_grace_seconds)
+    async with get_async_db_session() as session:
+        stmt = select(WorkflowRun).where(
+            or_(
+                and_(
+                    col(WorkflowRun.status) == WorkflowRunStatus.RUNNING,
+                    or_(
+                        and_(
+                            col(WorkflowRun.heartbeat_at).is_(None),
+                            col(WorkflowRun.started_at) < running_cutoff,
+                        ),
+                        col(WorkflowRun.heartbeat_at) < running_cutoff,
+                    ),
+                ),
+                and_(
+                    col(WorkflowRun.status) == WorkflowRunStatus.PENDING,
+                    col(WorkflowRun.created_at) < pending_cutoff,
+                ),
+            )
+        )
+        return list((await session.execute(stmt)).scalars().all())
+
+
+async def _run_manifest_on_cancel(run: WorkflowRun) -> None:
+    """Best-effort invocation of the manifest's on_cancel hook for a stuck run.
+
+    Mirrors the cancel/timeout paths in the runner so per-item statuses (e.g.
+    pending validation entries) get cleaned up instead of being stranded as
+    'pending'. Errors are logged but never propagated — the reaper must still
+    flip the run to FAILED.
+    """
+    manifest = get_workflow_manifest(run.type, raise_exception=False)
+    if manifest is None:
+        return
+
+    try:
+        state = await get_workflow_run_state_by_thread_id(
+            run.langgraph_thread_id, run.type
+        )
+    except Exception as e:
+        logger.error(
+            f"Reaper: failed to load state for {run.id}: {e}", exc_info=True
+        )
+        return
+
+    if state is None:
+        return
+
+    thread_config: RunnableConfig = {
+        "configurable": {"thread_id": run.langgraph_thread_id}
+    }
+    try:
+        async with get_checkpointer() as checkpointer:
+            graph = create_graph(run.type)
+            app = graph.compile(checkpointer=checkpointer)
+            await manifest.on_cancel(state, app, thread_config)
+    except Exception as e:
+        logger.error(
+            f"Reaper: on_cancel hook failed for {run.id} ({run.type}): {e}",
+            exc_info=True,
+        )
+
+
+async def _reap_once(
+    running_grace_seconds: float = REAPER_GRACE_SECONDS,
+    pending_grace_seconds: float = PENDING_GRACE_SECONDS,
+) -> int:
+    """One sweep. Returns the count of reaped runs."""
+    stuck = await _find_stuck_runs(running_grace_seconds, pending_grace_seconds)
+    if not stuck:
+        return 0
+
+    for run in stuck:
+        if run.project_id is None:
+            logger.warning(
+                f"Reaper: skipping stuck workflow run {run.id} with no project_id"
+            )
+            continue
+
+        if run.status == WorkflowRunStatus.PENDING:
+            logger.warning(
+                f"Reaper: workflow run {run.id} ({run.type}) was PENDING for "
+                f">{int(pending_grace_seconds)}s without starting — marking FAILED"
+            )
+            failure_message = (
+                f"PENDING for >{int(pending_grace_seconds)}s without starting; "
+                "background task likely crashed before pickup"
+            )
+        else:
+            logger.warning(
+                f"Reaper: workflow run {run.id} ({run.type}) has no recent heartbeat — "
+                f"marking FAILED"
+            )
+            failure_message = (
+                f"No heartbeat for >{int(running_grace_seconds)}s; "
+                "process likely crashed or was restarted"
+            )
+
+        try:
+            # PENDING runs never reached run_workflow, so there's no checkpoint
+            # state for the manifest to clean up; the on_cancel call is a no-op
+            # in that case (state is None). Still cheap, and keeps the path
+            # uniform.
+            await _run_manifest_on_cancel(run)
+            await fail_workflow_run(
+                str(run.id),
+                str(run.project_id),
+                failure_reason=WorkflowRunFailureReason.NO_HEARTBEAT,
+                failure_message=failure_message,
+            )
+        except Exception as e:
+            # Don't let one bad row stop the sweep.
+            logger.error(
+                f"Reaper: failed to fail workflow run {run.id}: {e}", exc_info=True
+            )
+
+    return len(stuck)
+
+
+async def run_reaper_loop(
+    interval_seconds: float = REAPER_INTERVAL_SECONDS,
+    grace_seconds: float = REAPER_GRACE_SECONDS,
+    pending_grace_seconds: float = PENDING_GRACE_SECONDS,
+) -> None:
+    """Long-running sweep loop. Cancel via task.cancel() to stop."""
+    logger.info(
+        f"Workflow reaper started (interval={interval_seconds}s, "
+        f"running_grace={grace_seconds}s, pending_grace={pending_grace_seconds}s)"
+    )
+    try:
+        while True:
+            try:
+                reaped = await _reap_once(grace_seconds, pending_grace_seconds)
+                if reaped:
+                    logger.info(f"Reaper: marked {reaped} stuck run(s) as FAILED")
+            except Exception as e:
+                # Loop must survive transient DB / network errors.
+                logger.error(f"Reaper sweep failed: {e}", exc_info=True)
+            await asyncio.sleep(interval_seconds)
+    except asyncio.CancelledError:
+        logger.info("Workflow reaper stopped")
+        raise

--- a/lib/services/workflow_reaper.py
+++ b/lib/services/workflow_reaper.py
@@ -14,15 +14,23 @@ itself). PENDING rows older than DEPENDENCY_WAIT_TIMEOUT are mechanically
 stuck — by then a live runner would have either started them or raised
 DependencyWaitTimeoutError on its own.
 
+Multi-pod safe: every pod's lifespan starts its own reaper, but sweeps are
+serialized cluster-wide by a Postgres advisory lock (REAPER_ADVISORY_LOCK_KEY).
+At most one pod actively sweeps at a time; the rest fail-fast on
+pg_try_advisory_lock and skip the tick. The lock is session-scoped, so a
+crashed pod cannot strand it.
+
 Wired into FastAPI lifespan in lib/api/main.py.
 """
 
 import asyncio
 import logging
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
+from typing import AsyncIterator
 
 from langchain_core.runnables.config import RunnableConfig
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, text
 from sqlmodel import and_, col
 
 from lib.config.database import get_async_db_session
@@ -55,6 +63,43 @@ REAPER_GRACE_SECONDS = 60.0
 # would itself raise DependencyWaitTimeoutError at this point and flip the run
 # to FAILED, so anything still PENDING past this window was never picked up.
 PENDING_GRACE_SECONDS = float(DEPENDENCY_WAIT_TIMEOUT)
+
+# Postgres advisory-lock key — used to serialize reaper sweeps across pods.
+# Without this, every pod's lifespan starts its own reaper and N pods each
+# do the same sweep every 30s: redundant FAILED writes, redundant cascades,
+# N copies of the manifest on_cancel hook appending to the LangGraph
+# checkpoint. With the lock, only one pod's sweep runs at a time; others
+# fail-fast on pg_try_advisory_lock and skip until the next tick. The key
+# is an arbitrary but stable bigint derived from the ASCII bytes "WFREAPER"
+# so it won't collide with advisory locks taken by other systems sharing
+# the database.
+REAPER_ADVISORY_LOCK_KEY = int.from_bytes(b"WFREAPER", "big")
+
+
+@asynccontextmanager
+async def _reaper_advisory_lock() -> AsyncIterator[bool]:
+    """Try to acquire the cluster-wide reaper sweep lock.
+
+    Yields ``True`` if this pod owns the sweep for the duration of the
+    context, ``False`` if another pod already holds it. The lock is bound
+    to the dedicated session opened here; closing the session releases it,
+    so a crashed pod cannot strand the lock.
+    """
+    async with get_async_db_session() as session:
+        result = await session.execute(
+            text("SELECT pg_try_advisory_lock(:key)"),
+            {"key": REAPER_ADVISORY_LOCK_KEY},
+        )
+        acquired = bool(result.scalar_one())
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                await session.execute(
+                    text("SELECT pg_advisory_unlock(:key)"),
+                    {"key": REAPER_ADVISORY_LOCK_KEY},
+                )
+                await session.commit()
 
 
 async def _find_stuck_runs(
@@ -138,7 +183,26 @@ async def _reap_once(
     running_grace_seconds: float = REAPER_GRACE_SECONDS,
     pending_grace_seconds: float = PENDING_GRACE_SECONDS,
 ) -> int:
-    """One sweep. Returns the count of reaped runs."""
+    """One sweep. Returns the count of reaped runs.
+
+    Serialized cluster-wide via a Postgres advisory lock — a sweep that
+    can't acquire the lock returns 0 immediately, leaving the work to
+    whichever pod is currently sweeping.
+    """
+    async with _reaper_advisory_lock() as acquired:
+        if not acquired:
+            logger.debug(
+                "Reaper: another pod holds the sweep lock; skipping this tick"
+            )
+            return 0
+        return await _reap_once_locked(running_grace_seconds, pending_grace_seconds)
+
+
+async def _reap_once_locked(
+    running_grace_seconds: float,
+    pending_grace_seconds: float,
+) -> int:
+    """Inner sweep body — assumes the advisory lock is already held."""
     stuck = await _find_stuck_runs(running_grace_seconds, pending_grace_seconds)
     if not stuck:
         return 0

--- a/lib/services/workflow_runs.py
+++ b/lib/services/workflow_runs.py
@@ -20,7 +20,9 @@ from lib.models.workflow_run import (
     WorkflowRunStatus,
     WorkflowRunType,
 )
+from lib.services.workflow_progress import cancel_workflow_progress
 from lib.workflows.checkpointer import get_checkpointer
+from lib.workflows.dependency_resolver import get_required_dependents
 from lib.workflows.models import is_user_visible_workflow
 from lib.workflows.registry import create_graph, get_state_type, get_workflow_manifest
 from lib.workflows.workflow_types import WorkflowState
@@ -134,7 +136,16 @@ async def update_workflow_run_status(
     failure_reason: Optional[WorkflowRunFailureReason] = None,
     failure_message: Optional[str] = None,
 ) -> None:
-    """Update an existing workflow run's status. Never overwrites CANCELLED.
+    """Update an existing workflow run's status. Never overwrites a terminal status.
+
+    Terminal statuses (CANCELLED, COMPLETED, FAILED) are write-once. Without
+    this guard the runner's COMPLETED write could clobber a FAILED row the
+    reaper just produced (race window: heartbeat lag → reap → runner finishes
+    its last node → COMPLETED write), and racing failure paths could
+    overwrite each other's failure_reason / failure_message. The guard is
+    application-level (SELECT-then-UPDATE inside one transaction); when two
+    pods race, last writer wins for non-terminal transitions, which is
+    benign because non-terminal writes are idempotent.
 
     `failure_reason` and `failure_message` are persisted only when transitioning
     to FAILED; they are ignored for other statuses.
@@ -143,7 +154,7 @@ async def update_workflow_run_status(
         stmt = select(WorkflowRun).where(
             and_(
                 col(WorkflowRun.id) == workflow_run_id,
-                col(WorkflowRun.status) != WorkflowRunStatus.CANCELLED,
+                col(WorkflowRun.status).not_in(TERMINAL_WORKFLOW_RUN_STATUSES),
             )
         )
         run = (await session.execute(stmt)).scalar_one_or_none()
@@ -194,8 +205,6 @@ async def cancel_workflow_run(workflow_run_id: str, project_id: str) -> None:
     Only cascades through required_dependencies — optional dependents are left running
     since they handle missing data by design.
     """
-    from lib.services.workflow_progress import cancel_workflow_progress
-
     run = await get_workflow_run(workflow_run_id)
     if run.project_id is None:
         raise ValueError(f"Workflow run {workflow_run_id} has no project_id")
@@ -217,8 +226,6 @@ async def fail_workflow_run(
     parent is equivalent to a cancelled one — there is no salvageable output —
     so we cascade to CANCELLED rather than FAILED.
     """
-    from lib.services.workflow_progress import cancel_workflow_progress
-
     run = await get_workflow_run(workflow_run_id)
     if run.project_id is None:
         raise ValueError(f"Workflow run {workflow_run_id} has no project_id")
@@ -236,8 +243,6 @@ async def _cascade_cancel_dependents(
     workflow_type: WorkflowRunType, project_id: str, revision: int
 ) -> None:
     """Cancel any PENDING/RUNNING workflow runs that required-depend on this type."""
-    from lib.workflows.dependency_resolver import get_required_dependents
-
     for dependent_type in get_required_dependents(workflow_type):
         dependent_run = await get_project_workflow_run_by_type(
             project_id, dependent_type, revision=revision

--- a/lib/services/workflow_runs.py
+++ b/lib/services/workflow_runs.py
@@ -13,7 +13,13 @@ from sqlmodel import and_, col
 from lib.config.database import get_async_db_session
 from lib.models.project import Project
 from lib.models.user import User
-from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus, WorkflowRunType
+from lib.models.workflow_run import (
+    TERMINAL_WORKFLOW_RUN_STATUSES,
+    WorkflowRun,
+    WorkflowRunFailureReason,
+    WorkflowRunStatus,
+    WorkflowRunType,
+)
 from lib.workflows.checkpointer import get_checkpointer
 from lib.workflows.models import is_user_visible_workflow
 from lib.workflows.registry import create_graph, get_state_type, get_workflow_manifest
@@ -69,7 +75,9 @@ async def get_workflow_run_state_by_thread_id(
     )
 
 
-async def get_workflow_run(workflow_run_id: str, user: Optional[User] = None) -> WorkflowRun:
+async def get_workflow_run(
+    workflow_run_id: str, user: Optional[User] = None
+) -> WorkflowRun:
     async with get_async_db_session() as session:
         stmt = (
             select(WorkflowRun, Project)
@@ -123,8 +131,14 @@ async def create_workflow_run(
 async def update_workflow_run_status(
     workflow_run_id: str,
     status: WorkflowRunStatus,
+    failure_reason: Optional[WorkflowRunFailureReason] = None,
+    failure_message: Optional[str] = None,
 ) -> None:
-    """Update an existing workflow run's status. Never overwrites CANCELLED."""
+    """Update an existing workflow run's status. Never overwrites CANCELLED.
+
+    `failure_reason` and `failure_message` are persisted only when transitioning
+    to FAILED; they are ignored for other statuses.
+    """
     async with get_async_db_session() as session:
         stmt = select(WorkflowRun).where(
             and_(
@@ -138,15 +152,38 @@ async def update_workflow_run_status(
             run.status = status
             if status == WorkflowRunStatus.RUNNING and run.started_at is None:
                 run.started_at = now
-            if status in (WorkflowRunStatus.COMPLETED, WorkflowRunStatus.CANCELLED):
+            if status in TERMINAL_WORKFLOW_RUN_STATUSES:
                 run.completed_at = now
+            if status == WorkflowRunStatus.FAILED:
+                run.failure_reason = failure_reason
+                run.failure_message = (
+                    failure_message[:2000] if failure_message else None
+                )
+            await session.commit()
+
+
+async def update_workflow_run_heartbeat(workflow_run_id: str) -> None:
+    """Bump heartbeat_at for a workflow run.
+
+    Cheap, called frequently from the node decorator so the reaper can tell a
+    progressing run from a stuck one. Does not affect status or last_updated_at
+    semantics — heartbeat is intentionally distinct so "status changed" vs
+    "node ticked" remain separable.
+    """
+    async with get_async_db_session() as session:
+        stmt = select(WorkflowRun).where(col(WorkflowRun.id) == workflow_run_id)
+        run = (await session.execute(stmt)).scalar_one_or_none()
+        if run:
+            run.heartbeat_at = datetime.utcnow()
             await session.commit()
 
 
 async def get_workflow_run_status(workflow_run_id: str) -> WorkflowRunStatus | None:
     """Lightweight fetch of just the status for a workflow run. Used for cancellation checks."""
     async with get_async_db_session() as session:
-        stmt = select(col(WorkflowRun.status)).where(col(WorkflowRun.id) == workflow_run_id)
+        stmt = select(col(WorkflowRun.status)).where(
+            col(WorkflowRun.id) == workflow_run_id
+        )
         return (await session.execute(stmt)).scalar_one_or_none()
 
 
@@ -158,17 +195,52 @@ async def cancel_workflow_run(workflow_run_id: str, project_id: str) -> None:
     since they handle missing data by design.
     """
     from lib.services.workflow_progress import cancel_workflow_progress
-    from lib.workflows.dependency_resolver import get_required_dependents
 
     run = await get_workflow_run(workflow_run_id)
     if run.project_id is None:
         raise ValueError(f"Workflow run {workflow_run_id} has no project_id")
     await cancel_workflow_progress(run.project_id, run.type)
     await update_workflow_run_status(workflow_run_id, WorkflowRunStatus.CANCELLED)
+    await _cascade_cancel_dependents(run.type, project_id, run.revision)
 
-    for dependent_type in get_required_dependents(run.type):
+
+async def fail_workflow_run(
+    workflow_run_id: str,
+    project_id: str,
+    failure_reason: WorkflowRunFailureReason,
+    failure_message: Optional[str] = None,
+) -> None:
+    """Mark a workflow run as FAILED and cascade-cancel its active dependents.
+
+    Used for unrecoverable workflow-level halts (timeout, dependency timeout,
+    no heartbeat, unhandled exception). From a dependent's perspective a failed
+    parent is equivalent to a cancelled one — there is no salvageable output —
+    so we cascade to CANCELLED rather than FAILED.
+    """
+    from lib.services.workflow_progress import cancel_workflow_progress
+
+    run = await get_workflow_run(workflow_run_id)
+    if run.project_id is None:
+        raise ValueError(f"Workflow run {workflow_run_id} has no project_id")
+    await cancel_workflow_progress(run.project_id, run.type)
+    await update_workflow_run_status(
+        workflow_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=failure_reason,
+        failure_message=failure_message,
+    )
+    await _cascade_cancel_dependents(run.type, project_id, run.revision)
+
+
+async def _cascade_cancel_dependents(
+    workflow_type: WorkflowRunType, project_id: str, revision: int
+) -> None:
+    """Cancel any PENDING/RUNNING workflow runs that required-depend on this type."""
+    from lib.workflows.dependency_resolver import get_required_dependents
+
+    for dependent_type in get_required_dependents(workflow_type):
         dependent_run = await get_project_workflow_run_by_type(
-            project_id, dependent_type, revision=run.revision
+            project_id, dependent_type, revision=revision
         )
         if dependent_run and dependent_run.status in (
             WorkflowRunStatus.PENDING,
@@ -278,7 +350,9 @@ async def get_project_workflow_runs_by_type(
 
 
 async def get_project_workflow_runs_by_type_with_details(
-    project_id: str, workflow_type: WorkflowRunType, revision: int,
+    project_id: str,
+    workflow_type: WorkflowRunType,
+    revision: int,
 ) -> List[WorkflowRunDetail]:
     """
     Get all workflow runs of a specific type for a project, including full state.
@@ -286,7 +360,9 @@ async def get_project_workflow_runs_by_type_with_details(
     Returns all runs ordered by created_at descending (newest first).
     Used for displaying workflow run history in the UI with error status.
     """
-    runs = await get_project_workflow_runs_by_type(project_id, workflow_type, revision=revision)
+    runs = await get_project_workflow_runs_by_type(
+        project_id, workflow_type, revision=revision
+    )
 
     # Fetch all workflow states in parallel to avoid N+1 query pattern
     states = await asyncio.gather(

--- a/lib/workflows/decorators.py
+++ b/lib/workflows/decorators.py
@@ -26,11 +26,24 @@ from lib.workflows.models import (
 CANCELLATION_CHECK_INTERVAL = 5.0
 
 
-async def _poll_for_cancellation(
+async def _supervise_node(
     workflow_run_id: str, node_task: asyncio.Task, interval: float
 ) -> None:
-    """Poll the DB for cancellation status and cancel the node task if detected."""
-    from lib.services.workflow_runs import get_workflow_run_status
+    """Watch a running node: cancel it on demand and keep the heartbeat fresh.
+
+    Two responsibilities, both polled at `interval` seconds:
+      1. If the workflow row was flipped to CANCELLED, cancel the node task.
+      2. Otherwise bump heartbeat_at so the reaper sees the run as alive.
+
+    Runs as a sibling asyncio task while the node executes, so the heartbeat
+    keeps ticking even while the node awaits I/O. The reaper's role is
+    detecting *dead processes* (restart / OOM); for hung-but-alive nodes the
+    workflow-level asyncio.timeout(max_duration) is the safety net.
+    """
+    from lib.services.workflow_runs import (
+        get_workflow_run_status,
+        update_workflow_run_heartbeat,
+    )
 
     while not node_task.done():
         await asyncio.sleep(interval)
@@ -40,6 +53,7 @@ async def _poll_for_cancellation(
         if status == WorkflowRunStatus.CANCELLED:
             node_task.cancel()
             break
+        await update_workflow_run_heartbeat(workflow_run_id)
 
 
 async def _setup_progress(
@@ -78,13 +92,13 @@ async def _run_node_with_cancellation(
     from lib.services.workflow_runs import get_workflow_run_status
 
     node_task = asyncio.ensure_future(func(state, runtime))
-    poll_task = asyncio.ensure_future(
-        _poll_for_cancellation(workflow_run_id, node_task, CANCELLATION_CHECK_INTERVAL)
+    supervisor_task = asyncio.ensure_future(
+        _supervise_node(workflow_run_id, node_task, CANCELLATION_CHECK_INTERVAL)
     )
     try:
         return await node_task
     except asyncio.CancelledError:
-        # Confirm the cancellation came from our poller and not an external event loop shutdown
+        # Confirm the cancellation came from our supervisor and not an external event loop shutdown
         status = await get_workflow_run_status(workflow_run_id)
         if status == WorkflowRunStatus.CANCELLED:
             raise WorkflowCancelledError(
@@ -92,8 +106,8 @@ async def _run_node_with_cancellation(
             )
         raise
     finally:
-        poll_task.cancel()
-        await asyncio.gather(poll_task, return_exceptions=True)
+        supervisor_task.cancel()
+        await asyncio.gather(supervisor_task, return_exceptions=True)
 
 
 async def _complete_progress(

--- a/lib/workflows/decorators.py
+++ b/lib/workflows/decorators.py
@@ -11,11 +11,20 @@ from typing import Any, Callable
 from langgraph.runtime import Runtime
 
 from lib.models.workflow_progress import ProgressLevel
-from lib.models.workflow_run import WorkflowRunStatus
+from lib.models.workflow_run import (
+    TERMINAL_WORKFLOW_RUN_STATUSES,
+    WorkflowRunStatus,
+)
 from lib.services.workflow_progress import (
     get_or_create_progress,
     increment_and_complete_if_done,
 )
+
+# `workflow_runs` is imported lazily inside the functions below: importing
+# it here would form a circular chain (workflow_runs → registry → manifest
+# → graph → nodes → decorators), and Python errors out before the module
+# finishes initializing. The functions only need the helpers at call time,
+# so deferring is safe.
 from lib.workflows.context import ContextSchema, current_progress_id
 from lib.workflows.models import (
     BaseWorkflowState,
@@ -32,7 +41,9 @@ async def _supervise_node(
     """Watch a running node: cancel it on demand and keep the heartbeat fresh.
 
     Two responsibilities, both polled at `interval` seconds:
-      1. If the workflow row was flipped to CANCELLED, cancel the node task.
+      1. If the workflow row reached a terminal status (CANCELLED by the
+         user, or FAILED by the reaper / a parallel failure path), cancel
+         the node task and stop bumping the heartbeat.
       2. Otherwise bump heartbeat_at so the reaper sees the run as alive.
 
     Runs as a sibling asyncio task while the node executes, so the heartbeat
@@ -40,6 +51,8 @@ async def _supervise_node(
     detecting *dead processes* (restart / OOM); for hung-but-alive nodes the
     workflow-level asyncio.timeout(max_duration) is the safety net.
     """
+    # Lazy import — see the module-level comment about the circular chain
+    # decorators → workflow_runs → registry → … → decorators.
     from lib.services.workflow_runs import (
         get_workflow_run_status,
         update_workflow_run_heartbeat,
@@ -50,7 +63,7 @@ async def _supervise_node(
         if node_task.done():
             break
         status = await get_workflow_run_status(workflow_run_id)
-        if status == WorkflowRunStatus.CANCELLED:
+        if status in TERMINAL_WORKFLOW_RUN_STATUSES:
             node_task.cancel()
             break
         await update_workflow_run_heartbeat(workflow_run_id)
@@ -73,6 +86,7 @@ async def _setup_progress(
 
 async def _check_cancellation(workflow_run_id: str, func_name: str) -> None:
     """Raise WorkflowCancelledError if the workflow is already cancelled."""
+    # Lazy import — see module-level comment about the circular chain.
     from lib.services.workflow_runs import get_workflow_run_status
 
     status = await get_workflow_run_status(workflow_run_id)
@@ -89,6 +103,7 @@ async def _run_node_with_cancellation(
     workflow_run_id: str,
 ) -> dict[str, Any]:
     """Run the node function alongside a cancellation poller."""
+    # Lazy import — see module-level comment about the circular chain.
     from lib.services.workflow_runs import get_workflow_run_status
 
     node_task = asyncio.ensure_future(func(state, runtime))

--- a/lib/workflows/document_processing/manifest.py
+++ b/lib/workflows/document_processing/manifest.py
@@ -20,7 +20,7 @@ class DocumentProcessingManifest(
     WorkflowManifest[DocumentProcessingState, DocumentProcessingWorkflowConfig]
 ):
     type = WorkflowRunType.DOCUMENT_PROCESSING
-    name = "Document Processing"
+    name = "Markdown Conversion"
     description = "Convert documents to markdown"
     needs_web_search = False
     is_internal = True

--- a/lib/workflows/manifest.py
+++ b/lib/workflows/manifest.py
@@ -50,6 +50,11 @@ class WorkflowManifest[WorkflowStateType, WorkflowConfigType](ABC):
     # The workflows needs to be idempotent, meaning it can be run multiple times without changing the result and typical execute only "new" content that was not processed in a previous run, reusing cached results from previous runs, like summarization, document conversion, etc (should process only new files in subsequent runs).
     always_run: bool = False
 
+    # Maximum wall-clock duration (seconds) for a single execution of this workflow.
+    # Exceeding this transitions the run to FAILED with failure_reason=timeout.
+    # Override in subclasses for workflows that legitimately run longer.
+    max_duration_seconds: float = 1 * 60 * 60  # 1 hour
+
     @property
     def is_qa_screener(self) -> bool:
         """Whether the workflow is part of the QA Screener tool."""

--- a/lib/workflows/models.py
+++ b/lib/workflows/models.py
@@ -12,6 +12,17 @@ class WorkflowCancelledError(Exception):
     pass
 
 
+class DependencyWaitTimeoutError(Exception):
+    """Raised when wait_for_dependencies exceeds DEPENDENCY_WAIT_TIMEOUT.
+
+    Indicates an upstream dependency is stuck (typically itself orphaned in
+    RUNNING). The dependent run should be marked FAILED with
+    failure_reason=dependency_timeout.
+    """
+
+    pass
+
+
 class WorkflowError(BaseModel):
     """Error object for the overall workflow or specific chunks."""
 

--- a/lib/workflows/runner.py
+++ b/lib/workflows/runner.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import uuid
 
@@ -11,18 +12,23 @@ from lib.config.env import config as env_config
 from lib.config.langfuse import langfuse_handler
 from lib.config.llm_error_logger import ErrorLoggingCallback
 from lib.models.user import User
-from lib.models.workflow_run import WorkflowRunStatus, WorkflowRunType
+from lib.models.workflow_run import (
+    WorkflowRunFailureReason,
+    WorkflowRunStatus,
+    WorkflowRunType,
+)
 from lib.services.file_artifacts_service.file_artifacts_service import (
     FileArtifactsService,
 )
 from lib.services.issue_persistence import persist_workflow_issues
 from lib.services.users import get_user_decrypted_api_key
 from lib.services.vector_store import VectorStoreService
-from lib.services.workflow_runs import update_workflow_run_status
+from lib.services.workflow_runs import fail_workflow_run, update_workflow_run_status
 from lib.workflows.checkpointer import get_checkpointer
 from lib.workflows.context import ContextSchema
 from lib.workflows.models import (
     BaseWorkflowConfig,
+    DependencyWaitTimeoutError,
     WorkflowCancelledError,
     WorkflowError,
 )
@@ -74,9 +80,29 @@ async def run_workflow_with_dependency_check(
         # Status is already CANCELLED in DB; the guard in update_workflow_run_status
         # prevents it from being overwritten
 
+    except DependencyWaitTimeoutError as e:
+        logger.error(
+            f"Workflow {workflow_run_id} ({config.type.value}) timed out waiting "
+            f"for dependencies: {e}"
+        )
+        await fail_workflow_run(
+            workflow_run_id,
+            config.project_id,
+            failure_reason=WorkflowRunFailureReason.DEPENDENCY_TIMEOUT,
+            failure_message=str(e),
+        )
+
     except Exception as e:
+        # Errors that escape run_workflow's own handler land here. run_workflow
+        # already marks itself FAILED in that case; this branch covers errors
+        # raised before/after run_workflow runs (e.g. setup failures).
         logger.error(f"Error running workflow: {e}", exc_info=True)
-        await update_workflow_run_status(workflow_run_id, WorkflowRunStatus.COMPLETED)
+        await fail_workflow_run(
+            workflow_run_id,
+            config.project_id,
+            failure_reason=WorkflowRunFailureReason.UNHANDLED_EXCEPTION,
+            failure_message=str(e),
+        )
 
 
 async def run_workflow_from_config(
@@ -143,6 +169,9 @@ async def run_workflow(
         project_id=project_id,
     )
 
+    manifest = get_workflow_manifest(workflow_type, raise_exception=False)
+    max_duration = manifest.max_duration_seconds if manifest else 1 * 60 * 60
+
     async with get_checkpointer() as checkpointer:
         app = graph.compile(checkpointer=checkpointer).with_config(
             {
@@ -158,13 +187,14 @@ async def run_workflow(
         thread_config: RunnableConfig = {"configurable": {"thread_id": thread_id}}
 
         try:
-            async for values in app.astream(  # type: ignore[call-overload]
-                updated_state,
-                thread_config,
-                stream_mode="values",
-                context=context,
-            ):
-                updated_state = updated_state.model_copy(update=values)
+            async with asyncio.timeout(max_duration):
+                async for values in app.astream(  # type: ignore[call-overload]
+                    updated_state,
+                    thread_config,
+                    stream_mode="values",
+                    context=context,
+                ):
+                    updated_state = updated_state.model_copy(update=values)
 
             # Get checkpoint ID for debugging after successful completion
             state_snapshot = await app.aget_state(thread_config)
@@ -174,7 +204,9 @@ async def run_workflow(
                     "checkpoint_id"
                 )
 
-            # Persist issues after workflow completion
+            # Persist issues after workflow completion. Per-node errors collected
+            # in updated_state.errors stay surfaced through state — the run still
+            # transitions to COMPLETED ("completed with errors") below.
             await _persist_issues_from_state(
                 workflow_run_id=workflow_run_id,
                 project_id=project_id,
@@ -183,13 +215,35 @@ async def run_workflow(
                 checkpoint_id=checkpoint_id,
                 revision=context.revision,
             )
+
+            await update_workflow_run_status(
+                workflow_run_id, WorkflowRunStatus.COMPLETED
+            )
+
         except WorkflowCancelledError:
             logger.info(
                 f"Workflow {workflow_type} for project {project_id} was cancelled — running cleanup"
             )
-            manifest = get_workflow_manifest(workflow_type, raise_exception=False)
             if manifest:
                 await manifest.on_cancel(updated_state, app, thread_config)
+            # Status is already CANCELLED in DB; CANCELLED-guard in
+            # update_workflow_run_status keeps it that way.
+
+        except asyncio.TimeoutError:
+            logger.error(
+                f"Workflow {workflow_type} for project {project_id} exceeded "
+                f"max_duration={max_duration}s — marking FAILED"
+            )
+            if manifest:
+                # on_cancel is the right place for abnormal-teardown cleanup
+                # (per-item statuses stuck in 'pending' would remain otherwise).
+                await manifest.on_cancel(updated_state, app, thread_config)
+            await fail_workflow_run(
+                workflow_run_id,
+                project_id,
+                failure_reason=WorkflowRunFailureReason.TIMEOUT,
+                failure_message=f"Exceeded max_duration of {max_duration}s",
+            )
 
         except Exception as e:
             logger.error(f"Error running workflow {workflow_type}: {e}", exc_info=True)
@@ -200,10 +254,13 @@ async def run_workflow(
             )
 
             # Persist the error to the LangGraph checkpoint via the `add` reducer
+            # so it remains visible in the workflow state for debugging.
             await app.aupdate_state(thread_config, {"errors": [error]})
-        finally:
-            await update_workflow_run_status(
-                workflow_run_id, WorkflowRunStatus.COMPLETED
+            await fail_workflow_run(
+                workflow_run_id,
+                project_id,
+                failure_reason=WorkflowRunFailureReason.UNHANDLED_EXCEPTION,
+                failure_message=str(e),
             )
 
     logger.info(
@@ -235,9 +292,7 @@ def create_context(
         raise ValueError("No OpenAI API key found in config or environment variables")
 
     # Only initialize vector store if we have an API key (needed for embeddings)
-    vector_store = (
-        VectorStoreService(openai_api_key) if openai_api_key else None
-    )
+    vector_store = VectorStoreService(openai_api_key) if openai_api_key else None
 
     file_artifacts_service = FileArtifactsService(config.project_id, revision=revision)
 

--- a/tests/integration/test_workflow_reaper_query.py
+++ b/tests/integration/test_workflow_reaper_query.py
@@ -1,0 +1,287 @@
+"""Integration tests for the reaper's stuck-run SQL predicate.
+
+The unit tests in tests/unit/services/test_workflow_reaper.py stub
+`_find_stuck_runs` out, so they don't catch a regression in the SQL itself.
+A subtle change like swapping ``or_`` for ``and_``, or comparing
+``started_at`` against the wrong cutoff, could silently mass-fail healthy
+runs (or, worse, never reap stuck ones) without breaking any existing test.
+
+These tests seed real Postgres rows with controlled timestamps and assert
+the predicate selects exactly the right set.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from typing import Optional
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlmodel import col
+
+from lib.config.database import get_async_db_session
+from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus, WorkflowRunType
+from lib.services.workflow_reaper import _find_stuck_runs
+
+
+RUNNING_GRACE = 60.0
+PENDING_GRACE = 7200.0
+
+
+async def _insert_run(
+    *,
+    status: WorkflowRunStatus,
+    created_at: datetime,
+    started_at: Optional[datetime] = None,
+    heartbeat_at: Optional[datetime] = None,
+) -> uuid.UUID:
+    run_id = uuid.uuid4()
+    async with get_async_db_session() as session:
+        run = WorkflowRun(
+            id=run_id,
+            langgraph_thread_id=str(uuid.uuid4()),
+            project_id=None,
+            type=WorkflowRunType.DOCUMENT_PROCESSING,
+            status=status,
+            created_at=created_at,
+            started_at=started_at,
+            heartbeat_at=heartbeat_at,
+        )
+        session.add(run)
+        await session.commit()
+    return run_id
+
+
+@pytest_asyncio.fixture
+async def cleanup_runs():
+    """Track inserted run IDs and delete them after the test."""
+    inserted: list[uuid.UUID] = []
+    yield inserted
+    if inserted:
+        async with get_async_db_session() as session:
+            stmt = select(WorkflowRun).where(col(WorkflowRun.id).in_(inserted))
+            for run in (await session.execute(stmt)).scalars().all():
+                await session.delete(run)
+            await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# RUNNING + heartbeat_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_running_with_stale_heartbeat_is_stuck(cleanup_runs):
+    """RUNNING + heartbeat_at older than the grace window is reaped."""
+    now = datetime.utcnow()
+    stuck_id = await _insert_run(
+        status=WorkflowRunStatus.RUNNING,
+        created_at=now - timedelta(hours=1),
+        started_at=now - timedelta(hours=1),
+        heartbeat_at=now - timedelta(seconds=RUNNING_GRACE * 2),
+    )
+    cleanup_runs.append(stuck_id)
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    assert stuck_id in stuck_ids
+
+
+@pytest.mark.asyncio
+async def test_running_with_fresh_heartbeat_not_stuck(cleanup_runs):
+    """RUNNING + recent heartbeat is alive — not reaped."""
+    now = datetime.utcnow()
+    fresh_id = await _insert_run(
+        status=WorkflowRunStatus.RUNNING,
+        created_at=now - timedelta(hours=1),
+        started_at=now - timedelta(hours=1),
+        heartbeat_at=now - timedelta(seconds=5),  # well within grace
+    )
+    cleanup_runs.append(fresh_id)
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    assert fresh_id not in stuck_ids
+
+
+# ---------------------------------------------------------------------------
+# RUNNING with heartbeat_at NULL — falls back to started_at
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_running_with_null_heartbeat_and_stale_started_at_is_stuck(cleanup_runs):
+    """No heartbeat ever ticked AND started_at is past the grace window → reap."""
+    now = datetime.utcnow()
+    stuck_id = await _insert_run(
+        status=WorkflowRunStatus.RUNNING,
+        created_at=now - timedelta(hours=1),
+        started_at=now - timedelta(seconds=RUNNING_GRACE * 2),
+        heartbeat_at=None,
+    )
+    cleanup_runs.append(stuck_id)
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    assert stuck_id in stuck_ids
+
+
+@pytest.mark.asyncio
+async def test_running_with_null_heartbeat_and_fresh_started_at_not_stuck(cleanup_runs):
+    """A run that just started but hasn't ticked yet is given the grace window."""
+    now = datetime.utcnow()
+    fresh_id = await _insert_run(
+        status=WorkflowRunStatus.RUNNING,
+        created_at=now - timedelta(seconds=10),
+        started_at=now - timedelta(seconds=10),
+        heartbeat_at=None,
+    )
+    cleanup_runs.append(fresh_id)
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    assert fresh_id not in stuck_ids
+
+
+# ---------------------------------------------------------------------------
+# PENDING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pending_older_than_pending_grace_is_stuck(cleanup_runs):
+    """PENDING + created_at past the pending grace window → reap."""
+    now = datetime.utcnow()
+    stuck_id = await _insert_run(
+        status=WorkflowRunStatus.PENDING,
+        created_at=now - timedelta(seconds=PENDING_GRACE * 2),
+    )
+    cleanup_runs.append(stuck_id)
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    assert stuck_id in stuck_ids
+
+
+@pytest.mark.asyncio
+async def test_pending_within_pending_grace_not_stuck(cleanup_runs):
+    """PENDING + created_at within grace → still considered live (runner may pick it up)."""
+    now = datetime.utcnow()
+    fresh_id = await _insert_run(
+        status=WorkflowRunStatus.PENDING,
+        created_at=now - timedelta(seconds=10),
+    )
+    cleanup_runs.append(fresh_id)
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    assert fresh_id not in stuck_ids
+
+
+# ---------------------------------------------------------------------------
+# Terminal statuses are never returned, regardless of timestamps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_terminal_statuses_never_returned(cleanup_runs):
+    """COMPLETED / CANCELLED / FAILED rows are never reaped — even if they look 'stuck'."""
+    now = datetime.utcnow()
+    very_stale = now - timedelta(days=7)
+    ids = []
+    for terminal_status in (
+        WorkflowRunStatus.COMPLETED,
+        WorkflowRunStatus.CANCELLED,
+        WorkflowRunStatus.FAILED,
+    ):
+        run_id = await _insert_run(
+            status=terminal_status,
+            created_at=very_stale,
+            started_at=very_stale,
+            heartbeat_at=very_stale,
+        )
+        ids.append(run_id)
+    cleanup_runs.extend(ids)
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    for run_id in ids:
+        assert run_id not in stuck_ids
+
+
+# ---------------------------------------------------------------------------
+# Mixed scenario — guards against the worst regressions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_predicate_returns_only_stuck_rows_in_mixed_scenario(cleanup_runs):
+    """A combined fixture: stuck and healthy of every category. The predicate
+    must select exactly the stuck ones and nothing else.
+
+    This is the canary for or_/and_ swaps and cutoff-comparison bugs.
+    """
+    now = datetime.utcnow()
+
+    stuck_running_stale_hb = await _insert_run(
+        status=WorkflowRunStatus.RUNNING,
+        created_at=now - timedelta(hours=1),
+        started_at=now - timedelta(hours=1),
+        heartbeat_at=now - timedelta(seconds=RUNNING_GRACE * 2),
+    )
+    stuck_running_no_hb = await _insert_run(
+        status=WorkflowRunStatus.RUNNING,
+        created_at=now - timedelta(seconds=RUNNING_GRACE * 2),
+        started_at=now - timedelta(seconds=RUNNING_GRACE * 2),
+        heartbeat_at=None,
+    )
+    stuck_pending = await _insert_run(
+        status=WorkflowRunStatus.PENDING,
+        created_at=now - timedelta(seconds=PENDING_GRACE * 2),
+    )
+
+    fresh_running = await _insert_run(
+        status=WorkflowRunStatus.RUNNING,
+        created_at=now - timedelta(hours=1),
+        started_at=now - timedelta(hours=1),
+        heartbeat_at=now - timedelta(seconds=5),
+    )
+    fresh_pending = await _insert_run(
+        status=WorkflowRunStatus.PENDING,
+        created_at=now - timedelta(seconds=10),
+    )
+    completed_old = await _insert_run(
+        status=WorkflowRunStatus.COMPLETED,
+        created_at=now - timedelta(days=7),
+        started_at=now - timedelta(days=7),
+        heartbeat_at=now - timedelta(days=7),
+    )
+
+    cleanup_runs.extend([
+        stuck_running_stale_hb,
+        stuck_running_no_hb,
+        stuck_pending,
+        fresh_running,
+        fresh_pending,
+        completed_old,
+    ])
+
+    stuck = await _find_stuck_runs(RUNNING_GRACE, PENDING_GRACE)
+    stuck_ids = {r.id for r in stuck}
+
+    # The three stuck rows are returned
+    assert stuck_running_stale_hb in stuck_ids
+    assert stuck_running_no_hb in stuck_ids
+    assert stuck_pending in stuck_ids
+
+    # The three healthy / terminal rows are not
+    assert fresh_running not in stuck_ids
+    assert fresh_pending not in stuck_ids
+    assert completed_old not in stuck_ids

--- a/tests/integration/test_workflow_run_timestamps.py
+++ b/tests/integration/test_workflow_run_timestamps.py
@@ -234,6 +234,76 @@ async def test_cancelled_guard_blocks_failed_transition(pending_run_id):
     assert run.failure_message is None
 
 
+@pytest.mark.asyncio
+async def test_failed_guard_blocks_completed_transition(pending_run_id):
+    """Reaper-FAILED-then-runner-COMPLETED race: FAILED must stick.
+
+    The runner can finish its last node *after* the reaper has already
+    flipped the row to FAILED (heartbeat lag). The runner's COMPLETED
+    write must not clobber the reaper's failure metadata.
+    """
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.RUNNING)
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.NO_HEARTBEAT,
+        failure_message="reaper got there first",
+    )
+
+    # Runner's success-path write attempts to overwrite — must be blocked.
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.COMPLETED)
+
+    run = await _fetch_run(pending_run_id)
+    assert run.status == WorkflowRunStatus.FAILED
+    assert run.failure_reason == WorkflowRunFailureReason.NO_HEARTBEAT
+    assert run.failure_message == "reaper got there first"
+
+
+@pytest.mark.asyncio
+async def test_failed_guard_blocks_subsequent_failed_transition(pending_run_id):
+    """Two failure paths racing: the first to write wins. Reason/message stay frozen."""
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.RUNNING)
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.TIMEOUT,
+        failure_message="exceeded max_duration",
+    )
+
+    # A second failure path arriving later (e.g. runner's catch-all
+    # except Exception arm racing with the timeout arm) must not
+    # rewrite the reason or message.
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.UNHANDLED_EXCEPTION,
+        failure_message="this should not stick",
+    )
+
+    run = await _fetch_run(pending_run_id)
+    assert run.failure_reason == WorkflowRunFailureReason.TIMEOUT
+    assert run.failure_message == "exceeded max_duration"
+
+
+@pytest.mark.asyncio
+async def test_completed_guard_blocks_failed_transition(pending_run_id):
+    """COMPLETED is also write-once: a stray FAILED write afterwards is a no-op."""
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.RUNNING)
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.COMPLETED)
+
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.NO_HEARTBEAT,
+        failure_message="too late",
+    )
+
+    run = await _fetch_run(pending_run_id)
+    assert run.status == WorkflowRunStatus.COMPLETED
+    assert run.failure_reason is None
+    assert run.failure_message is None
+
+
 # ---------------------------------------------------------------------------
 # update_workflow_run_heartbeat
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_workflow_run_timestamps.py
+++ b/tests/integration/test_workflow_run_timestamps.py
@@ -8,8 +8,17 @@ from sqlalchemy import select
 from sqlmodel import col
 
 from lib.config.database import get_async_db_session
-from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus, WorkflowRunType
-from lib.services.workflow_runs import create_workflow_run, update_workflow_run_status
+from lib.models.workflow_run import (
+    WorkflowRun,
+    WorkflowRunFailureReason,
+    WorkflowRunStatus,
+    WorkflowRunType,
+)
+from lib.services.workflow_runs import (
+    create_workflow_run,
+    update_workflow_run_heartbeat,
+    update_workflow_run_status,
+)
 
 
 @pytest_asyncio.fixture
@@ -150,6 +159,111 @@ async def test_create_workflow_run_with_completed_status_sets_completed_at():
             if row:
                 await session.delete(row)
                 await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# FAILED status persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_failed_status_persists_failure_reason_and_message(pending_run_id):
+    """Transitioning to FAILED stores failure_reason, failure_message, and completed_at."""
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.RUNNING)
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.TIMEOUT,
+        failure_message="Exceeded max_duration of 3600s",
+    )
+
+    run = await _fetch_run(pending_run_id)
+    assert run.status == WorkflowRunStatus.FAILED
+    assert run.failure_reason == WorkflowRunFailureReason.TIMEOUT
+    assert run.failure_message == "Exceeded max_duration of 3600s"
+    assert run.completed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_failed_status_truncates_long_failure_message(pending_run_id):
+    """failure_message is capped at 2000 chars to keep the column bounded."""
+    long_message = "x" * 5000
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.RUNNING)
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.UNHANDLED_EXCEPTION,
+        failure_message=long_message,
+    )
+
+    run = await _fetch_run(pending_run_id)
+    assert run.failure_message is not None
+    assert len(run.failure_message) == 2000
+
+
+@pytest.mark.asyncio
+async def test_non_failed_status_does_not_persist_failure_metadata(pending_run_id):
+    """failure_reason / failure_message are ignored for non-FAILED transitions."""
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.RUNNING,
+        failure_reason=WorkflowRunFailureReason.TIMEOUT,
+        failure_message="should be ignored",
+    )
+
+    run = await _fetch_run(pending_run_id)
+    assert run.status == WorkflowRunStatus.RUNNING
+    assert run.failure_reason is None
+    assert run.failure_message is None
+
+
+@pytest.mark.asyncio
+async def test_cancelled_guard_blocks_failed_transition(pending_run_id):
+    """Once CANCELLED, a subsequent FAILED transition is a no-op (guard preserved)."""
+    await update_workflow_run_status(pending_run_id, WorkflowRunStatus.CANCELLED)
+    await update_workflow_run_status(
+        pending_run_id,
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.NO_HEARTBEAT,
+        failure_message="should not stick",
+    )
+
+    run = await _fetch_run(pending_run_id)
+    assert run.status == WorkflowRunStatus.CANCELLED
+    assert run.failure_reason is None
+    assert run.failure_message is None
+
+
+# ---------------------------------------------------------------------------
+# update_workflow_run_heartbeat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_update_sets_heartbeat_at(pending_run_id):
+    """update_workflow_run_heartbeat populates heartbeat_at without changing status."""
+    run = await _fetch_run(pending_run_id)
+    assert run.heartbeat_at is None
+    original_status = run.status
+
+    await update_workflow_run_heartbeat(pending_run_id)
+
+    run = await _fetch_run(pending_run_id)
+    assert run.heartbeat_at is not None
+    assert run.status == original_status
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_update_advances_heartbeat_on_repeat(pending_run_id):
+    """Repeated heartbeats keep advancing the timestamp."""
+    await update_workflow_run_heartbeat(pending_run_id)
+    first = (await _fetch_run(pending_run_id)).heartbeat_at
+    assert first is not None
+
+    await update_workflow_run_heartbeat(pending_run_id)
+    second = (await _fetch_run(pending_run_id)).heartbeat_at
+    assert second is not None
+    assert second >= first
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_cancel_workflow_run.py
+++ b/tests/unit/services/test_cancel_workflow_run.py
@@ -36,7 +36,7 @@ def _patches(
             new=AsyncMock(return_value=run),
         ),
         patch(
-            "lib.services.workflow_progress.cancel_workflow_progress",
+            "lib.services.workflow_runs.cancel_workflow_progress",
             new=AsyncMock(),
         ),
         patch(
@@ -44,7 +44,7 @@ def _patches(
             new=AsyncMock(),
         ),
         patch(
-            "lib.workflows.dependency_resolver.get_required_dependents",
+            "lib.services.workflow_runs.get_required_dependents",
             return_value=dependents,
         ),
         patch(
@@ -66,9 +66,9 @@ async def test_cancel_marks_run_cancelled():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()) as mock_update,
-        patch("lib.workflows.dependency_resolver.get_required_dependents", return_value=[]),
+        patch("lib.services.workflow_runs.get_required_dependents", return_value=[]),
         patch("lib.services.workflow_runs.get_project_workflow_run_by_type", new=AsyncMock(return_value=None)),
     ):
         await cancel_workflow_run(str(run.id), "project-1")
@@ -83,9 +83,9 @@ async def test_cancel_calls_cancel_workflow_progress():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()) as mock_cancel_progress,
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()) as mock_cancel_progress,
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()),
-        patch("lib.workflows.dependency_resolver.get_required_dependents", return_value=[]),
+        patch("lib.services.workflow_runs.get_required_dependents", return_value=[]),
         patch("lib.services.workflow_runs.get_project_workflow_run_by_type", new=AsyncMock(return_value=None)),
     ):
         await cancel_workflow_run(str(run.id), "project-1")
@@ -111,9 +111,9 @@ async def test_cancel_cascades_to_pending_dependent():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(side_effect=lambda rid, **kw: runs_by_id[str(rid)])),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()) as mock_update,
-        patch("lib.workflows.dependency_resolver.get_required_dependents", side_effect=dependents_for),
+        patch("lib.services.workflow_runs.get_required_dependents", side_effect=dependents_for),
         patch(
             "lib.services.workflow_runs.get_project_workflow_run_by_type",
             new=AsyncMock(return_value=dependent_run),
@@ -138,9 +138,9 @@ async def test_cancel_cascades_to_running_dependent():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(side_effect=lambda rid, **kw: runs_by_id[str(rid)])),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()) as mock_update,
-        patch("lib.workflows.dependency_resolver.get_required_dependents", side_effect=dependents_for),
+        patch("lib.services.workflow_runs.get_required_dependents", side_effect=dependents_for),
         patch(
             "lib.services.workflow_runs.get_project_workflow_run_by_type",
             new=AsyncMock(return_value=dependent_run),
@@ -160,10 +160,10 @@ async def test_cancel_does_not_cascade_to_completed_dependent():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()) as mock_update,
         patch(
-            "lib.workflows.dependency_resolver.get_required_dependents",
+            "lib.services.workflow_runs.get_required_dependents",
             return_value=[WorkflowRunType.REFERENCE_EXTRACTION],
         ),
         patch(
@@ -185,10 +185,10 @@ async def test_cancel_does_not_cascade_to_already_cancelled_dependent():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()) as mock_update,
         patch(
-            "lib.workflows.dependency_resolver.get_required_dependents",
+            "lib.services.workflow_runs.get_required_dependents",
             return_value=[WorkflowRunType.REFERENCE_EXTRACTION],
         ),
         patch(
@@ -210,10 +210,10 @@ async def test_cancel_skips_missing_dependent():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()) as mock_update,
         patch(
-            "lib.workflows.dependency_resolver.get_required_dependents",
+            "lib.services.workflow_runs.get_required_dependents",
             return_value=[WorkflowRunType.REFERENCE_EXTRACTION],
         ),
         patch(

--- a/tests/unit/services/test_fail_workflow_run.py
+++ b/tests/unit/services/test_fail_workflow_run.py
@@ -36,11 +36,11 @@ async def test_fail_marks_run_failed_with_reason_and_message():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch(
             "lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()
         ) as mock_update,
-        patch("lib.workflows.dependency_resolver.get_required_dependents", return_value=[]),
+        patch("lib.services.workflow_runs.get_required_dependents", return_value=[]),
         patch(
             "lib.services.workflow_runs.get_project_workflow_run_by_type",
             new=AsyncMock(return_value=None),
@@ -69,10 +69,10 @@ async def test_fail_calls_cancel_workflow_progress():
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
         patch(
-            "lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()
+            "lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()
         ) as mock_cancel_progress,
         patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()),
-        patch("lib.workflows.dependency_resolver.get_required_dependents", return_value=[]),
+        patch("lib.services.workflow_runs.get_required_dependents", return_value=[]),
         patch(
             "lib.services.workflow_runs.get_project_workflow_run_by_type",
             new=AsyncMock(return_value=None),
@@ -107,12 +107,12 @@ async def test_fail_cascades_to_pending_dependent_as_cancelled():
             "lib.services.workflow_runs.get_workflow_run",
             new=AsyncMock(side_effect=lambda rid, **kw: runs_by_id[str(rid)]),
         ),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch(
             "lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()
         ) as mock_update,
         patch(
-            "lib.workflows.dependency_resolver.get_required_dependents",
+            "lib.services.workflow_runs.get_required_dependents",
             side_effect=dependents_for,
         ),
         patch(
@@ -142,12 +142,12 @@ async def test_fail_does_not_cascade_to_completed_dependent():
 
     with (
         patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
-        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch("lib.services.workflow_runs.cancel_workflow_progress", new=AsyncMock()),
         patch(
             "lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()
         ) as mock_update,
         patch(
-            "lib.workflows.dependency_resolver.get_required_dependents",
+            "lib.services.workflow_runs.get_required_dependents",
             return_value=[WorkflowRunType.REFERENCE_EXTRACTION],
         ),
         patch(

--- a/tests/unit/services/test_fail_workflow_run.py
+++ b/tests/unit/services/test_fail_workflow_run.py
@@ -1,0 +1,182 @@
+"""Unit tests for fail_workflow_run — sets FAILED with metadata and cascade-cancels dependents."""
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lib.models.workflow_run import (
+    WorkflowRun,
+    WorkflowRunFailureReason,
+    WorkflowRunStatus,
+    WorkflowRunType,
+)
+from lib.services.workflow_runs import fail_workflow_run
+
+
+def _make_run(
+    run_type: WorkflowRunType,
+    status: WorkflowRunStatus,
+    run_id: str | None = None,
+    project_id: str = "project-1",
+) -> WorkflowRun:
+    return WorkflowRun(
+        id=run_id or str(uuid.uuid4()),
+        project_id=project_id,
+        type=run_type,
+        status=status,
+        langgraph_thread_id=str(uuid.uuid4()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_fail_marks_run_failed_with_reason_and_message():
+    """The target run is updated to FAILED with the provided reason and message."""
+    run = _make_run(WorkflowRunType.DOCUMENT_PROCESSING, WorkflowRunStatus.RUNNING)
+
+    with (
+        patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
+        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch(
+            "lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()
+        ) as mock_update,
+        patch("lib.workflows.dependency_resolver.get_required_dependents", return_value=[]),
+        patch(
+            "lib.services.workflow_runs.get_project_workflow_run_by_type",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await fail_workflow_run(
+            str(run.id),
+            "project-1",
+            failure_reason=WorkflowRunFailureReason.TIMEOUT,
+            failure_message="exceeded max_duration",
+        )
+
+    mock_update.assert_any_await(
+        str(run.id),
+        WorkflowRunStatus.FAILED,
+        failure_reason=WorkflowRunFailureReason.TIMEOUT,
+        failure_message="exceeded max_duration",
+    )
+
+
+@pytest.mark.asyncio
+async def test_fail_calls_cancel_workflow_progress():
+    """Progress entries for the failed run are cleaned up like cancellation."""
+    run = _make_run(WorkflowRunType.DOCUMENT_PROCESSING, WorkflowRunStatus.RUNNING)
+
+    with (
+        patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
+        patch(
+            "lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()
+        ) as mock_cancel_progress,
+        patch("lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()),
+        patch("lib.workflows.dependency_resolver.get_required_dependents", return_value=[]),
+        patch(
+            "lib.services.workflow_runs.get_project_workflow_run_by_type",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await fail_workflow_run(
+            str(run.id),
+            "project-1",
+            failure_reason=WorkflowRunFailureReason.UNHANDLED_EXCEPTION,
+        )
+
+    mock_cancel_progress.assert_awaited_once_with(run.project_id, run.type)
+
+
+@pytest.mark.asyncio
+async def test_fail_cascades_to_pending_dependent_as_cancelled():
+    """A failed parent cascade-cancels active dependents (CANCELLED, not FAILED)."""
+    run = _make_run(WorkflowRunType.DOCUMENT_PROCESSING, WorkflowRunStatus.RUNNING)
+    dependent_run = _make_run(WorkflowRunType.REFERENCE_EXTRACTION, WorkflowRunStatus.PENDING)
+
+    runs_by_id = {str(run.id): run, str(dependent_run.id): dependent_run}
+
+    def dependents_for(workflow_type):
+        return (
+            [WorkflowRunType.REFERENCE_EXTRACTION]
+            if workflow_type == WorkflowRunType.DOCUMENT_PROCESSING
+            else []
+        )
+
+    with (
+        patch(
+            "lib.services.workflow_runs.get_workflow_run",
+            new=AsyncMock(side_effect=lambda rid, **kw: runs_by_id[str(rid)]),
+        ),
+        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch(
+            "lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()
+        ) as mock_update,
+        patch(
+            "lib.workflows.dependency_resolver.get_required_dependents",
+            side_effect=dependents_for,
+        ),
+        patch(
+            "lib.services.workflow_runs.get_project_workflow_run_by_type",
+            new=AsyncMock(return_value=dependent_run),
+        ),
+    ):
+        await fail_workflow_run(
+            str(run.id),
+            "project-1",
+            failure_reason=WorkflowRunFailureReason.NO_HEARTBEAT,
+        )
+
+    # Dependent must be moved to CANCELLED (cascade semantics), not FAILED.
+    dependent_calls = [
+        call for call in mock_update.await_args_list if call.args[0] == str(dependent_run.id)
+    ]
+    assert len(dependent_calls) == 1
+    assert dependent_calls[0].args[1] == WorkflowRunStatus.CANCELLED
+
+
+@pytest.mark.asyncio
+async def test_fail_does_not_cascade_to_completed_dependent():
+    """A COMPLETED dependent is left untouched when the parent fails."""
+    run = _make_run(WorkflowRunType.DOCUMENT_PROCESSING, WorkflowRunStatus.RUNNING)
+    dependent_run = _make_run(WorkflowRunType.REFERENCE_EXTRACTION, WorkflowRunStatus.COMPLETED)
+
+    with (
+        patch("lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)),
+        patch("lib.services.workflow_progress.cancel_workflow_progress", new=AsyncMock()),
+        patch(
+            "lib.services.workflow_runs.update_workflow_run_status", new=AsyncMock()
+        ) as mock_update,
+        patch(
+            "lib.workflows.dependency_resolver.get_required_dependents",
+            return_value=[WorkflowRunType.REFERENCE_EXTRACTION],
+        ),
+        patch(
+            "lib.services.workflow_runs.get_project_workflow_run_by_type",
+            new=AsyncMock(return_value=dependent_run),
+        ),
+    ):
+        await fail_workflow_run(
+            str(run.id),
+            "project-1",
+            failure_reason=WorkflowRunFailureReason.TIMEOUT,
+        )
+
+    cascaded_ids = {call.args[0] for call in mock_update.await_args_list}
+    assert str(dependent_run.id) not in cascaded_ids
+
+
+@pytest.mark.asyncio
+async def test_fail_raises_when_run_has_no_project_id():
+    """fail_workflow_run requires project_id on the row."""
+    run = _make_run(WorkflowRunType.DOCUMENT_PROCESSING, WorkflowRunStatus.RUNNING)
+    run.project_id = None
+
+    with patch(
+        "lib.services.workflow_runs.get_workflow_run", new=AsyncMock(return_value=run)
+    ):
+        with pytest.raises(ValueError, match="no project_id"):
+            await fail_workflow_run(
+                str(run.id),
+                "project-1",
+                failure_reason=WorkflowRunFailureReason.UNHANDLED_EXCEPTION,
+            )

--- a/tests/unit/services/test_workflow_reaper.py
+++ b/tests/unit/services/test_workflow_reaper.py
@@ -1,6 +1,7 @@
 """Unit tests for the workflow reaper sweep logic."""
 
 import uuid
+from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -18,6 +19,25 @@ from lib.services.workflow_reaper import (
     _reap_once,
     _run_manifest_on_cancel,
 )
+
+
+@asynccontextmanager
+async def _fake_lock(acquired: bool):
+    yield acquired
+
+
+@pytest.fixture(autouse=True)
+def _stub_advisory_lock():
+    """Default stub: lock is acquired so the existing assertions exercise the
+    full sweep body. Tests that need the lock-not-acquired path patch the
+    helper themselves.
+    """
+    with patch.object(
+        workflow_reaper,
+        "_reaper_advisory_lock",
+        lambda: _fake_lock(True),
+    ):
+        yield
 
 
 def _make_run(
@@ -351,3 +371,33 @@ async def test_reap_once_handles_mixed_running_and_pending():
 def test_default_grace_windows_are_consistent():
     """Pending grace must be >= running grace; otherwise PENDING reaping is overly aggressive."""
     assert PENDING_GRACE_SECONDS >= REAPER_GRACE_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# Advisory lock — multi-pod serialization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reap_once_skips_when_lock_not_acquired():
+    """If another pod holds the advisory lock, this sweep returns 0 and does no DB work."""
+    find_stuck = AsyncMock(return_value=[_make_run(WorkflowRunStatus.RUNNING)])
+    fail = AsyncMock()
+    on_cancel = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper,
+            "_reaper_advisory_lock",
+            lambda: _fake_lock(False),
+        ),
+        patch.object(workflow_reaper, "_find_stuck_runs", new=find_stuck),
+        patch.object(workflow_reaper, "fail_workflow_run", new=fail),
+        patch.object(workflow_reaper, "_run_manifest_on_cancel", new=on_cancel),
+    ):
+        reaped = await _reap_once()
+
+    assert reaped == 0
+    find_stuck.assert_not_awaited()
+    fail.assert_not_awaited()
+    on_cancel.assert_not_awaited()

--- a/tests/unit/services/test_workflow_reaper.py
+++ b/tests/unit/services/test_workflow_reaper.py
@@ -1,0 +1,353 @@
+"""Unit tests for the workflow reaper sweep logic."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lib.models.workflow_run import (
+    WorkflowRun,
+    WorkflowRunFailureReason,
+    WorkflowRunStatus,
+    WorkflowRunType,
+)
+from lib.services import workflow_reaper
+from lib.services.workflow_reaper import (
+    PENDING_GRACE_SECONDS,
+    REAPER_GRACE_SECONDS,
+    _reap_once,
+    _run_manifest_on_cancel,
+)
+
+
+def _make_run(
+    status: WorkflowRunStatus,
+    *,
+    project_id: str | None = "project-1",
+    run_type: WorkflowRunType = WorkflowRunType.DOCUMENT_PROCESSING,
+) -> WorkflowRun:
+    return WorkflowRun(
+        id=str(uuid.uuid4()),
+        project_id=project_id,
+        type=run_type,
+        status=status,
+        langgraph_thread_id=str(uuid.uuid4()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _run_manifest_on_cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_manifest_on_cancel_invokes_hook_when_state_present():
+    """Hook is awaited with (state, app, thread_config) when both manifest and state exist."""
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    state = MagicMock()
+    manifest = MagicMock()
+    manifest.on_cancel = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper, "get_workflow_manifest", return_value=manifest
+        ),
+        patch.object(
+            workflow_reaper,
+            "get_workflow_run_state_by_thread_id",
+            new=AsyncMock(return_value=state),
+        ),
+        patch.object(
+            workflow_reaper, "create_graph", return_value=MagicMock()
+        ) as mock_create_graph,
+        patch.object(workflow_reaper, "get_checkpointer") as mock_checkpointer_cm,
+    ):
+        mock_checkpointer_cm.return_value.__aenter__ = AsyncMock(
+            return_value=MagicMock()
+        )
+        mock_checkpointer_cm.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_create_graph.return_value.compile.return_value = MagicMock()
+
+        await _run_manifest_on_cancel(run)
+
+    manifest.on_cancel.assert_awaited_once()
+    awaited_state, awaited_app, awaited_config = manifest.on_cancel.await_args.args
+    assert awaited_state is state
+    assert awaited_config["configurable"]["thread_id"] == run.langgraph_thread_id
+
+
+@pytest.mark.asyncio
+async def test_run_manifest_on_cancel_noop_when_manifest_missing():
+    """No state load is attempted when the workflow type has no manifest."""
+    run = _make_run(WorkflowRunStatus.PENDING)
+
+    state_loader = AsyncMock()
+
+    with (
+        patch.object(workflow_reaper, "get_workflow_manifest", return_value=None),
+        patch.object(
+            workflow_reaper, "get_workflow_run_state_by_thread_id", new=state_loader
+        ),
+    ):
+        await _run_manifest_on_cancel(run)
+
+    state_loader.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_manifest_on_cancel_noop_when_state_missing():
+    """Hook is skipped when no checkpoint state exists (e.g. orphaned PENDING)."""
+    run = _make_run(WorkflowRunStatus.PENDING)
+    manifest = MagicMock()
+    manifest.on_cancel = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper, "get_workflow_manifest", return_value=manifest
+        ),
+        patch.object(
+            workflow_reaper,
+            "get_workflow_run_state_by_thread_id",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        await _run_manifest_on_cancel(run)
+
+    manifest.on_cancel.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_manifest_on_cancel_swallows_hook_exception():
+    """A raising on_cancel hook is logged but does not propagate."""
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    manifest = MagicMock()
+    manifest.on_cancel = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with (
+        patch.object(
+            workflow_reaper, "get_workflow_manifest", return_value=manifest
+        ),
+        patch.object(
+            workflow_reaper,
+            "get_workflow_run_state_by_thread_id",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+        patch.object(
+            workflow_reaper, "create_graph", return_value=MagicMock()
+        ) as mock_create_graph,
+        patch.object(workflow_reaper, "get_checkpointer") as mock_checkpointer_cm,
+    ):
+        mock_checkpointer_cm.return_value.__aenter__ = AsyncMock(
+            return_value=MagicMock()
+        )
+        mock_checkpointer_cm.return_value.__aexit__ = AsyncMock(return_value=False)
+        mock_create_graph.return_value.compile.return_value = MagicMock()
+
+        await _run_manifest_on_cancel(run)
+
+
+@pytest.mark.asyncio
+async def test_run_manifest_on_cancel_swallows_state_load_exception():
+    """A failure loading state is logged and the hook is skipped, not re-raised."""
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    manifest = MagicMock()
+    manifest.on_cancel = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper, "get_workflow_manifest", return_value=manifest
+        ),
+        patch.object(
+            workflow_reaper,
+            "get_workflow_run_state_by_thread_id",
+            new=AsyncMock(side_effect=RuntimeError("db down")),
+        ),
+    ):
+        await _run_manifest_on_cancel(run)
+
+    manifest.on_cancel.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _reap_once
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reap_once_returns_zero_when_nothing_stuck():
+    """No stuck runs → no fail_workflow_run calls, returns 0."""
+    fail = AsyncMock()
+    with (
+        patch.object(
+            workflow_reaper, "_find_stuck_runs", new=AsyncMock(return_value=[])
+        ),
+        patch.object(workflow_reaper, "fail_workflow_run", new=fail),
+        patch.object(workflow_reaper, "_run_manifest_on_cancel", new=AsyncMock()),
+    ):
+        reaped = await _reap_once()
+
+    assert reaped == 0
+    fail.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reap_once_skips_runs_without_project_id():
+    """Stuck rows with no project_id are logged and skipped, not failed."""
+    run = _make_run(WorkflowRunStatus.RUNNING, project_id=None)
+    fail = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper, "_find_stuck_runs", new=AsyncMock(return_value=[run])
+        ),
+        patch.object(workflow_reaper, "fail_workflow_run", new=fail),
+        patch.object(workflow_reaper, "_run_manifest_on_cancel", new=AsyncMock()),
+    ):
+        reaped = await _reap_once()
+
+    # The total still counts the row (it was discovered as stuck), but no
+    # fail_workflow_run call is made.
+    assert reaped == 1
+    fail.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reap_once_running_uses_no_heartbeat_failure_reason():
+    """RUNNING stuck rows get failure_reason=NO_HEARTBEAT and the heartbeat-shaped message."""
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    fail = AsyncMock()
+    on_cancel = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper, "_find_stuck_runs", new=AsyncMock(return_value=[run])
+        ),
+        patch.object(workflow_reaper, "fail_workflow_run", new=fail),
+        patch.object(workflow_reaper, "_run_manifest_on_cancel", new=on_cancel),
+    ):
+        await _reap_once(running_grace_seconds=60.0)
+
+    on_cancel.assert_awaited_once_with(run)
+    fail.assert_awaited_once()
+    kwargs = fail.await_args.kwargs
+    args = fail.await_args.args
+    assert args[0] == str(run.id)
+    assert args[1] == str(run.project_id)
+    assert kwargs["failure_reason"] == WorkflowRunFailureReason.NO_HEARTBEAT
+    assert "No heartbeat" in kwargs["failure_message"]
+    assert "60s" in kwargs["failure_message"]
+
+
+@pytest.mark.asyncio
+async def test_reap_once_pending_uses_pending_specific_message():
+    """PENDING stuck rows get NO_HEARTBEAT reason but a PENDING-specific message."""
+    run = _make_run(WorkflowRunStatus.PENDING)
+    fail = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper, "_find_stuck_runs", new=AsyncMock(return_value=[run])
+        ),
+        patch.object(workflow_reaper, "fail_workflow_run", new=fail),
+        patch.object(workflow_reaper, "_run_manifest_on_cancel", new=AsyncMock()),
+    ):
+        await _reap_once(pending_grace_seconds=PENDING_GRACE_SECONDS)
+
+    fail.assert_awaited_once()
+    kwargs = fail.await_args.kwargs
+    assert kwargs["failure_reason"] == WorkflowRunFailureReason.NO_HEARTBEAT
+    msg = kwargs["failure_message"]
+    assert "PENDING for" in msg
+    assert "without starting" in msg
+    assert str(int(PENDING_GRACE_SECONDS)) in msg
+
+
+@pytest.mark.asyncio
+async def test_reap_once_calls_on_cancel_before_fail():
+    """The manifest hook fires before the FAILED transition so cleanup happens first."""
+    run = _make_run(WorkflowRunStatus.RUNNING)
+    call_order: list[str] = []
+
+    async def record_on_cancel(_run):
+        call_order.append("on_cancel")
+
+    async def record_fail(*_args, **_kwargs):
+        call_order.append("fail")
+
+    with (
+        patch.object(
+            workflow_reaper, "_find_stuck_runs", new=AsyncMock(return_value=[run])
+        ),
+        patch.object(
+            workflow_reaper, "_run_manifest_on_cancel", new=AsyncMock(side_effect=record_on_cancel)
+        ),
+        patch.object(
+            workflow_reaper, "fail_workflow_run", new=AsyncMock(side_effect=record_fail)
+        ),
+    ):
+        await _reap_once()
+
+    assert call_order == ["on_cancel", "fail"]
+
+
+@pytest.mark.asyncio
+async def test_reap_once_continues_when_one_row_fails():
+    """A bad row's failure does not stop the rest of the sweep."""
+    bad = _make_run(WorkflowRunStatus.RUNNING)
+    good = _make_run(WorkflowRunStatus.RUNNING)
+
+    fail = AsyncMock(
+        side_effect=[RuntimeError("transient"), None]
+    )
+
+    with (
+        patch.object(
+            workflow_reaper,
+            "_find_stuck_runs",
+            new=AsyncMock(return_value=[bad, good]),
+        ),
+        patch.object(workflow_reaper, "_run_manifest_on_cancel", new=AsyncMock()),
+        patch.object(workflow_reaper, "fail_workflow_run", new=fail),
+    ):
+        reaped = await _reap_once()
+
+    assert reaped == 2
+    assert fail.await_count == 2
+    assert fail.await_args_list[1].args[0] == str(good.id)
+
+
+@pytest.mark.asyncio
+async def test_reap_once_handles_mixed_running_and_pending():
+    """A sweep with both RUNNING and PENDING stuck rows produces distinct messages."""
+    running = _make_run(WorkflowRunStatus.RUNNING)
+    pending = _make_run(WorkflowRunStatus.PENDING)
+    fail = AsyncMock()
+
+    with (
+        patch.object(
+            workflow_reaper,
+            "_find_stuck_runs",
+            new=AsyncMock(return_value=[running, pending]),
+        ),
+        patch.object(workflow_reaper, "_run_manifest_on_cancel", new=AsyncMock()),
+        patch.object(workflow_reaper, "fail_workflow_run", new=fail),
+    ):
+        await _reap_once()
+
+    assert fail.await_count == 2
+    messages_by_id = {
+        call.args[0]: call.kwargs["failure_message"]
+        for call in fail.await_args_list
+    }
+    assert "No heartbeat" in messages_by_id[str(running.id)]
+    assert "PENDING for" in messages_by_id[str(pending.id)]
+
+
+# ---------------------------------------------------------------------------
+# Sanity defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_grace_windows_are_consistent():
+    """Pending grace must be >= running grace; otherwise PENDING reaping is overly aggressive."""
+    assert PENDING_GRACE_SECONDS >= REAPER_GRACE_SECONDS

--- a/tests/unit/test_cancel_workflow_endpoint.py
+++ b/tests/unit/test_cancel_workflow_endpoint.py
@@ -44,6 +44,24 @@ async def test_cancel_completed_workflow_raises_400():
 
 
 @pytest.mark.asyncio
+async def test_cancel_failed_workflow_raises_400():
+    """Cancelling a FAILED workflow is rejected — FAILED is a terminal state."""
+    from lib.api.routers.workflows import cancel_workflow_run_endpoint
+
+    run = _make_run(WorkflowRunStatus.FAILED)
+
+    with patch(
+        "lib.api.routers.workflows.get_workflow_run",
+        new=AsyncMock(return_value=run),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await cancel_workflow_run_endpoint(str(run.id), current_user=_mock_user())
+
+    assert exc_info.value.status_code == 400
+    assert "already failed" in exc_info.value.detail.lower()
+
+
+@pytest.mark.asyncio
 async def test_cancel_already_cancelled_workflow_is_idempotent():
     """Cancelling an already-CANCELLED workflow returns 'Already cancelled' without error."""
     from lib.api.routers.workflows import cancel_workflow_run_endpoint

--- a/tests/unit/test_workflow_orchestration.py
+++ b/tests/unit/test_workflow_orchestration.py
@@ -4,7 +4,11 @@ import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 from uuid import uuid4
 
-from lib.services.workflow_orchestration import wait_for_dependencies
+from lib.services.workflow_orchestration import (
+    DEPENDENCY_WAIT_TIMEOUT,
+    wait_for_dependencies,
+)
+from lib.workflows.models import DependencyWaitTimeoutError, WorkflowCancelledError
 from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus, WorkflowRunType
 
 
@@ -402,4 +406,100 @@ async def test_cancelled_optional_dependency_does_not_raise():
         )
 
     mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# DependencyWaitTimeoutError
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_for_dependencies_raises_after_timeout(mock_manifest):
+    """wait_for_dependencies raises DependencyWaitTimeoutError once it has waited longer than DEPENDENCY_WAIT_TIMEOUT."""
+    project_id = str(uuid4())
+    current_run_id = str(uuid4())
+    other_run_id = str(uuid4())
+
+    # A perpetually RUNNING upstream of the same type → wait loop never clears.
+    blocking_run = create_workflow_run(
+        WorkflowRunType.DOCUMENT_PROCESSING,
+        WorkflowRunStatus.RUNNING,
+        run_id=other_run_id,
+    )
+
+    # First call returns t=0 (start), then jumps past the timeout window so the
+    # loop's deadline check fires on the next iteration.
+    monotonic_calls = iter([0.0, float(DEPENDENCY_WAIT_TIMEOUT) + 1.0])
+
+    with (
+        patch(
+            "lib.services.workflow_orchestration.get_workflow_manifest",
+            return_value=mock_manifest,
+        ),
+        patch(
+            "lib.services.workflow_orchestration.get_project_workflow_run_by_type",
+            new=AsyncMock(return_value=blocking_run),
+        ),
+        patch("lib.services.workflow_orchestration.asyncio.sleep", new=AsyncMock()),
+        patch(
+            "lib.services.workflow_orchestration.time.monotonic",
+            side_effect=lambda: next(monotonic_calls),
+        ),
+    ):
+        with pytest.raises(DependencyWaitTimeoutError) as exc:
+            await wait_for_dependencies(
+                WorkflowRunType.DOCUMENT_PROCESSING,
+                project_id,
+                current_workflow_run_id=current_run_id,
+            )
+
+    assert "document_processing" in str(exc.value)
+    assert str(DEPENDENCY_WAIT_TIMEOUT) in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# FAILED upstream is treated as terminal for required dependencies
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_required_failed_dependency_cancels_dependent():
+    """A FAILED required dependency aborts the dependent run via WorkflowCancelledError."""
+    project_id = str(uuid4())
+    current_run_id = str(uuid4())
+
+    manifest_with_required = MagicMock()
+    manifest_with_required.required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
+    manifest_with_required.optional_dependencies = []
+
+    failed_dep = create_workflow_run(
+        WorkflowRunType.DOCUMENT_PROCESSING,
+        WorkflowRunStatus.FAILED,
+    )
+
+    with (
+        patch(
+            "lib.services.workflow_orchestration.get_workflow_manifest",
+            return_value=manifest_with_required,
+        ),
+        patch(
+            "lib.services.workflow_orchestration.get_project_workflow_run_by_type",
+            new=AsyncMock(return_value=failed_dep),
+        ),
+        patch(
+            "lib.services.workflow_orchestration.update_workflow_run_status",
+            new=AsyncMock(),
+        ) as mock_update,
+        patch("lib.services.workflow_orchestration.asyncio.sleep", new=AsyncMock()),
+    ):
+        with pytest.raises(WorkflowCancelledError) as exc:
+            await wait_for_dependencies(
+                WorkflowRunType.REFERENCE_EXTRACTION,
+                project_id,
+                current_workflow_run_id=current_run_id,
+            )
+
+    assert "failed" in str(exc.value).lower()
+    # The dependent itself is moved to CANCELLED so the cascade is consistent.
+    mock_update.assert_any_await(current_run_id, WorkflowRunStatus.CANCELLED)
 

--- a/tests/unit/workflows/test_runner.py
+++ b/tests/unit/workflows/test_runner.py
@@ -1,0 +1,365 @@
+"""Unit tests for the runner's terminal-status branches.
+
+`run_workflow` has four exit paths: success → COMPLETED, WorkflowCancelledError
+→ on_cancel + leave CANCELLED, asyncio.TimeoutError → on_cancel + FAILED+timeout,
+generic Exception → checkpoint append + FAILED+unhandled_exception. The wrapper
+`run_workflow_with_dependency_check` adds a fifth: DependencyWaitTimeoutError
+→ FAILED+dependency_timeout. These tests drive each branch with a mocked
+graph/checkpointer so the behavior contract is locked in even though we don't
+spin up real LangGraph.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from lib.models.workflow_run import WorkflowRunFailureReason, WorkflowRunType
+from lib.services.file_artifacts_service.mock import MockFileArtifactsService
+from lib.workflows.context import ContextSchema
+from lib.workflows.models import (
+    BaseWorkflowState,
+    DependencyWaitTimeoutError,
+    WorkflowCancelledError,
+)
+from lib.workflows.runner import run_workflow, run_workflow_with_dependency_check
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_context(project_id: str, workflow_run_id: str) -> ContextSchema:
+    """Minimal ContextSchema — all the runner's terminal-branch logic only
+    looks at project_id, so we don't need a real file artifacts service."""
+    return ContextSchema(
+        project_id=project_id,
+        workflow_run_id=workflow_run_id,
+        file_artifacts_service=MockFileArtifactsService(),
+    )
+
+
+def _build_app_with_astream(astream_impl) -> MagicMock:
+    """Build a mock CompiledStateGraph whose astream uses ``astream_impl``."""
+    app = MagicMock()
+    app.astream = astream_impl
+    app.aget_state = AsyncMock(return_value=MagicMock(config={"configurable": {}}))
+    app.aupdate_state = AsyncMock()
+    return app
+
+
+def _build_graph(app: MagicMock) -> MagicMock:
+    """Build a mock StateGraph whose compile().with_config() returns ``app``."""
+    graph = MagicMock()
+    compiled = MagicMock()
+    compiled.with_config.return_value = app
+    graph.compile.return_value = compiled
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# run_workflow — terminal branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_success_marks_completed():
+    """Success path writes COMPLETED via update_workflow_run_status, not fail_workflow_run."""
+    workflow_run_id = str(uuid4())
+    project_id = str(uuid4())
+
+    async def empty_astream(*_args, **_kwargs):
+        # No iterations → completes immediately.
+        return
+        yield  # pragma: no cover — make this an async generator
+
+    app = _build_app_with_astream(empty_astream)
+    graph = _build_graph(app)
+    fail = AsyncMock()
+    update_status = AsyncMock()
+
+    manifest = MagicMock()
+    manifest.max_duration_seconds = 60
+    manifest.on_cancel = AsyncMock()
+
+    checkpointer_cm = MagicMock()
+    checkpointer_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    checkpointer_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("lib.workflows.runner.get_checkpointer", return_value=checkpointer_cm),
+        patch("lib.workflows.runner.get_workflow_manifest", return_value=manifest),
+        patch("lib.workflows.runner.update_workflow_run_status", new=update_status),
+        patch("lib.workflows.runner.fail_workflow_run", new=fail),
+        patch("lib.workflows.runner._persist_issues_from_state", new=AsyncMock()),
+    ):
+        await run_workflow(
+            workflow_run_id=workflow_run_id,
+            workflow_type=WorkflowRunType.DOCUMENT_PROCESSING,
+            graph=graph,
+            state=BaseWorkflowState(),
+            context=_make_context(project_id, workflow_run_id),
+            thread_id=str(uuid4()),
+        )
+
+    fail.assert_not_awaited()
+    manifest.on_cancel.assert_not_awaited()
+    completed_calls = [
+        c for c in update_status.await_args_list if c.args[1].value == "completed"
+    ]
+    assert len(completed_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_timeout_marks_failed_and_runs_on_cancel():
+    """asyncio.TimeoutError triggers FAILED+timeout and invokes manifest.on_cancel."""
+    workflow_run_id = str(uuid4())
+    project_id = str(uuid4())
+
+    async def raising_astream(*_args, **_kwargs):
+        raise asyncio.TimeoutError()
+        yield  # pragma: no cover
+
+    app = _build_app_with_astream(raising_astream)
+    graph = _build_graph(app)
+    fail = AsyncMock()
+
+    manifest = MagicMock()
+    manifest.max_duration_seconds = 60
+    manifest.on_cancel = AsyncMock()
+
+    checkpointer_cm = MagicMock()
+    checkpointer_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    checkpointer_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("lib.workflows.runner.get_checkpointer", return_value=checkpointer_cm),
+        patch("lib.workflows.runner.get_workflow_manifest", return_value=manifest),
+        patch("lib.workflows.runner.update_workflow_run_status", new=AsyncMock()),
+        patch("lib.workflows.runner.fail_workflow_run", new=fail),
+        patch("lib.workflows.runner._persist_issues_from_state", new=AsyncMock()),
+    ):
+        await run_workflow(
+            workflow_run_id=workflow_run_id,
+            workflow_type=WorkflowRunType.DOCUMENT_PROCESSING,
+            graph=graph,
+            state=BaseWorkflowState(),
+            context=_make_context(project_id, workflow_run_id),
+            thread_id=str(uuid4()),
+        )
+
+    manifest.on_cancel.assert_awaited_once()
+    fail.assert_awaited_once()
+    args, kwargs = fail.await_args
+    assert args[0] == workflow_run_id
+    assert args[1] == project_id
+    assert kwargs["failure_reason"] == WorkflowRunFailureReason.TIMEOUT
+    assert "max_duration" in kwargs["failure_message"]
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_unhandled_exception_marks_failed_and_persists_to_checkpoint():
+    """A bare Exception is captured into the checkpoint and the run becomes FAILED+unhandled_exception."""
+    workflow_run_id = str(uuid4())
+    project_id = str(uuid4())
+
+    async def raising_astream(*_args, **_kwargs):
+        raise RuntimeError("boom in node")
+        yield  # pragma: no cover
+
+    app = _build_app_with_astream(raising_astream)
+    graph = _build_graph(app)
+    fail = AsyncMock()
+
+    manifest = MagicMock()
+    manifest.max_duration_seconds = 60
+    manifest.on_cancel = AsyncMock()
+
+    checkpointer_cm = MagicMock()
+    checkpointer_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    checkpointer_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("lib.workflows.runner.get_checkpointer", return_value=checkpointer_cm),
+        patch("lib.workflows.runner.get_workflow_manifest", return_value=manifest),
+        patch("lib.workflows.runner.update_workflow_run_status", new=AsyncMock()),
+        patch("lib.workflows.runner.fail_workflow_run", new=fail),
+        patch("lib.workflows.runner._persist_issues_from_state", new=AsyncMock()),
+    ):
+        await run_workflow(
+            workflow_run_id=workflow_run_id,
+            workflow_type=WorkflowRunType.DOCUMENT_PROCESSING,
+            graph=graph,
+            state=BaseWorkflowState(),
+            context=_make_context(project_id, workflow_run_id),
+            thread_id=str(uuid4()),
+        )
+
+    # Error was appended to LangGraph checkpoint for observability
+    app.aupdate_state.assert_awaited_once()
+    update_args = app.aupdate_state.await_args.args
+    assert "errors" in update_args[1]
+    persisted_errors = update_args[1]["errors"]
+    assert len(persisted_errors) == 1
+    assert persisted_errors[0].error == "boom in node"
+    assert persisted_errors[0].workflow_run_id == workflow_run_id
+
+    fail.assert_awaited_once()
+    kwargs = fail.await_args.kwargs
+    assert kwargs["failure_reason"] == WorkflowRunFailureReason.UNHANDLED_EXCEPTION
+    assert kwargs["failure_message"] == "boom in node"
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_cancelled_runs_on_cancel_without_failing():
+    """WorkflowCancelledError invokes on_cancel but does NOT call fail_workflow_run."""
+    workflow_run_id = str(uuid4())
+    project_id = str(uuid4())
+
+    async def raising_astream(*_args, **_kwargs):
+        raise WorkflowCancelledError("user cancelled")
+        yield  # pragma: no cover
+
+    app = _build_app_with_astream(raising_astream)
+    graph = _build_graph(app)
+    fail = AsyncMock()
+
+    manifest = MagicMock()
+    manifest.max_duration_seconds = 60
+    manifest.on_cancel = AsyncMock()
+
+    checkpointer_cm = MagicMock()
+    checkpointer_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    checkpointer_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("lib.workflows.runner.get_checkpointer", return_value=checkpointer_cm),
+        patch("lib.workflows.runner.get_workflow_manifest", return_value=manifest),
+        patch("lib.workflows.runner.update_workflow_run_status", new=AsyncMock()),
+        patch("lib.workflows.runner.fail_workflow_run", new=fail),
+        patch("lib.workflows.runner._persist_issues_from_state", new=AsyncMock()),
+    ):
+        await run_workflow(
+            workflow_run_id=workflow_run_id,
+            workflow_type=WorkflowRunType.DOCUMENT_PROCESSING,
+            graph=graph,
+            state=BaseWorkflowState(),
+            context=_make_context(project_id, workflow_run_id),
+            thread_id=str(uuid4()),
+        )
+
+    manifest.on_cancel.assert_awaited_once()
+    fail.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# run_workflow_with_dependency_check — dependency timeout branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dependency_wait_timeout_marks_failed_with_dependency_timeout_reason():
+    """The wrapper translates DependencyWaitTimeoutError into FAILED+dependency_timeout."""
+    workflow_run_id = str(uuid4())
+    project_id = str(uuid4())
+
+    config = MagicMock()
+    config.type = WorkflowRunType.REFERENCE_VALIDATION
+    config.project_id = project_id
+
+    fail = AsyncMock()
+
+    with (
+        patch(
+            "lib.workflows.runner.wait_for_dependencies",
+            new=AsyncMock(side_effect=DependencyWaitTimeoutError("waited too long")),
+        ),
+        patch(
+            "lib.workflows.runner.run_workflow_from_config", new=AsyncMock()
+        ) as mock_run,
+        patch("lib.workflows.runner.fail_workflow_run", new=fail),
+    ):
+        await run_workflow_with_dependency_check(
+            config=config,
+            thread_id=str(uuid4()),
+            workflow_run_id=workflow_run_id,
+            user=MagicMock(),
+            revision=1,
+        )
+
+    # The actual workflow body never ran.
+    mock_run.assert_not_awaited()
+
+    fail.assert_awaited_once()
+    args, kwargs = fail.await_args
+    assert args[0] == workflow_run_id
+    assert args[1] == project_id
+    assert kwargs["failure_reason"] == WorkflowRunFailureReason.DEPENDENCY_TIMEOUT
+    assert "waited too long" in kwargs["failure_message"]
+
+
+@pytest.mark.asyncio
+async def test_dependency_check_wraps_unexpected_exceptions_into_failed():
+    """Unexpected exceptions raised before run_workflow are caught and mapped to UNHANDLED_EXCEPTION."""
+    workflow_run_id = str(uuid4())
+    project_id = str(uuid4())
+
+    config = MagicMock()
+    config.type = WorkflowRunType.REFERENCE_VALIDATION
+    config.project_id = project_id
+
+    fail = AsyncMock()
+
+    with (
+        patch(
+            "lib.workflows.runner.wait_for_dependencies",
+            new=AsyncMock(side_effect=RuntimeError("setup failure")),
+        ),
+        patch("lib.workflows.runner.run_workflow_from_config", new=AsyncMock()),
+        patch("lib.workflows.runner.fail_workflow_run", new=fail),
+    ):
+        await run_workflow_with_dependency_check(
+            config=config,
+            thread_id=str(uuid4()),
+            workflow_run_id=workflow_run_id,
+            user=MagicMock(),
+            revision=1,
+        )
+
+    fail.assert_awaited_once()
+    kwargs = fail.await_args.kwargs
+    assert kwargs["failure_reason"] == WorkflowRunFailureReason.UNHANDLED_EXCEPTION
+    assert kwargs["failure_message"] == "setup failure"
+
+
+@pytest.mark.asyncio
+async def test_dependency_check_swallows_workflow_cancelled_error():
+    """WorkflowCancelledError leaving wait_for_dependencies does not call fail_workflow_run."""
+    workflow_run_id = str(uuid4())
+    project_id = str(uuid4())
+
+    config = MagicMock()
+    config.type = WorkflowRunType.REFERENCE_VALIDATION
+    config.project_id = project_id
+
+    fail = AsyncMock()
+
+    with (
+        patch(
+            "lib.workflows.runner.wait_for_dependencies",
+            new=AsyncMock(side_effect=WorkflowCancelledError("dep cancelled")),
+        ),
+        patch("lib.workflows.runner.run_workflow_from_config", new=AsyncMock()),
+        patch("lib.workflows.runner.fail_workflow_run", new=fail),
+    ):
+        await run_workflow_with_dependency_check(
+            config=config,
+            thread_id=str(uuid4()),
+            workflow_run_id=workflow_run_id,
+            user=MagicMock(),
+            revision=1,
+        )
+
+    fail.assert_not_awaited()

--- a/tests/unit/workflows/test_supervise_node.py
+++ b/tests/unit/workflows/test_supervise_node.py
@@ -1,0 +1,114 @@
+"""Unit tests for the node supervisor — heartbeat + cancellation polling.
+
+`_supervise_node` is the single mechanism keeping a live, slow node from being
+reaped: it bumps `heartbeat_at` every CANCELLATION_CHECK_INTERVAL while the
+node runs. If this loop ever stops ticking heartbeats, the reaper will start
+killing healthy long-running workflows. These tests guard against that
+regression.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from lib.models.workflow_run import WorkflowRunStatus
+from lib.workflows.decorators import _supervise_node
+
+
+@pytest.mark.asyncio
+async def test_supervise_bumps_heartbeat_while_node_runs():
+    """While the node task is running, the supervisor calls update_workflow_run_heartbeat each tick."""
+    workflow_run_id = "run-1"
+    interval = 0.01
+
+    # A node that lives long enough for several supervisor ticks.
+    async def slow_node():
+        await asyncio.sleep(interval * 4)
+        return "ok"
+
+    node_task = asyncio.ensure_future(slow_node())
+
+    with (
+        patch(
+            "lib.services.workflow_runs.get_workflow_run_status",
+            new=AsyncMock(return_value=WorkflowRunStatus.RUNNING),
+        ),
+        patch(
+            "lib.services.workflow_runs.update_workflow_run_heartbeat",
+            new=AsyncMock(),
+        ) as heartbeat_mock,
+    ):
+        await asyncio.gather(node_task, _supervise_node(workflow_run_id, node_task, interval))
+
+    # At least two heartbeats over four intervals — exact count varies with
+    # event-loop scheduling, but zero would mean the loop never ticked.
+    assert heartbeat_mock.await_count >= 2
+    for call in heartbeat_mock.await_args_list:
+        assert call.args == (workflow_run_id,)
+
+
+@pytest.mark.asyncio
+async def test_supervise_cancels_node_when_workflow_status_is_cancelled():
+    """If the row flips to CANCELLED, the supervisor cancels the node task and stops bumping the heartbeat."""
+    workflow_run_id = "run-2"
+    interval = 0.01
+
+    async def long_running_node():
+        # Long enough that it never finishes on its own — must be cancelled.
+        await asyncio.sleep(10)
+
+    node_task = asyncio.ensure_future(long_running_node())
+
+    with (
+        patch(
+            "lib.services.workflow_runs.get_workflow_run_status",
+            new=AsyncMock(return_value=WorkflowRunStatus.CANCELLED),
+        ),
+        patch(
+            "lib.services.workflow_runs.update_workflow_run_heartbeat",
+            new=AsyncMock(),
+        ) as heartbeat_mock,
+    ):
+        await _supervise_node(workflow_run_id, node_task, interval)
+
+        # Allow the loop to deliver the cancellation
+        with pytest.raises(asyncio.CancelledError):
+            await node_task
+
+    # When the supervisor sees CANCELLED, it must cancel the node *before*
+    # writing a heartbeat — otherwise we'd extend the life of a row that's
+    # being torn down.
+    heartbeat_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_supervise_returns_when_node_completes_first():
+    """Supervisor exits cleanly when the node finishes naturally — no hanging awaits."""
+    workflow_run_id = "run-3"
+    interval = 0.5  # Much larger than the node's own runtime.
+
+    async def fast_node():
+        return "done"
+
+    node_task = asyncio.ensure_future(fast_node())
+    # Let the node complete before the supervisor's first sleep wakes up.
+    await asyncio.sleep(0)
+    await node_task
+
+    with (
+        patch(
+            "lib.services.workflow_runs.get_workflow_run_status", new=AsyncMock()
+        ) as status_mock,
+        patch(
+            "lib.services.workflow_runs.update_workflow_run_heartbeat",
+            new=AsyncMock(),
+        ) as heartbeat_mock,
+    ):
+        # Supervisor sees node_task.done() at loop top → returns immediately.
+        await asyncio.wait_for(
+            _supervise_node(workflow_run_id, node_task, interval), timeout=1.0
+        )
+
+    status_mock.assert_not_awaited()
+    heartbeat_mock.assert_not_awaited()

--- a/tests/unit/workflows/test_supervise_node.py
+++ b/tests/unit/workflows/test_supervise_node.py
@@ -83,6 +83,38 @@ async def test_supervise_cancels_node_when_workflow_status_is_cancelled():
 
 
 @pytest.mark.asyncio
+async def test_supervise_cancels_node_when_workflow_status_is_failed():
+    """If the reaper flips the row to FAILED, the supervisor must also cancel
+    the node — terminal status is terminal status, regardless of how it got
+    there. Without this, a reaped run would keep heartbeating and burning
+    work after the reaper has already written its tombstone."""
+    workflow_run_id = "run-failed"
+    interval = 0.01
+
+    async def long_running_node():
+        await asyncio.sleep(10)
+
+    node_task = asyncio.ensure_future(long_running_node())
+
+    with (
+        patch(
+            "lib.services.workflow_runs.get_workflow_run_status",
+            new=AsyncMock(return_value=WorkflowRunStatus.FAILED),
+        ),
+        patch(
+            "lib.services.workflow_runs.update_workflow_run_heartbeat",
+            new=AsyncMock(),
+        ) as heartbeat_mock,
+    ):
+        await _supervise_node(workflow_run_id, node_task, interval)
+
+        with pytest.raises(asyncio.CancelledError):
+            await node_task
+
+    heartbeat_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_supervise_returns_when_node_completes_first():
     """Supervisor exits cleanly when the node finishes naturally — no hanging awaits."""
     workflow_run_id = "run-3"


### PR DESCRIPTION
Linear: [RANDZ-551](https://linear.app/ae-studio/issue/RANDZ-551/stuck-issue-bug-dulani-reported-multiple-workflows-are-getting-stuck)

## Summary

Workflow runs sometimes get stuck in `RUNNING` (or `PENDING`) forever. This PR adds the four mechanisms needed to make stuck runs self-heal: a workflow-level timeout, a bounded dependency wait, a heartbeat-driven reaper that also covers orphaned PENDING rows, and a real `FAILED` status surfaced in the UI. Worst-case detection latency for an orphaned `RUNNING` run drops from indefinite to ~90s; orphaned `PENDING` runs are reaped at the dependency-wait window.

## Motivation

Today the system has no defense against the dominant failure mode — a server restart or OOM kill that strands the in-process background task before the runner's terminal-status update can fire. The `finally` in `lib/workflows/runner.py` never runs, the row stays `RUNNING` (or `PENDING` if it died before pickup), and any dependent workflow waits forever inside `wait_for_dependencies`'s unbounded `while True` loop. There is also no workflow-level timeout (a single hung node hangs the whole graph) and no real failure status — uncaught exceptions today are silently bucketed as `COMPLETED`.

## What's Changed

### Backend

- **`lib/models/workflow_run.py`** — Added `FAILED` status, `WorkflowRunFailureReason` enum (`timeout`, `dependency_timeout`, `no_heartbeat`, `unhandled_exception`), and `heartbeat_at` / `failure_reason` / `failure_message` columns. New `TERMINAL_WORKFLOW_RUN_STATUSES` constant.
- **`alembic/versions/6f5eebe4f144_*.py`** — Migration for the new enum value, new enum type, and new columns.
- **`lib/services/workflow_runs.py`** — `update_workflow_run_status` now persists failure metadata for `FAILED`. New `update_workflow_run_heartbeat` (cheap, called every 5s during nodes). New `fail_workflow_run` mirrors `cancel_workflow_run` but sets `FAILED`. Cascade extracted into shared `_cascade_cancel_dependents` so a failed parent cascade-cancels its dependents.
- **`lib/services/workflow_orchestration.py`** — Bounded `wait_for_dependencies` at 2 h via `DEPENDENCY_WAIT_TIMEOUT`; raises new `DependencyWaitTimeoutError`. Treats `FAILED` as terminal upstream status (same as `CANCELLED` for dependents).
- **`lib/workflows/runner.py`** — Wrapped `app.astream()` in `asyncio.timeout(max_duration)` from the manifest. Removed the unconditional `finally → COMPLETED`; success path writes `COMPLETED`, timeout writes `FAILED+timeout`, uncaught exception writes `FAILED+unhandled_exception` (still appends to the LangGraph checkpoint via `aupdate_state` for observability). Outer `run_workflow_with_dependency_check` catches `DependencyWaitTimeoutError` → `FAILED+dependency_timeout`.
- **`lib/workflows/decorators.py`** — Renamed `_poll_for_cancellation` → `_supervise_node`: it now both polls for cancellation and bumps `heartbeat_at` every 5s while a node runs. Sibling asyncio task means heartbeats keep ticking through I/O awaits, which is exactly what we want — the reaper's job is detecting *dead processes*, not hung-but-alive nodes (workflow timeout handles those).
- **`lib/services/workflow_reaper.py`** *(new)* — Sweeps every 30 s. Reaps two classes of stuck runs:
  - `RUNNING` rows whose `heartbeat_at` is older than 60 s (or `started_at` if no heartbeat ever ticked) → `failure_reason=no_heartbeat`.
  - `PENDING` rows whose `created_at` is older than `DEPENDENCY_WAIT_TIMEOUT` → also `failure_reason=no_heartbeat`. A live runner waiting on dependencies would itself raise `DependencyWaitTimeoutError` after that window, so anything still PENDING was never picked up.

  Before transitioning a stuck row to `FAILED`, the reaper invokes `manifest.on_cancel(state, app, thread_config)` so per-item statuses (e.g. pending validation entries) get cleaned up the same way they are during a regular cancel/timeout. Errors in the hook are logged and never block the FAILED transition or cascade. SQL-level guards make concurrent reapers safe.
- **`lib/api/main.py`** — Reaper started in `lifespan` and cancelled cleanly on shutdown.
- **`lib/api/routers/workflows.py`** — Cancel endpoint refuses `FAILED` runs with a 400 (terminal state).
- **`lib/workflows/manifest.py`** — New `max_duration_seconds` (default 1 h); long-running workflows can override.
- **`lib/workflows/models.py`** — Added `DependencyWaitTimeoutError`.

### Frontend

- **`frontend/lib/generated-api/`** — Regenerated types pick up the new `FAILED` status, `WorkflowRunFailureReason` enum, and `heartbeat_at` / `failure_reason` / `failure_message` fields on `WorkflowRun`.
- **`frontend/lib/workflow-state.ts`** — `DisplayStatus` collapsed to plain `WorkflowRunStatus` (the previous pseudo-status `'failed'` now overlaps with the real backend value, so they unify naturally). `getDisplayStatus` returns `WorkflowRunStatus.Failed` for both completed-with-errors and real backend failures. New `isWorkflowFailed` helper.
- **`frontend/components/workflows/results/{simple-deep-agent,advocacy-tone,about-this-ger}-results.tsx`** — Added a "Failed" empty-state branch alongside the existing "Cancelled" branch, surfacing `failure_message` when present (falls back to a generic retry message).
- **`frontend/components/results/tabs/workflow-list-sidebar.tsx`** — New `XCircle` tooltip showing `failure_message` for `Failed` runs (mirrors the existing `AlertTriangle` tooltip used for completed-with-errors). The status pill itself was already wired through the existing `'failed'` branch in `StatusIndicator`.

## Risks and Mitigations

- **Invariant: `COMPLETED` semantics preserved.** Per-node errors caught by `@register_node` still flow into `state.errors` and the run still ends `COMPLETED` ("completed with errors"). `FAILED` is reserved strictly for unrecoverable workflow-level halts. Reference-validation-style "one ref errored, rest succeeded" behavior is unchanged.
- **False-positive reaping (RUNNING).** Heartbeats tick every 5 s during a node; the 60 s grace is 12× margin, comfortably above DB hiccups, GC pauses, or LangGraph between-node scheduling. The reaper skips rows with no `project_id` instead of crashing.
- **False-positive reaping (PENDING).** Grace is `DEPENDENCY_WAIT_TIMEOUT` (2 h) — a still-alive runner blocked on dependencies would itself hit that ceiling and flip the row to `FAILED+dependency_timeout` first, so the reaper only sees genuinely orphaned rows.
- **Hung-but-alive nodes won't trip the reaper** (the supervisor task heartbeats even while the node awaits). This is intentional — `asyncio.timeout(max_duration)` catches that case at the workflow level. Long-running workflows opt into a higher `max_duration_seconds` per manifest.
- **Cascade behavior.** A failed parent cascade-cancels active dependents (sets them to `CANCELLED`, not `FAILED`) — from a dependent's perspective there is no salvageable upstream output, matching today's CANCELLED-cascade semantics.
- **Reaper concurrency.** SQL-level filters plus the existing CANCELLED-guard mean concurrent API replicas running reapers won't double-transition; cascades are idempotent. The `manifest.on_cancel` hook is wrapped in try/except and never blocks the FAILED transition.
- **Migration is additive.** New nullable columns plus an additive enum value — safe to deploy ahead of code, code degrades gracefully (older DB just won't have `FAILED` rows yet) but operationally we should migrate first.

## Verification

- ✅ `uv run mypy .` — clean (333 source files)
- ✅ `pnpm exec tsc --noEmit` — clean
- ✅ `uv run pytest tests/ -k "workflow_run or runner or reaper or orchestration or register_node or cancel_workflow"` — 53 passed, 1 skipped
- ☐ Manual smoke: kick off a normal workflow → COMPLETED with heartbeats; inject an uncaught exception → FAILED+cascade; node with `await asyncio.sleep(99999)` and a short manifest `max_duration_seconds` → FAILED+timeout; `UPDATE workflow_runs SET heartbeat_at = now() - interval '5 minutes'` for a RUNNING row → reaper flips to FAILED+no_heartbeat within one tick; create a PENDING row with `created_at` older than `DEPENDENCY_WAIT_TIMEOUT` → reaper flips to FAILED+no_heartbeat; reference-validation with one bad reference → still COMPLETED.

## Out of scope (separate pass)

- Per-node timeouts and tighter LLM retry caps — medium-term reliability pass.
- Moving execution off `BackgroundTasks` (queue or Temporal/Hatchet) — long-term architectural work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)