### PR TITLE
feat(mcp): ask user for web-access consent before running web-search workflows

### DIFF
--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -327,10 +327,19 @@ def _build_gate_required_payload(exc: WorkflowGateRequiredError) -> dict:
         )
     if pending_web_search:
         sections.append(
-            "Web-search consent is required because these workflows access "
-            f"the open web: {pending_web_search}. Confirm with the user that "
-            "they're OK with Draft Detective making external web requests on "
-            "their behalf for this project before retrying."
+            "Web-search consent is required for these workflows: "
+            f"{pending_web_search}. Before retrying, relay the following to "
+            "the user verbatim and get their explicit OK:\n\n"
+            "  \"To run this assessment, parts of your document — and possibly "
+            "the whole document — will be sent to a web search provider as "
+            "search queries. Don't proceed if the document contains "
+            "confidential information you aren't comfortable sharing with an "
+            "external search engine. Do you consent to running web search on "
+            "this document?\"\n\n"
+            "Only retry with approve_web_search=true after the user "
+            "explicitly consents. If they decline, do not retry — instead "
+            "offer to run a different workflow that doesn't need web access "
+            "(see list_workflow_types and skip any with needs_web_search=true)."
         )
     sections.append(
         "Once the user confirms (e.g. 'go ahead and start'), call "

--- a/lib/api/mcp.py
+++ b/lib/api/mcp.py
@@ -16,7 +16,7 @@ from mcp.types import ToolAnnotations
 from lib.api.mcp_auth import create_mcp_auth
 from lib.api.models import StartMultipleWorkflowsRequest
 from lib.api.services.workflow_runner import (
-    HumanApprovalRequiredError,
+    WorkflowGateRequiredError,
     run_multiple_workflows_blocking,
 )
 from lib.config.env import config as env_config
@@ -216,6 +216,7 @@ async def run_workflow(
     project_id: str,
     workflow_types: list[str],
     approve_human_steps: bool = False,
+    approve_web_search: bool = False,
     token: AccessToken = CurrentAccessToken(),
 ) -> str:
     """
@@ -232,18 +233,27 @@ async def run_workflow(
     workflow_types must be a list of type values returned by list_workflow_types
     (e.g. ["claim_extraction", "reference_validation"]).
 
-    Some workflows (e.g. claim_reference_validation_v2) gate on a human review
-    of the reference→file mappings before running. On the first call, leave
-    approve_human_steps=False (the default): the tool returns a JSON response
-    with status="human_approval_required" pointing the user at the project URL
-    so they can review references first. After the user explicitly confirms
-    (e.g. "go ahead and start"), call this tool again with the same arguments
-    plus approve_human_steps=True to record the approval and run the workflow.
+    Two kinds of consent gates may apply:
 
-    When the gate triggers, also offer the user two options for filling in
-    missing supporting files:
+    1. Human approval — some workflows (e.g. claim_reference_validation_v2)
+       gate on a human review of the reference→file mappings before running.
+    2. Web-search consent — some workflows (e.g. reference_validation,
+       reference_downloader, literature_review) call out to the open web,
+       which the user must explicitly opt into.
+
+    On the first call, leave both flags at False (the default). If any gate
+    applies, the tool returns a JSON response with status="approval_required"
+    listing pending_human_approval and pending_web_search workflow types and
+    pointing the user at the project URL. After the user explicitly confirms
+    (e.g. "go ahead and start"), call this tool again with the same arguments
+    plus approve_human_steps=True and/or approve_web_search=True (whichever
+    gates were listed) to record consent and run the workflow.
+
+    When the human-approval gate triggers, also offer the user two options
+    for filling in missing supporting files:
       1. Have Draft Detective auto-fetch them from the web — include
-         "reference_downloader" in workflow_types on the retry call.
+         "reference_downloader" in workflow_types on the retry call (this
+         requires approve_web_search=True).
       2. Provide/upload the files directly — use get_tus_upload_credentials
          with role="support" and the matching reference_id (look it up via
          get_project) for each file, upload, then retry.
@@ -272,40 +282,69 @@ async def run_workflow(
 
     try:
         await run_multiple_workflows_blocking(
-            parsed_types, request, user, approve_human_steps=approve_human_steps
+            parsed_types,
+            request,
+            user,
+            approve_human_steps=approve_human_steps,
+            approve_web_search=approve_web_search,
         )
-    except HumanApprovalRequiredError as exc:
-        return json.dumps(
-            {
-                "status": "human_approval_required",
-                "project_id": exc.project_id,
-                "project_url": _build_project_url(exc.project_id),
-                "pending_workflow_types": [
-                    w.value for w in exc.pending_workflow_types
-                ],
-                "message": (
-                    "This workflow requires the user to review the reference→file "
-                    "mappings before it can run. Share the project_url with the user "
-                    "so they can review references in the web UI, or offer to list "
-                    "the references and supporting-file mappings here (use "
-                    "get_project to fetch them).\n\n"
-                    "Offer the user these options for filling in missing supporting "
-                    "files before approving:\n"
-                    "  1. Have Draft Detective auto-fetch them from the web — add "
-                    "'reference_downloader' to workflow_types on the retry call.\n"
-                    "  2. Provide/upload the files yourself — call "
-                    "get_tus_upload_credentials with role='support' and the "
-                    "matching reference_id (from get_project) for each file, then "
-                    "upload via the returned TUS endpoint before retrying.\n\n"
-                    "Once the user confirms (e.g. 'go ahead and start'), call "
-                    "run_workflow again with the same arguments plus "
-                    "approve_human_steps=true (and 'reference_downloader' in "
-                    "workflow_types if they opted into option 1)."
-                ),
-            }
-        )
+    except WorkflowGateRequiredError as exc:
+        return json.dumps(_build_gate_required_payload(exc))
 
     return await _get_project_details_json(project_id, AccessLevel.WRITE, user)
+
+
+def _build_gate_required_payload(exc: WorkflowGateRequiredError) -> dict:
+    """Build the JSON payload returned to the MCP client when consent is missing."""
+    pending_human_approval = [w.value for w in exc.pending_human_approval]
+    pending_web_search = [w.value for w in exc.pending_web_search]
+
+    retry_flags: list[str] = []
+    if pending_human_approval:
+        retry_flags.append("approve_human_steps=true")
+    if pending_web_search:
+        retry_flags.append("approve_web_search=true")
+    retry_flags_text = " and ".join(retry_flags)
+
+    sections: list[str] = []
+    if pending_human_approval:
+        sections.append(
+            "Human approval is required because the user must review the "
+            "reference→file mappings before these workflows can run: "
+            f"{pending_human_approval}. Share the project_url with the user "
+            "so they can review references in the web UI, or offer to list "
+            "the references and supporting-file mappings here (use "
+            "get_project to fetch them).\n\n"
+            "Offer the user these options for filling in missing supporting "
+            "files before approving:\n"
+            "  1. Have Draft Detective auto-fetch them from the web — add "
+            "'reference_downloader' to workflow_types on the retry call "
+            "(this also requires approve_web_search=true).\n"
+            "  2. Provide/upload the files yourself — call "
+            "get_tus_upload_credentials with role='support' and the matching "
+            "reference_id (from get_project) for each file, then upload via "
+            "the returned TUS endpoint before retrying."
+        )
+    if pending_web_search:
+        sections.append(
+            "Web-search consent is required because these workflows access "
+            f"the open web: {pending_web_search}. Confirm with the user that "
+            "they're OK with Draft Detective making external web requests on "
+            "their behalf for this project before retrying."
+        )
+    sections.append(
+        "Once the user confirms (e.g. 'go ahead and start'), call "
+        f"run_workflow again with the same arguments plus {retry_flags_text}."
+    )
+
+    return {
+        "status": "approval_required",
+        "project_id": exc.project_id,
+        "project_url": _build_project_url(exc.project_id),
+        "pending_human_approval": pending_human_approval,
+        "pending_web_search": pending_web_search,
+        "message": "\n\n".join(sections),
+    }
 
 
 @mcp.tool(

--- a/lib/api/services/workflow_runner.py
+++ b/lib/api/services/workflow_runner.py
@@ -37,21 +37,33 @@ class AutoRunWorkflowItem(BaseModel):
     workflow_run_id: str
 
 
-class HumanApprovalRequiredError(Exception):
-    """Raised when a blocking workflow run hits an unsatisfied human-trigger gate.
+class WorkflowGateRequiredError(Exception):
+    """Raised when a blocking workflow run hits one or more unsatisfied consent gates.
 
-    Carries the project_id and the human-trigger workflow types that still
-    need approval so callers (e.g. the MCP tool) can render a useful prompt.
+    Today there are two gate kinds:
+      - human approval (manifest.requires_human_trigger)
+      - web-search consent (manifest.needs_web_search)
+
+    Each carries the workflow types that triggered it so callers (e.g. the
+    MCP tool) can render a useful prompt and ask the user to confirm.
     """
 
     def __init__(
-        self, project_id: str, pending_workflow_types: List[WorkflowRunType]
+        self,
+        project_id: str,
+        pending_human_approval: List[WorkflowRunType],
+        pending_web_search: List[WorkflowRunType],
     ):
         self.project_id = project_id
-        self.pending_workflow_types = pending_workflow_types
+        self.pending_human_approval = pending_human_approval
+        self.pending_web_search = pending_web_search
+        parts: List[str] = []
+        if pending_human_approval:
+            parts.append(f"human_approval={[w.value for w in pending_human_approval]}")
+        if pending_web_search:
+            parts.append(f"web_search={[w.value for w in pending_web_search]}")
         super().__init__(
-            f"Human approval required for project {project_id}: "
-            f"{[w.value for w in pending_workflow_types]}"
+            f"Workflow gates required for project {project_id}: {', '.join(parts)}"
         )
 
 
@@ -76,12 +88,14 @@ async def _prepare_workflow_items(
     user: User,
     *,
     approve_human_steps: bool = False,
-    raise_on_pending_human_steps: bool = False,
+    approve_web_search: bool = False,
+    raise_on_pending_gates: bool = False,
 ) -> tuple[
     Project,
     int,
     List[str],
     List[AutoRunWorkflowItem],
+    List[WorkflowRunType],
     List[WorkflowRunType],
 ]:
     """
@@ -94,6 +108,10 @@ async def _prepare_workflow_items(
     - all_workflow_run_ids: IDs of all newly created run records (including
       human-trigger workflows that won't be auto-run)
     - auto_run_items: subset of items that should actually be executed
+    - pending_human_triggers: human-trigger workflows blocked by missing approval
+      (only populated when raise_on_pending_gates=True)
+    - pending_web_search: workflows blocked by missing web-search consent
+      (only populated when raise_on_pending_gates=True)
     """
     project, _ = await get_project_access(
         request.project_id, user=user, required_level=AccessLevel.WRITE
@@ -114,9 +132,10 @@ async def _prepare_workflow_items(
     workflow_run_ids: List[str] = []
     auto_run_items: List[AutoRunWorkflowItem] = []
     pending_human_triggers: List[WorkflowRunType] = []
-    # Workflows blocked behind an unsatisfied human-trigger gate (the gate
-    # itself plus anything downstream of it). resolved_workflow_types is in
-    # topological order, so a single forward pass is sufficient.
+    pending_web_search: List[WorkflowRunType] = []
+    # Workflows blocked behind an unsatisfied gate (the gate itself plus
+    # anything downstream of it). resolved_workflow_types is in topological
+    # order, so a single forward pass is sufficient.
     blocked_set: set[WorkflowRunType] = set()
 
     revision = project.current_revision
@@ -144,13 +163,25 @@ async def _prepare_workflow_items(
             )
             continue
 
-        # If any required dep is blocked behind a pending human-trigger gate,
-        # this workflow is downstream and must be deferred to the post-approval
-        # retry. Don't create a PENDING record either — the next call will.
+        # If any required dep is blocked behind a pending gate, this workflow
+        # is downstream and must be deferred to the post-approval retry.
+        # Don't create a PENDING record either — the next call will.
         if any(dep in blocked_set for dep in manifest.required_dependencies):
             logger.info(
-                f"Deferring {workflow_type.value} - depends on a workflow blocked by human approval"
+                f"Deferring {workflow_type.value} - depends on a workflow blocked by a consent gate"
             )
+            blocked_set.add(workflow_type)
+            continue
+
+        # Web-search consent gate. Only enforced on the blocking/MCP path
+        # (raise_on_pending_gates=True); the UI path collects consent in the
+        # frontend, so we don't gate it again at the backend there.
+        if (
+            manifest.needs_web_search
+            and not approve_web_search
+            and raise_on_pending_gates
+        ):
+            pending_web_search.append(workflow_type)
             blocked_set.add(workflow_type)
             continue
 
@@ -160,7 +191,7 @@ async def _prepare_workflow_items(
                 request.project_id, workflow_type
             )
             if not previously_approved and not approve_human_steps:
-                if raise_on_pending_human_steps:
+                if raise_on_pending_gates:
                     pending_human_triggers.append(workflow_type)
                     blocked_set.add(workflow_type)
                     # Don't create a PENDING record — the caller is about to
@@ -209,6 +240,7 @@ async def _prepare_workflow_items(
         workflow_run_ids,
         auto_run_items,
         pending_human_triggers,
+        pending_web_search,
     )
 
 
@@ -286,9 +318,14 @@ async def start_multiple_workflow_runs(
     Raises:
         HTTPException: If project_id is missing or project doesn't exist
     """
-    _, revision, workflow_run_ids, auto_run_items, _ = await _prepare_workflow_items(
-        workflow_types, request, user
-    )
+    (
+        _,
+        revision,
+        workflow_run_ids,
+        auto_run_items,
+        _,
+        _,
+    ) = await _prepare_workflow_items(workflow_types, request, user)
 
     if auto_run_items:
         logger.info(
@@ -314,6 +351,7 @@ async def run_multiple_workflows_blocking(
     user: User,
     *,
     approve_human_steps: bool = False,
+    approve_web_search: bool = False,
 ) -> tuple[Project, List[str]]:
     """
     Prepare and run multiple workflows sequentially, blocking until all complete.
@@ -328,15 +366,20 @@ async def run_multiple_workflows_blocking(
         user: User running the workflows
         approve_human_steps: When True, treat any unsatisfied human-trigger
             dependency as approved by the caller and run it inline. When False
-            (default), raises HumanApprovalRequiredError so the caller can
+            (default), raises WorkflowGateRequiredError so the caller can
             prompt the user to confirm before retrying with approval.
+        approve_web_search: When True, treat any workflow with
+            manifest.needs_web_search=True as having explicit user consent to
+            access the web. When False (default), raises
+            WorkflowGateRequiredError so the caller can prompt the user.
 
     Returns:
         A tuple of (project, list of workflow_run_ids for all created runs)
 
     Raises:
-        HumanApprovalRequiredError: when approve_human_steps is False and a
-            resolved dependency requires human approval.
+        WorkflowGateRequiredError: when one or more required consent gates
+            (human approval, web-search) are unsatisfied for the resolved
+            workflows.
     """
     (
         project,
@@ -344,12 +387,14 @@ async def run_multiple_workflows_blocking(
         workflow_run_ids,
         auto_run_items,
         pending_human_triggers,
+        pending_web_search,
     ) = await _prepare_workflow_items(
         workflow_types,
         request,
         user,
         approve_human_steps=approve_human_steps,
-        raise_on_pending_human_steps=not approve_human_steps,
+        approve_web_search=approve_web_search,
+        raise_on_pending_gates=True,
     )
 
     # Run upstream prep (e.g. document_processing, reference_extraction,
@@ -364,10 +409,11 @@ async def run_multiple_workflows_blocking(
             revision=revision,
         )
 
-    if pending_human_triggers:
-        raise HumanApprovalRequiredError(
+    if pending_human_triggers or pending_web_search:
+        raise WorkflowGateRequiredError(
             project_id=str(project.id),
-            pending_workflow_types=pending_human_triggers,
+            pending_human_approval=pending_human_triggers,
+            pending_web_search=pending_web_search,
         )
 
     return project, workflow_run_ids

--- a/tests/unit/test_mcp_tools.py
+++ b/tests/unit/test_mcp_tools.py
@@ -389,13 +389,14 @@ async def test_run_workflow_passes_approve_human_steps_to_runner():
 
 @pytest.mark.asyncio
 async def test_run_workflow_returns_human_approval_required_payload():
-    from lib.api.services.workflow_runner import HumanApprovalRequiredError
+    from lib.api.services.workflow_runner import WorkflowGateRequiredError
     from lib.models.workflow_run import WorkflowRunType
 
     user = _make_user()
-    err = HumanApprovalRequiredError(
+    err = WorkflowGateRequiredError(
         project_id="p1",
-        pending_workflow_types=[WorkflowRunType.HUMAN_APPROVAL],
+        pending_human_approval=[WorkflowRunType.HUMAN_APPROVAL],
+        pending_web_search=[],
     )
 
     with (
@@ -416,11 +417,76 @@ async def test_run_workflow_returns_human_approval_required_payload():
         )
 
     data = json.loads(result)
-    assert data["status"] == "human_approval_required"
+    assert data["status"] == "approval_required"
     assert data["project_id"] == "p1"
     assert "p1" in data["project_url"]
-    assert data["pending_workflow_types"] == [WorkflowRunType.HUMAN_APPROVAL.value]
+    assert data["pending_human_approval"] == [WorkflowRunType.HUMAN_APPROVAL.value]
+    assert data["pending_web_search"] == []
     assert "approve_human_steps=true" in data["message"]
+    mock_details.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_passes_approve_web_search_to_runner():
+    user = _make_user()
+    project_json = json.dumps({"id": "p1", "project_url": "http://x/projects/p1"})
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch(
+            "lib.api.mcp.run_multiple_workflows_blocking", new=AsyncMock()
+        ) as mock_run,
+        patch(
+            "lib.api.mcp._get_project_details_json",
+            new=AsyncMock(return_value=project_json),
+        ),
+    ):
+        await run_workflow(
+            project_id="p1",
+            workflow_types=["reference_validation"],
+            approve_web_search=True,
+            token=_make_token(),
+        )
+
+    mock_run.assert_awaited_once()
+    assert mock_run.await_args.kwargs["approve_web_search"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_returns_web_search_required_payload():
+    from lib.api.services.workflow_runner import WorkflowGateRequiredError
+    from lib.models.workflow_run import WorkflowRunType
+
+    user = _make_user()
+    err = WorkflowGateRequiredError(
+        project_id="p1",
+        pending_human_approval=[],
+        pending_web_search=[WorkflowRunType.REFERENCE_VALIDATION],
+    )
+
+    with (
+        patch("lib.api.mcp._resolve_user", new=AsyncMock(return_value=user)),
+        patch(
+            "lib.api.mcp.run_multiple_workflows_blocking",
+            new=AsyncMock(side_effect=err),
+        ),
+        patch(
+            "lib.api.mcp._get_project_details_json",
+            new=AsyncMock(),
+        ) as mock_details,
+    ):
+        result = await run_workflow(
+            project_id="p1",
+            workflow_types=["reference_validation"],
+            token=_make_token(),
+        )
+
+    data = json.loads(result)
+    assert data["status"] == "approval_required"
+    assert data["pending_human_approval"] == []
+    assert data["pending_web_search"] == [WorkflowRunType.REFERENCE_VALIDATION.value]
+    assert "approve_web_search=true" in data["message"]
+    assert "approve_human_steps=true" not in data["message"]
     mock_details.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

- Extends the existing human-approval gate to a unified consent-gate framework that also covers web access, so MCP clients have to opt-in the same way the web UI checkbox does today.
- Adds `approve_web_search` to the `run_workflow` MCP tool. When a workflow has `manifest.needs_web_search=True` and consent isn't given, the tool now returns a structured `approval_required` payload telling the client which flag(s) to set on retry.

Linked Linear issue: [RANDZ-553](https://linear.app/ae-studio/issue/RANDZ-553/mcp-ask-user-for-web-access)

## Motivation

The web UI already requires the user to tick a "this workflow accesses the web" consent checkbox before workflows like `reference_validation`, `reference_downloader`, `literature_review`, etc. can run. Until now there was no equivalent on the MCP surface — an MCP client could trigger any of those workflows without surfacing a consent prompt to the user. This PR brings MCP to parity by reusing and generalizing the existing human-approval gate plumbing.

## What's Changed

### Backend

- **`lib/api/services/workflow_runner.py`**
  - Renamed `HumanApprovalRequiredError` → `WorkflowGateRequiredError`. Carries two parallel lists: `pending_human_approval` and `pending_web_search`.
  - `_prepare_workflow_items` now accepts `approve_web_search` and a generalized `raise_on_pending_gates` flag (replacing `raise_on_pending_human_steps`). Returns a sixth tuple element with web-search-blocked workflows. The web-search gate is only evaluated on the blocking path, so the existing UI flow (frontend localStorage consent) is unaffected.
  - `run_multiple_workflows_blocking` accepts `approve_web_search` and raises the unified error when either gate is pending.

- **`lib/api/mcp.py`**
  - `run_workflow` exposes a new `approve_web_search: bool = False` parameter alongside `approve_human_steps`.
  - On gate violation, returns a single `{"status": "approval_required", "pending_human_approval": [...], "pending_web_search": [...], "message": ...}` payload. The message is composed from per-gate sections so the LLM client knows exactly what to ask the user and which flag(s) to set on retry.
  - The tool docstring documents both gate kinds and the retry protocol.

### Tests

- **`tests/unit/test_mcp_tools.py`**
  - Updated `test_run_workflow_returns_human_approval_required_payload` for the new error signature and `approval_required` response shape.
  - Added `test_run_workflow_passes_approve_web_search_to_runner` to lock down the new MCP parameter is forwarded.
  - Added `test_run_workflow_returns_web_search_required_payload` covering the web-search-only gate path.

## Risks and Mitigations

- **Renamed exception type**: `HumanApprovalRequiredError` no longer exists. Searched the codebase — the only callers were `lib/api/mcp.py` and the MCP tests, both updated. No external API surface depends on the class name.
- **Behavior change for MCP clients invoking web-search workflows**: previously these would just run; now they require `approve_web_search=true` on retry. This is intentional and matches the UI behavior. The error response is structured so the calling LLM can prompt the user and retry without human intervention beyond the consent question.
- **UI flow untouched**: the web-search gate only fires when `raise_on_pending_gates=True`, which is set only by `run_multiple_workflows_blocking` (the MCP path). `start_multiple_workflow_runs` (UI/REST path) doesn't pass this flag, so the existing frontend-localStorage-based consent continues to work unchanged.
- **Verified locally**: `uv run mypy .` clean (338 files); MCP tool tests + workflow_runner integration tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)