### PR TITLE
feat(workflows): add Recommendation Check analysis (RANDZ-527)

### DIFF
--- a/evals_inspectai/e2e/recommendation_check/dataset.json
+++ b/evals_inspectai/e2e/recommendation_check/dataset.json
@@ -1,0 +1,56 @@
+[
+  {
+    "input": "# Remote Work Productivity Study\n\n## Findings\n\nA twelve-month survey of 1,240 employees across four departments found that median self-reported productivity rose by 14 percent after the introduction of fully remote work. Engineering teams showed the largest gain at 19 percent, while customer support saw a smaller but still positive 6 percent gain. Meeting hours fell by an average of 4.2 hours per week per employee.\n\nEmployee retention over the study period rose from 82 percent to 91 percent year-over-year, with exit-interview data attributing the change primarily to schedule flexibility.\n\n## Recommendations\n\n1. Continue the fully remote work policy across all four departments based on the sustained productivity and retention gains observed.\n2. Reduce the standing-meeting load further by capping recurring meetings at six hours per week per employee, building on the observed 4.2-hour reduction.\n3. Expand schedule flexibility to contractor staff, who were not covered by the present study.\n",
+    "target_severity_counts": {
+      "none": 1,
+      "medium": 1,
+      "high": 1
+    },
+    "target_answer": "Recommendation 1 is fully supported by the documented productivity and retention gains. Recommendation 2 is partially supported: the document shows a 4.2-hour meeting reduction, but the specific six-hour weekly cap is a new threshold not grounded in any finding — under the boundary rule, when a recommendation adds a specific threshold not in the findings, it is partially_supported (medium) rather than supported. Recommendation 3 is unsupported (high) per the out-of-scope-population rule: contractor staff were not covered by the study at all, even though the underlying intervention (schedule flexibility) is supported for in-house staff. The agent should report 1 'none', 1 'medium', and 1 'high' issue."
+  },
+  {
+    "input": "# Coastal Erosion Mitigation: Pilot Programme Report\n\n## Findings\n\nThe pilot installed permeable groynes at three of the five monitoring sites (S1, S2, S3) over a 24-month period. Sites S4 and S5 served as untreated controls.\n\nMean annual erosion at the treated sites fell from 58 mm/year to 22 mm/year, a 62 percent reduction. The control sites showed no significant change (61 mm/year vs 59 mm/year). Cost per linear metre of intervention was 1,420 USD, roughly 30 percent below the original budget estimate.\n\nNo measurable change in beach width or sediment composition was observed at any site during the study period.\n\n## Recommendations\n\n1. Scale the permeable groyne intervention to all five sites, given the observed 62 percent reduction in erosion at treated sites and the favourable cost performance.\n2. Use the intervention to restore beach width along the wider regional coastline.\n",
+    "target_severity_counts": {
+      "none": 0,
+      "medium": 1,
+      "high": 1
+    },
+    "target_answer": "Recommendation 1 is partially_supported: the intervention's 62 percent erosion reduction is well documented, but the recommendation extends application to sites S4 and S5 where the intervention was *not* applied (they served as untreated controls). Under the rule for extrapolating from a measured site to a closely related but unmeasured one, this is partially_supported (medium). Recommendation 2 is unsupported (high) — and in fact contradicted by findings: the document explicitly states no measurable change in beach width was observed. The agent should report 1 'medium' and 1 'high' issue."
+  },
+  {
+    "input": "# Annual Air Quality Report\n\n## Overview\n\nThis report summarises pollutant readings across twelve monitoring stations between January and December.\n\n## PM2.5 Trends\n\nMean annual PM2.5 fell from 24 µg/m³ in the previous year to 21 µg/m³ this year, a reduction of approximately 12 percent. The station closest to the new low-emission zone (Station 4) showed a 28 percent reduction.\n\n## NO₂ Trends\n\nNO₂ readings were stable across all stations, with no statistically significant change year-over-year.\n\n## Ozone Trends\n\nOzone showed a small seasonal increase in summer months, consistent with prior years.\n\n## Conclusion\n\nThe data indicate that targeted low-emission zones are correlated with localised PM2.5 reductions. NO₂ levels were unchanged. Ozone showed the usual seasonal pattern.\n",
+    "target_severity_counts": {
+      "none": 0,
+      "medium": 0,
+      "high": 0
+    },
+    "target_answer": "This document contains only findings and a factual conclusion summarising those findings. There are no recommendations — no calls to action, no proposed changes, no policy suggestions. The agent should report zero issues."
+  },
+  {
+    "input": "# Public Library Digital Services Review\n\n## Executive Summary\n\nThis review assessed digital service uptake at twenty-two public library branches over the 2024 calendar year.\n\n### Recommendations\n\n- **Expand e-book lending budget across all branches.**\n- **Open extended evening hours at the five busiest branches.**\n- **Replace ageing self-checkout terminals.**\n\n## Findings\n\nE-book loans grew 38 percent year-over-year and now represent 41 percent of all loans system-wide. Branches that exhausted their e-book budget within the first nine months saw flat or declining overall loan numbers in Q4.\n\nFoot traffic data shows the five busiest branches (Central, Eastgate, Westwood, Riverside, Hilltop) operate above 95 percent of seating capacity for the final hour of every weekday. No data was collected on demand outside currently operating hours.\n\nNo equipment audit was performed during this review.\n\n## Detailed Recommendations\n\n1. Increase the e-book lending budget by at least 25 percent across all branches, prioritising those that exhausted their allocation in the first nine months. The 38 percent growth in e-book loans, coupled with reduced overall lending where budgets were exhausted, justifies expanded investment.\n2. Open extended evening hours (until 10 PM) at the five busiest branches — Central, Eastgate, Westwood, Riverside, and Hilltop — to absorb demand from patrons currently turned away during peak final-hour periods.\n3. Replace ageing self-checkout terminals across the network within the next 18 months to improve patron experience.\n",
+    "target_severity_counts": {
+      "none": 1,
+      "medium": 3,
+      "high": 2
+    },
+    "target_answer": "The document contains two recommendation sections (Executive Summary and Detailed Recommendations) with three recommendations each — six occurrences total, evaluated independently. The summary e-book recommendation ('expand e-book lending budget across all branches') is fully supported by the loan-growth and budget-exhaustion findings → 1 'none'. The detailed e-book recommendation adds a specific '25 percent' threshold that is not grounded in any finding — under the boundary rule, when a recommendation adds a specific threshold not in the findings it is partially_supported → 1 'medium'. Both extended-hours recommendations (summary and detailed) are partially_supported: the 95 percent capacity finding implies demand at the final operating hour, but the document explicitly states no data was collected on demand outside currently operating hours, so extending until 10 PM is a small inferential extension → 2 'medium'. Both terminal-replacement recommendations are unsupported: the document explicitly states no equipment audit was performed, so the recommendation's subject is entirely unmeasured → 2 'high'. The agent should report 6 issues total: 1 'none', 3 'medium', 2 'high'."
+  },
+  {
+    "input": "# Workplace Safety: Annual Incident Review\n\n## Findings\n\nReportable incidents fell from 47 in the prior year to 31 in the current year, a 34 percent reduction. The introduction of mandatory pre-shift safety briefings in March is the largest single change correlated with the reduction; in months following the introduction, incident rates were 42 percent lower than in equivalent months the previous year.\n\nNear-miss reporting rose from 112 to 198 reports over the same period. Internal review suggests the increase reflects greater willingness to report rather than a genuine rise in near-miss frequency.\n\nLost-time injury rate fell from 3.1 to 2.4 per 100,000 hours worked.\n\n## Findings and Recommendations\n\n### Recommendations\n\n1. Make pre-shift safety briefings a permanent fixture across all sites, given the 42 percent reduction in incident rates in months following their introduction.\n2. Continue to encourage near-miss reporting and treat increases in reports as a positive indicator of safety culture rather than a deterioration.\n3. Roll out the mandatory safety briefings to contractor sites worldwide.\n",
+    "target_severity_counts": {
+      "none": 1,
+      "medium": 1,
+      "high": 1
+    },
+    "target_answer": "Recommendation 1 is partially_supported: the 42 percent post-introduction reduction supports the briefings' effectiveness, but 'making permanent' is a temporal extension beyond the studied period — it adds a horizon (indefinite continuation) that the findings do not directly establish. Recommendation 2 is supported by the document's own note that the increase in near-miss reports reflects willingness to report rather than rising frequency. Recommendation 3 is unsupported: extending to contractor sites worldwide goes to a population/scope the study did not cover at all. The agent should report 1 'none', 1 'medium', and 1 'high' issue."
+  },
+  {
+    "input": "# Hospital Readmission Reduction Pilot\n\n## Findings\n\nA six-month pilot of post-discharge nurse calls covered 412 patients across two cardiology wards. The 30-day readmission rate for the pilot cohort was 11.2 percent, compared to 18.4 percent in the matched control cohort drawn from the prior year. The difference (-7.2 percentage points) was statistically significant at p < 0.01.\n\nAverage call duration was 14 minutes. Per-patient cost was 38 USD. Estimated savings per avoided readmission was 8,400 USD.\n\nPatient-reported satisfaction with the call programme averaged 4.6/5.\n\n## Conclusion and Recommendations\n\n1. Roll out the post-discharge nurse call programme to the remaining cardiology wards in the network, given the demonstrated 7.2-percentage-point reduction in readmissions and favourable cost-benefit profile.\n2. Extend the call programme to oncology wards as a next step, where readmission rates have historically been comparable to cardiology.\n",
+    "target_severity_counts": {
+      "none": 0,
+      "medium": 1,
+      "high": 1
+    },
+    "target_answer": "Recommendation 1 is partially_supported: the 7.2-percentage-point reduction is shown in the two pilot wards, and the recommendation extends application to the 'remaining cardiology wards' which were not part of the pilot — this is the canonical pilot-to-rollout extrapolation to closely related but unmeasured sites. Recommendation 2 is unsupported under the out-of-scope-population rule: oncology wards were not measured at all in the document, and a different ward type is a different unmeasured population. The agent should report 1 'medium' and 1 'high' issue."
+  }
+]

--- a/evals_inspectai/e2e/recommendation_check/recommendation_check_e2e.py
+++ b/evals_inspectai/e2e/recommendation_check/recommendation_check_e2e.py
@@ -1,0 +1,62 @@
+from collections import Counter
+from pathlib import Path
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, json_dataset
+from inspect_ai.scorer import Score
+from inspect_ai.solver import TaskState
+
+from evals_inspectai.common.api_solver import api_workflow_agent
+from evals_inspectai.common.comparers import deep_diff_score
+from evals_inspectai.common.loaders import resolve_input
+from evals_inspectai.common.scorers import model_graded_check, structured_output_scorer
+from evals_inspectai.common.simple_deep_agent_types import SimpleDeepAgentOutput
+
+
+def _record_to_sample(record: dict) -> Sample:
+    return Sample(
+        input=resolve_input(record["input"]),
+        target=record.get("target_answer", ""),
+        metadata={
+            "target_severity_counts": record.get("target_severity_counts", {}),
+        },
+    )
+
+
+@task
+def recommendation_check_e2e():
+    dataset = json_dataset(
+        str(Path(__file__).parent / "dataset.json"),
+        _record_to_sample,
+    )
+
+    return Task(
+        dataset=dataset,
+        fail_on_error=0.2,
+        solver=api_workflow_agent("recommendation_check", timeout_s=600),
+        scorer=[
+            structured_output_scorer(SimpleDeepAgentOutput, _compare_severity_counts),
+            model_graded_check(partial_credit=True),
+        ],
+    )
+
+
+def _compare_severity_counts(output: SimpleDeepAgentOutput, state: TaskState) -> Score:
+    """Compare per-severity issue counts to the expected counts.
+
+    Recommendation Check emits one issue per recommendation occurrence:
+      - severity 'none' for supported
+      - severity 'medium' for partially_supported
+      - severity 'high' for unsupported
+    Issue titles include free-form paraphrases of the recommendation, so we
+    score on the stable signal (counts per bucket) rather than exact titles.
+    """
+    expected: dict = state.metadata.get("target_severity_counts", {})
+    issues = output.result.issues if output.result else []
+    actual = dict(Counter(issue.severity for issue in issues))
+
+    for key in ("none", "low", "medium", "high"):
+        expected.setdefault(key, 0)
+        actual.setdefault(key, 0)
+
+    return deep_diff_score(expected, actual)

--- a/frontend/components/results/tabs/workflow-results-renderer.tsx
+++ b/frontend/components/results/tabs/workflow-results-renderer.tsx
@@ -105,10 +105,13 @@ function renderWorkflowResults(
       return <ReferenceValidationV2Results workflowDetail={workflowRun} />;
     case WorkflowRunType.DocumentStructure:
     case WorkflowRunType.FiguresTablesCheck:
+    case WorkflowRunType.RecommendationCheck:
       return (
         <SimpleDeepAgentResults
+          project={project}
           workflowDetail={workflowRun as WorkflowRunDetailTyped<SimpleDeepAgentState>}
           workflowName={getWorkflowTypeName(type)}
+          onNavigateToDocumentExplorer={onNavigateToDocumentExplorer}
         />
       );
     default:

--- a/frontend/components/workflows/results/inference-validation-v2-results.tsx
+++ b/frontend/components/workflows/results/inference-validation-v2-results.tsx
@@ -185,7 +185,7 @@ function InferenceAnalysisCard({
           &ldquo;{analysis.key_sentence}&rdquo;
         </blockquote>
 
-        {onNavigateToDocumentExplorer && analysis.chunk_indices?.length && (
+        {onNavigateToDocumentExplorer && !!analysis.chunk_indices?.length && (
           <NavigateToExplorerButton
             onClick={() => {
               // Span all chunks the inference overlaps so the Explorer lands on

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -2,10 +2,11 @@
 
 import { ReadonlyThread } from '@/components/assistant-ui/readonly-thread';
 import { Markdown } from '@/components/markdown';
+import { DocumentIssueCard } from '@/components/results/components/document-issue-card';
 import { EmptyState } from '@/components/shared/empty-state';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { AgentCheckResult, SimpleDeepAgentState } from '@/lib/generated-api';
+import { Issue, ProjectDetailed, SeverityEnum, SimpleDeepAgentState } from '@/lib/generated-api';
 import {
   isWorkflowCancelled,
   isWorkflowFailed,
@@ -14,60 +15,91 @@ import {
 } from '@/lib/workflow-state';
 import { AssistantRuntimeProvider, ThreadMessageLike, useExternalStoreRuntime } from '@assistant-ui/react';
 import { convertLangChainMessages, LangChainMessage } from '@assistant-ui/react-langgraph';
-import { AlertTriangle, Ban, CheckCircle2, ClipboardList, Loader2, MessageSquare, XCircle } from 'lucide-react';
+import { Ban, CheckCircle2, ClipboardList, Loader2, MessageSquare, XCircle } from 'lucide-react';
+import { useMemo } from 'react';
 
 interface SimpleDeepAgentResultsProps {
+  project: ProjectDetailed;
   workflowDetail: WorkflowRunDetailTyped<SimpleDeepAgentState>;
   workflowName: string;
+  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
 }
 
-function IssuesList({ result }: { result: AgentCheckResult }) {
-  const issues = result.issues ?? [];
+function IssuesList({
+  issues,
+  onNavigateToDocumentExplorer,
+}: {
+  issues: Issue[];
+  onNavigateToDocumentExplorer: (lineRange?: [number, number]) => void;
+}) {
+  const realIssues = issues.filter((i) => i.severity !== SeverityEnum.None);
+  const informational = issues.filter((i) => i.severity === SeverityEnum.None);
 
-  if (issues.length === 0) {
-    return (
-      <Card className="border-green-200 bg-green-50/30 dark:bg-green-950/30 dark:border-green-900">
-        <CardContent className="flex items-center gap-3 py-6">
-          <div className="h-10 w-10 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center flex-shrink-0">
-            <CheckCircle2 className="h-5 w-5 text-green-600" />
-          </div>
-          <div>
-            <p className="text-sm font-medium">All Checks Passed</p>
-            <p className="text-xs text-muted-foreground">No issues were found in the document.</p>
-          </div>
-        </CardContent>
-      </Card>
-    );
-  }
+  const handleSelect = (issue: Issue) => {
+    if (typeof issue.start_line === 'number' && typeof issue.end_line === 'number') {
+      onNavigateToDocumentExplorer([issue.start_line, issue.end_line]);
+    } else {
+      onNavigateToDocumentExplorer();
+    }
+  };
 
   return (
-    <Card className="border-amber-200 gap-2">
-      <CardHeader className="pb-2">
-        <CardTitle className="text-sm text-amber-800 dark:text-amber-200">
-          {issues.length} Issue{issues.length !== 1 ? 's' : ''} Found
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {issues.map((issue, idx) => (
-          <div
-            key={idx}
-            className="flex items-start gap-2 p-2 rounded-md bg-amber-50 border border-amber-100 dark:bg-amber-950/40 dark:border-amber-900"
-          >
-            <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-            <div>
-              <p className="text-sm font-medium text-amber-800 dark:text-amber-200">{issue.title}</p>
-              <p className="text-xs text-amber-700 dark:text-amber-300 mt-0.5">{issue.description}</p>
+    <>
+      {realIssues.length === 0 ? (
+        <Card className="border-green-200 bg-green-50/30 dark:bg-green-950/30 dark:border-green-900">
+          <CardContent className="flex items-center gap-3 py-6">
+            <div className="h-10 w-10 rounded-full bg-green-100 dark:bg-green-900 flex items-center justify-center flex-shrink-0">
+              <CheckCircle2 className="h-5 w-5 text-green-600" />
             </div>
+            <div>
+              <p className="text-sm font-medium">All Checks Passed</p>
+              <p className="text-xs text-muted-foreground">No issues were found in the document.</p>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <section className="space-y-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            {realIssues.length} Issue{realIssues.length !== 1 ? 's' : ''} Found
+          </h3>
+          <div className="space-y-2">
+            {realIssues.map((issue) => (
+              <DocumentIssueCard key={issue.id} issue={issue} onSelect={handleSelect} />
+            ))}
           </div>
-        ))}
-      </CardContent>
-    </Card>
+        </section>
+      )}
+
+      {informational.length > 0 && (
+        <section className="space-y-2 mt-4">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            {informational.length} Informational Item{informational.length !== 1 ? 's' : ''}
+          </h3>
+          <div className="space-y-2">
+            {informational.map((issue) => (
+              <DocumentIssueCard key={issue.id} issue={issue} onSelect={handleSelect} />
+            ))}
+          </div>
+        </section>
+      )}
+    </>
   );
 }
 
-export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleDeepAgentResultsProps) {
+export function SimpleDeepAgentResults({
+  project,
+  workflowDetail,
+  workflowName,
+  onNavigateToDocumentExplorer,
+}: SimpleDeepAgentResultsProps) {
   const messages = workflowDetail.state?.messages ?? [];
   const displayedMessages = messages.filter((message) => message.type !== 'tool');
+
+  const workflowRunId = workflowDetail.run.id;
+  const issues = useMemo(
+    () => (project.issues ?? []).filter((i) => i.workflow_run_id === workflowRunId),
+    [project.issues, workflowRunId],
+  );
 
   const runtime = useExternalStoreRuntime({
     messages: displayedMessages,
@@ -131,8 +163,6 @@ export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleD
       </TabsList>
 
       <TabsContent value="results" className="space-y-4">
-        <IssuesList result={result} />
-
         {result.report_markdown && (
           <Card className="gap-2">
             <CardHeader>
@@ -143,6 +173,8 @@ export function SimpleDeepAgentResults({ workflowDetail, workflowName }: SimpleD
             </CardContent>
           </Card>
         )}
+
+        <IssuesList issues={issues} onNavigateToDocumentExplorer={onNavigateToDocumentExplorer} />
       </TabsContent>
 
       <TabsContent value="messages" className="mt-4">

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -64,6 +64,7 @@ const workflowTypeIcons: Record<WorkflowRunType, LucideIcon> = {
   [WorkflowRunType.Reviewer2]: BookOpen,
   [WorkflowRunType.DocumentStructure]: FileCheckIcon,
   [WorkflowRunType.FiguresTablesCheck]: TableIcon,
+  [WorkflowRunType.RecommendationCheck]: ClipboardCheck,
 };
 
 const DEFAULT_ICON = FileText;

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -3031,9 +3031,9 @@ export type IssueItem = {
   /**
    * Severity
    *
-   * Issue severity: low, medium, or high
+   * Issue severity: none, low, medium, or high. Use 'none' for informational items that should be surfaced but do not represent a problem.
    */
-  severity?: 'low' | 'medium' | 'high';
+  severity?: 'none' | 'low' | 'medium' | 'high';
   /**
    * Long Description
    *
@@ -5672,6 +5672,7 @@ export const WorkflowRunType = {
   Reviewer2: 'reviewer_2',
   DocumentStructure: 'document_structure',
   FiguresTablesCheck: 'figures_tables_check',
+  RecommendationCheck: 'recommendation_check',
 } as const;
 
 /**

--- a/lib/workflows/categories.py
+++ b/lib/workflows/categories.py
@@ -38,6 +38,7 @@ WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
             WorkflowRunType.METHODOLOGICAL_ALIGNMENT,
             WorkflowRunType.RESULTS_EXTRACTION,
             WorkflowRunType.REVIEWER_2,
+            WorkflowRunType.RECOMMENDATION_CHECK,
         ],
     ),
     CategoryConfig(

--- a/lib/workflows/models.py
+++ b/lib/workflows/models.py
@@ -105,6 +105,7 @@ class WorkflowRunType(str, Enum):
     REVIEWER_2 = "reviewer_2"
     DOCUMENT_STRUCTURE = "document_structure"
     FIGURES_TABLES_CHECK = "figures_tables_check"
+    RECOMMENDATION_CHECK = "recommendation_check"
 
 
 def is_user_visible_workflow(workflow_type: WorkflowRunType) -> bool:

--- a/lib/workflows/recommendation_check/manifest.py
+++ b/lib/workflows/recommendation_check/manifest.py
@@ -1,0 +1,118 @@
+"""Manifest for the Recommendation Check workflow.
+
+Verifies that recommendations made in the document are directly supported by
+the findings/evidence presented elsewhere in the same document. Complements
+citation-grounding workflows: those check that claims are backed by external
+sources; this one checks that recommendations are backed by the document's
+own findings.
+"""
+
+from lib.workflows.models import WorkflowRunType
+from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
+
+_USER_PROMPT = """\
+Evaluate whether each recommendation in the document is directly supported \
+by findings presented elsewhere in the same document.
+
+A "finding" is empirical evidence, analysis, data, or a substantive observation \
+presented in the body of the document (e.g. results, case study outcomes, \
+quantitative analysis, expert interviews summarized within the document). \
+A finding must come from the document itself — external citations alone do \
+not count, since other analyses cover citation grounding.
+
+## Procedure
+
+1. **Locate recommendations.** Recommendations typically live in a section \
+titled "Recommendations", "Findings and Recommendations", "Conclusions and \
+Recommendations", or similar. They may also appear in the executive summary, \
+conclusions, or policy implications. A document often contains **multiple \
+recommendation sections** — for example, a high-level summary near the \
+beginning and a detailed version at the end. **Check all of them**, and treat \
+each distinct recommendation as a separate item even when multiple appear in \
+the same paragraph or bullet list. If the same recommendation is restated in \
+multiple sections (e.g. once in a summary and again in a detailed section), \
+evaluate **each occurrence separately** — wording often differs slightly \
+between restatements, and a difference in phrasing can change whether the \
+document's findings actually support it.
+
+2. **For each recommendation, search the document for supporting findings.** \
+Read the body, results, and analysis sections to identify the finding(s) \
+that directly justify the recommendation. Quote the supporting text and note \
+where it appears.
+
+3. **Classify each recommendation as one of:**
+
+   - **supported** — at least one finding in the document directly backs \
+**the recommendation as worded**, including any specific numeric thresholds, \
+percentages, time horizons, or scope qualifiers it contains. If the \
+recommendation introduces a new specific (e.g. "cap at 6 hours", "increase \
+by at least 25 percent", "within 18 months") that is not itself stated or \
+clearly implied by a finding, do **not** classify as supported — choose \
+partially_supported instead.
+
+   - **partially_supported** — a relevant finding exists in the document and \
+substantively backs the *direction* of the recommendation, but one of the \
+following applies:
+     * The recommendation adds a specific threshold, magnitude, or time \
+horizon that is not directly grounded in a finding.
+     * The recommendation addresses only part of what the findings cover, \
+or covers more than the findings do (a small inferential extension).
+     * The recommendation extrapolates from a measured population/site to \
+a closely related but unmeasured one (e.g. from one ward to another ward \
+in the same hospital, or from a pilot region to neighbouring regions of \
+the same kind).
+     * The recommendation is stated weakly or generically but the underlying \
+direction is consistent with the findings.
+
+   - **unsupported** — use this classification when **any** of the following \
+apply:
+     * **Out-of-scope population, geography, or domain.** The recommendation \
+explicitly applies to a group, location, or domain the document's findings \
+did not cover at all (e.g. recommending changes for "contractors worldwide" \
+when the study covered only in-house staff at a single organisation, or for \
+"oncology wards" when only cardiology was studied). Even when the underlying \
+intervention is shown to work in the studied scope, extending to an entirely \
+unstudied scope is **unsupported, not partially_supported**.
+     * **No relevant finding.** The document contains no finding that \
+addresses the subject of the recommendation at all (e.g. recommending \
+equipment replacement when no equipment audit was performed).
+     * **Contradicted by findings.** The available findings directly \
+contradict the recommendation (e.g. recommending an intervention to \
+restore beach width when findings explicitly state no beach-width change \
+was observed).
+
+   **Boundary rule (when in doubt between partially_supported and \
+unsupported):** If the recommendation's *subject* (the population, location, \
+domain, or measurement) was studied at all in the document — even partially \
+— it is at most partially_supported. If the *subject itself* was never \
+measured, it is unsupported.
+
+## Reporting
+
+- For each **supported** recommendation, emit one issue with \
+**severity: none** — these are informational and confirm the recommendation \
+is properly grounded.
+- For each **partially_supported** recommendation, emit one issue with \
+**severity: medium**.
+- For each **unsupported** recommendation, emit one issue with \
+**severity: high**.
+
+Emit one issue per recommendation occurrence (a recommendation restated in \
+multiple sections produces multiple issues, evaluated independently).
+"""
+
+
+class RecommendationCheckManifest(SimpleDeepAgentManifest):
+    """Checks that recommendations are supported by the document's own findings."""
+
+    type = WorkflowRunType.RECOMMENDATION_CHECK
+    name = "Recommendation Check"
+    description = (
+        "Are the document's recommendations supported by its own findings? "
+        "Flags recommendations that lack backing evidence in the body, or "
+        "where the evidence is weak, indirect, or contradictory."
+    )
+    required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
+    is_experimental = False
+
+    user_prompt = _USER_PROMPT

--- a/lib/workflows/registry.py
+++ b/lib/workflows/registry.py
@@ -92,6 +92,9 @@ def register_all_workflow_manifests():
         ReferenceFileMatchingManifest,
     )
     from lib.workflows.reference_validation.manifest import ReferenceValidationManifest
+    from lib.workflows.recommendation_check.manifest import (
+        RecommendationCheckManifest,
+    )
     from lib.workflows.reference_validation_v2.manifest import (
         ReferenceValidationV2Manifest,
     )
@@ -125,6 +128,7 @@ def register_all_workflow_manifests():
         Reviewer2Manifest(),
         DocumentStructureManifest(),
         FiguresTablesCheckManifest(),
+        RecommendationCheckManifest(),
     ]
 
     for manifest in manifests:

--- a/lib/workflows/simple_deep_agent/agent_types.py
+++ b/lib/workflows/simple_deep_agent/agent_types.py
@@ -19,9 +19,9 @@ class IssueItem(BaseModel):
     description: str = Field(
         description="Detailed description of the issue. Supports markdown."
     )
-    severity: Literal["low", "medium", "high"] = Field(
+    severity: Literal["none", "low", "medium", "high"] = Field(
         default="medium",
-        description="Issue severity: low, medium, or high",
+        description="Issue severity: none, low, medium, or high. Use 'none' for informational items that should be surfaced but do not represent a problem.",
     )
     long_description: Optional[str] = Field(
         default=None,
@@ -60,6 +60,7 @@ class AgentCheckResult(BaseModel):
 
 
 _SEVERITY_MAP = {
+    "none": SeverityEnum.NONE,
     "low": SeverityEnum.LOW,
     "medium": SeverityEnum.MEDIUM,
     "high": SeverityEnum.HIGH,

--- a/skills/issues/SKILL.md
+++ b/skills/issues/SKILL.md
@@ -19,12 +19,13 @@ A short, specific title that names the problem. If the instructions specify a ti
 **`description`** (`str`, markdown supported)
 A 1–3 sentence explanation of the problem. Reference the specific text, element, or rule that failed. Explain what was expected and what was found. Do not invent content — base every judgment strictly on what is present in the document. Markdown formatting (bold, inline code, etc.) is supported and encouraged when it improves clarity.
 
-**`severity`** (`"low"` | `"medium"` | `"high"`)
+**`severity`** (`"none"` | `"low"` | `"medium"` | `"high"`)
 Choose based on impact on document quality:
 
 - `"high"` — critical problems that significantly undermine document integrity: missing required sections, broken or unresolvable references, absent mandatory elements.
 - `"medium"` — notable problems that reduce clarity or compliance: incomplete sections, unreferenced figures or tables, inconsistent numbering, rule violations that affect readability.
 - `"low"` — minor issues with minimal impact: style suggestions, optional improvements, minor formatting inconsistencies.
+- `"none"` — **informational, opt-in only.** Use exclusively when the workflow's user prompt explicitly asks you to surface valid / passing checks alongside problems (e.g. confirming a recommendation is well-grounded, attesting that a section meets a rule). Never emit `"none"` issues unless the workflow instructions request them — by default, do not create entries for rules that pass.
 
 When the workflow instructions specify a severity for a particular rule, always use that value.
 
@@ -55,7 +56,7 @@ When used, format `long_description` with markdown to maximize readability:
 
 ## Issues List
 
-Report one issue per problem found. Only create an issue for a failing rule or missing element — do not add entries for rules that pass.
+Report one issue per problem found. Only create an issue for a failing rule or missing element — do not add entries for rules that pass, **unless** the workflow's user prompt explicitly asks you to surface passing checks as informational (`severity: "none"`) items.
 
 ## Line-Number Conventions
 
@@ -65,7 +66,7 @@ Report one issue per problem found. Only create an issue for a failing rule or m
 
 ## Best Practices
 
-- Report only genuine problems. Do not create issues for rules that pass.
+- Report only genuine problems. Do not create issues for rules that pass, unless the workflow instructions explicitly request informational (`severity: "none"`) entries for passing checks.
 - Each issue should be individually actionable — a reader should be able to locate the problem and fix it without further clarification.
 - Descriptions must be grounded in the document content; never speculate or invent details.
 - When multiple rules fail for the same element, create one issue per failed rule so each is independently actionable (unless the workflow instructions say otherwise).


### PR DESCRIPTION
## Summary

- Adds a new **Recommendation Check** workflow under **Substantive Review** that verifies whether the recommendations in a document are directly supported by findings presented elsewhere in the same document.
- Built on the existing `SimpleDeepAgent` pattern (single full-document deep-agent pass). Each recommendation occurrence is classified as supported (severity `none`, informational) / partially_supported (`medium`) / unsupported (`high`).
- Frontend `SimpleDeepAgentResults` now renders persisted `Issue`s via `DocumentIssueCard` (severity badge, jump-to-line, feedback, resolve, suggested-action, expandable details), with a separate "Informational Items" section for severity-`none` items so supported recommendations don't inflate the "Issues Found" count.
- New Inspect AI e2e eval suite with 6 samples; latest run scored `structured_output_scorer` 0.994 / `model_graded_check` 0.944 across 3 epochs.

## Motivation

Closes [RANDZ-527](https://linear.app/ae-studio/issue/RANDZ-527/new-analysis-type-recommendation-check). Proposed in the 2026-04-13 Design & Storywriting meeting as a complement to existing substantive checks: those verify that *claims* are grounded in *external sources*; this one verifies that *recommendations* are grounded in the document's own findings. Carlos committed to a 1-day MVP for review.

## What's Changed

### Backend

- `lib/workflows/models.py` — adds `WorkflowRunType.RECOMMENDATION_CHECK`. Stored as `String(255)`, so no Alembic migration needed.
- `lib/workflows/recommendation_check/manifest.py` (new) — `RecommendationCheckManifest` subclassing `SimpleDeepAgentManifest`. Prompt instructs the agent to (1) locate all recommendation sections (including alternative names like "Findings and Recommendations" and multiple sections per document), (2) evaluate each occurrence independently because wording often differs between restatements, (3) classify each recommendation against an explicit boundary rule:
  - **supported** — directly backed *as worded*, including any specific thresholds.
  - **partially_supported** — direction backed, but adds an ungrounded specific, addresses only part, extrapolates to a closely related but unmeasured site/population, or is weakly phrased.
  - **unsupported** — out-of-scope population/geography/domain, no relevant finding at all, or contradicted by findings.
- `lib/workflows/registry.py` — registers `RecommendationCheckManifest`.
- `lib/workflows/categories.py` — adds the new workflow under **Substantive Review**.
- `lib/workflows/simple_deep_agent/agent_types.py` — extends `IssueItem.severity` to accept `"none"` (additive) and adds `"none" → SeverityEnum.NONE` to `_SEVERITY_MAP`. Other simple-deep-agent workflows can now opt in to informational items.

### Frontend

- `frontend/components/results/tabs/workflow-results-renderer.tsx` — routes `RecommendationCheck` to `SimpleDeepAgentResults` (alongside `DocumentStructure` and `FiguresTablesCheck`); now passes `project` and `onNavigateToDocumentExplorer`.
- `frontend/components/workflows/results/simple-deep-agent-results.tsx` — replaces the lightweight `IssueItem` rendering with `DocumentIssueCard` driven by the persisted `Issue`s on `ProjectDetailed.issues` (filtered by `workflow_run_id`). Splits issues into "N Issues Found" (severity ≠ `none`) and "N Informational Items" (severity `none`) sections; moves the Report card above the issues list.
- `frontend/components/workflows/workflow-type-checkbox.tsx` — adds `RecommendationCheck → ClipboardCheck` icon mapping (required by the `Record<WorkflowRunType, LucideIcon>` exhaustiveness check).
- `frontend/components/workflows/results/inference-validation-v2-results.tsx` — minor `!!` boolean-coercion fix surfaced by tsc.
- `frontend/lib/generated-api/types.gen.ts` — regenerated via `pnpm run openapi-generate`.

### Evals

- `evals_inspectai/e2e/recommendation_check/recommendation_check_e2e.py` (new) — task targeting the workflow via `api_workflow_agent`. Two scorers: a `structured_output_scorer` that compares per-severity issue counts (titles include free-form paraphrases of the recommendation, so counts are the stable signal), and `model_graded_check` with partial credit.
- `evals_inspectai/e2e/recommendation_check/dataset.json` (new) — 6 synthetic samples covering: directly-supported recs with one out-of-scope extension, contradicted recs (beach-width finding contradicts beach-width recommendation), no-recommendation baseline, multi-section docs evaluated independently, "Findings and Recommendations" alternative section name, and pilot-to-rollout / oncology extrapolation patterns.
- Latest 3-epoch run: `structured_output_scorer` mean **0.994** (stderr 0.006), `model_graded_check` accuracy **0.944** (stderr 0.035).

## Risks and Mitigations

- **Prompt boundary calibration.** The supported/partial/unsupported boundary is qualitative; the prompt now contains explicit triggers and a boundary rule, but reasonable agents may still flicker on edge cases (one stochastic flicker observed in the 18-run eval). *Mitigation:* the dataset is calibrated to the prompt's semantics; Emily will iterate on eval cases as real RAND documents flow through.
- **Issue count vs. title matching.** Issue titles embed a paraphrase of the recommendation, so they're not stable across runs. *Mitigation:* the eval scorer keys on per-severity counts rather than titles.
- **Frontend `SimpleDeepAgent` results refactor.** Switching from rendering lightweight `IssueItem`s to persisted `Issue`s also affects `DocumentStructure` and `FiguresTablesCheck`. The persisted issues come from each manifest's `convert_state_to_issues` (the base manifest already implements this), so behaviour should match. *Mitigation:* tested locally; FE typechecks clean. Worth a smoke check in those two existing workflows post-merge.
- **No DB migration.** `WorkflowRunType` is stored as `String(255)`, so adding a new value is non-breaking for existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)