### PR TITLE
chore: rename project from AI Reviewer to Draft Detective

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-This guide covers everything you need to know to set up, run, and develop the AI Reviewer project locally.
+This guide covers everything you need to know to set up, run, and develop the Draft Detective project locally.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AI Reviewer
+# Draft Detective
 
 AI-powered assistant for academic peer review. Built with LangGraph, this tool validates references against claims, flags unsupported assertions, performs literature reviews, and suggests relevant citations — helping reviewers and researchers assess rigor more efficiently.
 
@@ -8,7 +8,7 @@ Project funded by RAND: https://rand.org/
 
 ## Goals
 
-The main goal of AI Reviewer is to assist and streamline the academic peer review process by reducing manual workload and improving the consistency, transparency, and rigor of evaluations.
+The main goal of Draft Detective is to assist and streamline the academic peer review process by reducing manual workload and improving the consistency, transparency, and rigor of evaluations.
 
 ## Features
 

--- a/addin/README.md
+++ b/addin/README.md
@@ -77,6 +77,6 @@ https://learn.microsoft.com/en-us/microsoft-365/admin/manage/office-addins?view=
 
 In step 3, choose **Add-in only manifest** and provide the manifest URL.
 
-Manifest URL from this repo: `https://raw.githubusercontent.com/agencyenterprise/ai-reviewer/refs/heads/dev/addin/manifest.xml`
+Manifest URL from this repo: `https://raw.githubusercontent.com/agencyenterprise/draft-detective/refs/heads/dev/addin/manifest.xml`
 
 Reference video (older, but still useful): https://www.youtube.com/watch?v=p3aeO9muEI8&t=181s

--- a/addin/manifest-dev.xml
+++ b/addin/manifest-dev.xml
@@ -2,10 +2,10 @@
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
   <Id>4ebc6824-f166-4bf3-a691-cc07c6b2221e</Id>
   <Version>1.0.0.0</Version>
-  <ProviderName>AI Reviewer (DEV)</ProviderName>
+  <ProviderName>Draft Detective (DEV)</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
-  <DisplayName DefaultValue="AI Reviewer (DEV)"/>
-  <Description DefaultValue="AI Reviewer add-in allows you to see the issues on AI Reviewer in your word document." />
+  <DisplayName DefaultValue="Draft Detective (DEV)"/>
+  <Description DefaultValue="Draft Detective add-in allows you to see the issues on Draft Detective in your word document." />
   <IconUrl DefaultValue="https://ai-reviewer-app-dev.up.railway.app/logo_160x160.png"/>
   <HighResolutionIconUrl DefaultValue="https://ai-reviewer-app-dev.up.railway.app/logo_160x160.png"/>
   <SupportUrl DefaultValue="https://ai-reviewer-app-dev.up.railway.app/"/>
@@ -75,13 +75,13 @@
         <bt:Url id="Taskpane.Url" DefaultValue="https://ai-reviewer-app-dev.up.railway.app/addin"/>
       </bt:Urls>
       <bt:ShortStrings>
-        <bt:String id="GetStarted.Title" DefaultValue="Get started with the AI Reviewer (DEV) add-in!"/>
-        <bt:String id="CommandsGroup.Label" DefaultValue="AI Reviewer (DEV)"/>
-        <bt:String id="TaskpaneButton.Label" DefaultValue="AI Reviewer (DEV)"/>
+        <bt:String id="GetStarted.Title" DefaultValue="Get started with the Draft Detective (DEV) add-in!"/>
+        <bt:String id="CommandsGroup.Label" DefaultValue="Draft Detective (DEV)"/>
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Draft Detective (DEV)"/>
       </bt:ShortStrings>
       <bt:LongStrings>
-        <bt:String id="GetStarted.Description" DefaultValue="The AI Reviewer (DEV) add-in loaded successfully. Go to the HOME tab and click the 'AI Reviewer (DEV)' button to get started."/>
-        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Click to open the AI Reviewer (DEV) add-in."/>
+        <bt:String id="GetStarted.Description" DefaultValue="The Draft Detective (DEV) add-in loaded successfully. Go to the HOME tab and click the 'Draft Detective (DEV)' button to get started."/>
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Click to open the Draft Detective (DEV) add-in."/>
       </bt:LongStrings>
     </Resources>
   </VersionOverrides>

--- a/addin/manifest-template.xml
+++ b/addin/manifest-template.xml
@@ -2,10 +2,10 @@
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0" xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
   <Id>d11b2ab1-20e0-4baf-abcf-e54ed028ce7d</Id>
   <Version>1.0.0.0</Version>
-  <ProviderName>AI Reviewer</ProviderName>
+  <ProviderName>Draft Detective</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
-  <DisplayName DefaultValue="AI Reviewer"/>
-  <Description DefaultValue="AI Reviewer add-in allows you to see the issues on AI Reviewer in your word document." />
+  <DisplayName DefaultValue="Draft Detective"/>
+  <Description DefaultValue="Draft Detective add-in allows you to see the issues on Draft Detective in your word document." />
   <IconUrl DefaultValue="{FRONTEND_URL}/logo_160x160.png"/>
   <HighResolutionIconUrl DefaultValue="{FRONTEND_URL}/logo_160x160.png"/>
   <SupportUrl DefaultValue="{FRONTEND_URL}/"/>
@@ -75,13 +75,13 @@
         <bt:Url id="Taskpane.Url" DefaultValue="{FRONTEND_URL}/addin"/>
       </bt:Urls>
       <bt:ShortStrings>
-        <bt:String id="GetStarted.Title" DefaultValue="Get started with the AI Reviewer add-in!"/>
-        <bt:String id="CommandsGroup.Label" DefaultValue="AI Reviewer"/>
-        <bt:String id="TaskpaneButton.Label" DefaultValue="AI Reviewer"/>
+        <bt:String id="GetStarted.Title" DefaultValue="Get started with the Draft Detective add-in!"/>
+        <bt:String id="CommandsGroup.Label" DefaultValue="Draft Detective"/>
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Draft Detective"/>
       </bt:ShortStrings>
       <bt:LongStrings>
-        <bt:String id="GetStarted.Description" DefaultValue="The AI Reviewer add-in loaded successfully. Go to the HOME tab and click the 'AI Reviewer' button to get started."/>
-        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Click to open the AI Reviewer add-in."/>
+        <bt:String id="GetStarted.Description" DefaultValue="The Draft Detective add-in loaded successfully. Go to the HOME tab and click the 'Draft Detective' button to get started."/>
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Click to open the Draft Detective add-in."/>
       </bt:LongStrings>
     </Resources>
   </VersionOverrides>

--- a/addin/manifest.xml
+++ b/addin/manifest.xml
@@ -6,10 +6,10 @@
   xsi:type="TaskPaneApp">
   <Id>e8f82310-9703-42b4-8e7c-996e237f7d23</Id>
   <Version>1.0.0.0</Version>
-  <ProviderName>AI Reviewer</ProviderName>
+  <ProviderName>Draft Detective</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
-  <DisplayName DefaultValue="AI Reviewer" />
-  <Description DefaultValue="AI Reviewer add-in allows you to see the issues on AI Reviewer in your word document." />
+  <DisplayName DefaultValue="Draft Detective" />
+  <Description DefaultValue="Draft Detective add-in allows you to see the issues on Draft Detective in your word document." />
   <IconUrl DefaultValue="https://ai-reviewer-app-production.up.railway.app/logo_160x160.png" />
   <HighResolutionIconUrl
     DefaultValue="https://ai-reviewer-app-production.up.railway.app/logo_160x160.png" />
@@ -86,14 +86,14 @@
           DefaultValue="https://ai-reviewer-app-production.up.railway.app/addin" />
       </bt:Urls>
       <bt:ShortStrings>
-        <bt:String id="GetStarted.Title" DefaultValue="Get started with the AI Reviewer add-in!" />
-        <bt:String id="CommandsGroup.Label" DefaultValue="AI Reviewer" />
-        <bt:String id="TaskpaneButton.Label" DefaultValue="AI Reviewer" />
+        <bt:String id="GetStarted.Title" DefaultValue="Get started with the Draft Detective add-in!" />
+        <bt:String id="CommandsGroup.Label" DefaultValue="Draft Detective" />
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Draft Detective" />
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description"
-          DefaultValue="The AI Reviewer add-in loaded successfully. Go to the HOME tab and click the 'AI Reviewer' button to get started." />
-        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Click to open the AI Reviewer add-in." />
+          DefaultValue="The Draft Detective add-in loaded successfully. Go to the HOME tab and click the 'Draft Detective' button to get started." />
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Click to open the Draft Detective add-in." />
       </bt:LongStrings>
     </Resources>
   </VersionOverrides>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,10 @@
-AI Reviewer is an automated document analysis system designed to assist in academic peer review by systematically evaluating the relationship between claims and their supporting evidence in research documents. The project goal is to employ most recent LLMs, agent-based workflows and techniques found the most recent literature to help researchers, reviewers, and academics improve the rigor and quality of their work.
+Draft Detective is an automated document analysis system designed to assist in academic peer review by systematically evaluating the relationship between claims and their supporting evidence in research documents. The project goal is to employ most recent LLMs, agent-based workflows and techniques found the most recent literature to help researchers, reviewers, and academics improve the rigor and quality of their work.
 
 This project is funded by [RAND](https://rand.org/)'s [CAST Center](https://www.rand.org/global-and-emerging-risks/centers/ai-security-and-technology.html) (RAND Center on AI, Security, and Technology).
 
 ---
 
-_This page outlines the project's scientific and technical approach and presents its results, showcasing some real input/output examples. For development setup and usage instructions of the tool, see the README and DEVELOPMENT files in the [GitHub repository](https://github.com/agencyenterprise/ai-reviewer)._
+_This page outlines the project's scientific and technical approach and presents its results, showcasing some real input/output examples. For development setup and usage instructions of the tool, see the README and DEVELOPMENT files in the [GitHub repository](https://github.com/agencyenterprise/draft-detective)._
 
 ## 5-minute demo video
 
@@ -49,7 +49,7 @@ For organizational quality assurance workflows, the system also includes experim
 
 ![Document Processing Pipeline](./document-processing-pipeline.png)
 
-The system accepts two primary inputs: a **main document** to be reviewed and a set of **supporting documents/references** that provide the evidentiary foundation. These inputs are processed by the AI-Reviewer, which orchestrates a series of specialized agents to analyze the document. The output is a comprehensive table containing all extracted elements—files, chunks, claims, citations, and their verification results—along with a detailed analysis summary. The web interface provides multiple views (Summary, Explorer, Files, Chunks, Citations) to navigate the results and assess the quality of claim substantiation throughout the document.
+The system accepts two primary inputs: a **main document** to be reviewed and a set of **supporting documents/references** that provide the evidentiary foundation. These inputs are processed by Draft Detective, which orchestrates a series of specialized agents to analyze the document. The output is a comprehensive table containing all extracted elements—files, chunks, claims, citations, and their verification results—along with a detailed analysis summary. The web interface provides multiple views (Summary, Explorer, Files, Chunks, Citations) to navigate the results and assess the quality of claim substantiation throughout the document.
 
 The system processes documents through a multi-stage pipeline implemented using LangGraph, which orchestrates a series of specialized AI agents:
 

--- a/docs/railway-deployment.md
+++ b/docs/railway-deployment.md
@@ -1,6 +1,6 @@
 # Railway Deployment Guide
 
-This guide covers deploying AI Reviewer to [Railway](https://railway.app).
+This guide covers deploying Draft Detective to [Railway](https://railway.app).
 
 ## Prerequisites
 
@@ -14,7 +14,7 @@ This guide covers deploying AI Reviewer to [Railway](https://railway.app).
 
 1. Go to [Railway Dashboard](https://railway.app/dashboard)
 2. Click **New Project** → **Deploy from GitHub repo**
-3. Select your AI Reviewer repository
+3. Select your Draft Detective repository
 
 ### 2. Add Required Services
 

--- a/evals_inspectai/common/api_client.py
+++ b/evals_inspectai/common/api_client.py
@@ -1,4 +1,4 @@
-"""Async HTTP client for calling the AI Reviewer API in e2e evals."""
+"""Async HTTP client for calling the Draft Detective API in e2e evals."""
 
 import asyncio
 import logging
@@ -16,7 +16,7 @@ from evals_inspectai.common.errors import check_workflow_errors
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "http://localhost:8000"
-DEFAULT_USER_EMAIL = "eval@ai-reviewer.local"
+DEFAULT_USER_EMAIL = "eval@draft-detective.local"
 DEFAULT_USER_NAME = "E2E Eval Runner"
 DEFAULT_POLL_INTERVAL_S = 5
 DEFAULT_TIMEOUT_S = 300

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "ai-reviewer",
+  "name": "draft-detective",
   "version": "0.5.34",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/agencyenterprise/ai-reviewer"
+    "url": "https://github.com/agencyenterprise/draft-detective"
   },
   "scripts": {
     "dev": "next dev --turbopack",

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,6 +1,6 @@
-# AI Reviewer - Kubernetes Deployment
+# Draft Detective - Kubernetes Deployment
 
-Simple, plug-and-play Kubernetes deployment for AI Reviewer.
+Simple, plug-and-play Kubernetes deployment for Draft Detective.
 **Optimized for OpenShift** with support for vanilla Kubernetes.
 
 ## Prerequisites

--- a/lib/api/mcp/instance.py
+++ b/lib/api/mcp/instance.py
@@ -6,7 +6,7 @@ from lib.config.env import config as env_config
 
 mcp_auth = create_mcp_auth()
 mcp = FastMCP(
-    "AI Reviewer / Draft Detective",
+    "Draft Detective",
     auth=mcp_auth,
     website_url=env_config.FRONTEND_URL,
     icons=[Icon(src=env_config.FRONTEND_URL + "/icon.svg")],

--- a/lib/config_keys/about_page.py
+++ b/lib/config_keys/about_page.py
@@ -50,7 +50,7 @@ citation checks.
 ## Analysis Types
 
 Each check is listed below, organized by category. Evaluation coverage is in active development — \
-see the [evals folder on GitHub](https://github.com/agencyenterprise/ai-reviewer/tree/main/evals_inspectai) \
+see the [evals folder on GitHub](https://github.com/agencyenterprise/draft-detective/tree/main/evals_inspectai) \
 for details.
 
 ### Language
@@ -63,21 +63,21 @@ for details.
 
 | Analysis Type | Description | Eval |
 |:---|:---|:---:|
-| **Abbreviation Scan** | Scans the document for abbreviations and acronyms, verifies each is defined inline at its first occurrence, and checks that all abbreviations appear in an Abbreviations section. | [eval](https://github.com/agencyenterprise/ai-reviewer/tree/main/evals_inspectai/e2e/abbreviation_checker) |
-| **Document Contents** | Checks that key content is present: Acknowledgements, Methods, Results, Conclusion, References, and Appendix (if referenced in text). `#experimental` | [eval](https://github.com/agencyenterprise/ai-reviewer/tree/main/evals_inspectai/e2e/document_structure) |
-| **Figures & Tables Check** | Verifies that every figure and table has a title, is consistently numbered, is referenced in the body text, and that every body-text reference resolves to an actual figure or table in the document. `#experimental` | [eval](https://github.com/agencyenterprise/ai-reviewer/tree/main/evals_inspectai/e2e/figures_tables_check) |
+| **Abbreviation Scan** | Scans the document for abbreviations and acronyms, verifies each is defined inline at its first occurrence, and checks that all abbreviations appear in an Abbreviations section. | [eval](https://github.com/agencyenterprise/draft-detective/tree/main/evals_inspectai/e2e/abbreviation_checker) |
+| **Document Contents** | Checks that key content is present: Acknowledgements, Methods, Results, Conclusion, References, and Appendix (if referenced in text). `#experimental` | [eval](https://github.com/agencyenterprise/draft-detective/tree/main/evals_inspectai/e2e/document_structure) |
+| **Figures & Tables Check** | Verifies that every figure and table has a title, is consistently numbered, is referenced in the body text, and that every body-text reference resolves to an actual figure or table in the document. `#experimental` | [eval](https://github.com/agencyenterprise/draft-detective/tree/main/evals_inspectai/e2e/figures_tables_check) |
 
 ### Citation Check
 
 | Analysis Type | Description | Eval |
 |:---|:---|:---:|
-| **Reference Error Checker** | Uses web search to check whether each reference is findable online and whether the author, title, year, and publisher match public sources — useful for catching reference typos or hallucinated citations. `#web_search` | [eval](https://github.com/agencyenterprise/ai-reviewer/tree/main/evals_inspectai/e2e/reference_validation) |
+| **Reference Error Checker** | Uses web search to check whether each reference is findable online and whether the author, title, year, and publisher match public sources — useful for catching reference typos or hallucinated citations. `#web_search` | [eval](https://github.com/agencyenterprise/draft-detective/tree/main/evals_inspectai/e2e/reference_validation) |
 
 ### Substantive Review
 
 | Analysis Type | Description | Eval |
 |:---|:---|:---:|
-| **Claim Reference Validation** | Validates claims against supporting documents using retrieval-augmented generation (RAG). Retrieves relevant passages from uploaded reference PDFs and returns a verdict for each claim: supported, partially supported, unsupported, or unverifiable. `#full_text_refs` | [evals](https://github.com/agencyenterprise/ai-reviewer/tree/main/evals_inspectai) |
+| **Claim Reference Validation** | Validates claims against supporting documents using retrieval-augmented generation (RAG). Retrieves relevant passages from uploaded reference PDFs and returns a verdict for each claim: supported, partially supported, unsupported, or unverifiable. `#full_text_refs` | [evals](https://github.com/agencyenterprise/draft-detective/tree/main/evals_inspectai) |
 | **Internal Inference Validation** | Analyzes the full document for invalid inferences, identifying logical fallacies, unsupported conclusions, and faulty reasoning. Each finding includes the key sentence, an analysis of the argument, and a suggested correction. | |
 | **Methodological Alignment** | Compares the methodology used in the document against typical methods in the field, using web search to gather field context and highlight gaps or risks. `#web_search` | |
 | **Reproducibility Check** | Extracts the document's main results and assesses their reproducibility — returning a structured list of findings (figures, tables, equations, key text) each with a reproducibility classification and rationale. | |
@@ -88,14 +88,14 @@ for details.
 | Analysis Type | Description | Eval |
 |:---|:---|:---:|
 | **Literature Review** | Searches the web for relevant academic sources related to your document's claims that you may not have cited, noting for each whether it supports or conflicts with your work. `#experimental` `#web_search` | |
-| **Citation Suggester** | Identifies claims that would benefit from additional citations and recommends specific references from your uploaded supporting documents. Can be paired with Literature Review to suggest newly discovered sources. `#experimental` `#web_search` `#full_text_refs` | [evals](https://github.com/agencyenterprise/ai-reviewer/tree/main/evals_inspectai) |
+| **Citation Suggester** | Identifies claims that would benefit from additional citations and recommends specific references from your uploaded supporting documents. Can be paired with Literature Review to suggest newly discovered sources. `#experimental` `#web_search` `#full_text_refs` | [evals](https://github.com/agencyenterprise/draft-detective/tree/main/evals_inspectai) |
 | **Live Reports** | Analyzes claims against sources published after the document's date, identifying findings that may need updating in light of newer evidence and generating a consolidated addendum. `#experimental` `#web_search` | |
 
 ---
 
 ## Source Code
 
-The source code is available on [GitHub](https://github.com/agencyenterprise/ai-reviewer).
+The source code is available on [GitHub](https://github.com/agencyenterprise/draft-detective).
 """
 
 ABOUT_PAGE_DEFAULTS = [

--- a/lib/services/docx/manipulator.py
+++ b/lib/services/docx/manipulator.py
@@ -129,7 +129,7 @@ class DocxComment(BaseModel):
             return SEVERITY_AUTHORS.get(
                 self.severity, SEVERITY_AUTHORS[CommentSeverity.NONE]
             )[0]
-        return "AI Reviewer"
+        return "Draft Detective"
 
     def get_initials(self) -> str:
         """Get initials for the comment author."""
@@ -294,7 +294,7 @@ class DocxManipulatorService:
                     wrap_paragraph_with_content_control(
                         paragraph=paragraph,
                         tag_value=f"{ISSUE_MARKER_TAG}:{paragraph_index}",
-                        title=f"{len(paragraph_issues)} AI Reviewer Issues",
+                        title=f"{len(paragraph_issues)} Draft Detective Issues",
                         color_hex=highlight_color,
                     )
             else:
@@ -376,7 +376,7 @@ class DocxManipulatorService:
                 full_comment_text = comment.comment_text
                 if comment.share_link:
                     full_comment_text += (
-                        f"\n\n🔗 View in AI Reviewer: {comment.share_link}"
+                        f"\n\n🔗 View in Draft Detective: {comment.share_link}"
                     )
 
                 self._add_comment_to_paragraph(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "ai-reviewer"
+name = "draft-detective"
 version = "0.1.0"
 description = "AI-powered peer-review document analysis"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -9,123 +9,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "ai-reviewer"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "aiofiles" },
-    { name = "alembic" },
-    { name = "alembic-postgresql-enum" },
-    { name = "black" },
-    { name = "cryptography" },
-    { name = "deepagents" },
-    { name = "deepdiff", extra = ["optimize"] },
-    { name = "dotenv" },
-    { name = "fastapi", extra = ["standard"] },
-    { name = "fastmcp", extra = ["tasks"] },
-    { name = "httpx" },
-    { name = "inspect-ai" },
-    { name = "langchain" },
-    { name = "langchain-anthropic" },
-    { name = "langchain-google-genai" },
-    { name = "langchain-openai" },
-    { name = "langchain-postgres" },
-    { name = "langchain-text-splitters" },
-    { name = "langfuse" },
-    { name = "langgraph" },
-    { name = "langgraph-checkpoint-postgres" },
-    { name = "markitdown", extra = ["docx", "pdf", "pptx", "xls", "xlsx"] },
-    { name = "mypy" },
-    { name = "nest-asyncio" },
-    { name = "nltk" },
-    { name = "numpy" },
-    { name = "openai" },
-    { name = "pgvector" },
-    { name = "psycopg", extra = ["binary", "pool"] },
-    { name = "psycopg2-binary" },
-    { name = "pyjwt" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-repeat" },
-    { name = "pytest-xdist" },
-    { name = "python-docx" },
-    { name = "python-magic" },
-    { name = "pyyaml" },
-    { name = "rapidfuzz" },
-    { name = "rich" },
-    { name = "sqlalchemy" },
-    { name = "sqlmodel" },
-    { name = "tabulate" },
-    { name = "textblob" },
-    { name = "tuspyserver" },
-    { name = "xxhash" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "lxml-stubs" },
-    { name = "types-aiofiles" },
-    { name = "types-pyyaml" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiofiles", specifier = ">=25.1.0" },
-    { name = "alembic", specifier = ">=1.14.0" },
-    { name = "alembic-postgresql-enum", specifier = ">=1.8.0" },
-    { name = "black", specifier = ">=25.1.0" },
-    { name = "cryptography", specifier = ">=46.0.4" },
-    { name = "deepagents", specifier = ">=0.4.8" },
-    { name = "deepdiff", extras = ["optimize"], specifier = ">=8.6.1" },
-    { name = "dotenv", specifier = ">=0.9.9" },
-    { name = "fastapi", extras = ["standard"], specifier = ">=0.120.2" },
-    { name = "fastmcp", extras = ["tasks"], specifier = ">=3.2.0" },
-    { name = "httpx", specifier = ">=0.28.1" },
-    { name = "inspect-ai", specifier = ">=0.3.200" },
-    { name = "langchain", specifier = ">=1.2.15" },
-    { name = "langchain-anthropic", specifier = ">=1.4.0" },
-    { name = "langchain-google-genai", specifier = ">=4.2.1" },
-    { name = "langchain-openai", specifier = ">=1.1.14" },
-    { name = "langchain-postgres", specifier = ">=0.0.17" },
-    { name = "langchain-text-splitters", specifier = ">=1.1.2" },
-    { name = "langfuse", specifier = ">=4.2.0" },
-    { name = "langgraph", specifier = ">=1.1.6" },
-    { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.5" },
-    { name = "markitdown", extras = ["docx", "pdf", "pptx", "xls", "xlsx"], specifier = ">=0.1.5" },
-    { name = "mypy", specifier = ">=1.19.1" },
-    { name = "nest-asyncio", specifier = ">=1.6.0" },
-    { name = "nltk", specifier = ">=3.9.4" },
-    { name = "numpy", specifier = ">=1.24.0" },
-    { name = "openai", specifier = ">=2.26.0" },
-    { name = "pgvector", specifier = ">=0.2.5,<0.4" },
-    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.10" },
-    { name = "psycopg2-binary", specifier = ">=2.9.9" },
-    { name = "pyjwt", specifier = ">=2.10.1" },
-    { name = "pytest", specifier = ">=9.0.3" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-repeat", specifier = ">=0.9.4" },
-    { name = "pytest-xdist", specifier = ">=3.8.0" },
-    { name = "python-docx", specifier = ">=1.1.0" },
-    { name = "python-magic", specifier = ">=0.4.27" },
-    { name = "pyyaml", specifier = ">=6.0.0" },
-    { name = "rapidfuzz", specifier = ">=3.0.0" },
-    { name = "rich", specifier = ">=14.2.0" },
-    { name = "sqlalchemy", specifier = ">=2.0.25" },
-    { name = "sqlmodel", specifier = ">=0.0.24" },
-    { name = "tabulate", specifier = ">=0.9.0" },
-    { name = "textblob", specifier = ">=0.18.0" },
-    { name = "tuspyserver", specifier = ">=4.2.3" },
-    { name = "xxhash", specifier = ">=3.5.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "lxml-stubs", specifier = ">=0.5.1" },
-    { name = "types-aiofiles", specifier = ">=25.1.0.20251011" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20260408" },
-]
-
-[[package]]
 name = "aioboto3"
 version = "15.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -856,6 +739,123 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/b7/545d2c10c1fc15e48653c91efde329a790f2eecfbbf2bd16003b5db2bab0/dotenv-0.9.9-py2.py3-none-any.whl", hash = "sha256:29cf74a087b31dafdb5a446b6d7e11cbce8ed2741540e2339c69fbef92c94ce9", size = 1892, upload-time = "2025-02-19T22:15:01.647Z" },
+]
+
+[[package]]
+name = "draft-detective"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "alembic" },
+    { name = "alembic-postgresql-enum" },
+    { name = "black" },
+    { name = "cryptography" },
+    { name = "deepagents" },
+    { name = "deepdiff", extra = ["optimize"] },
+    { name = "dotenv" },
+    { name = "fastapi", extra = ["standard"] },
+    { name = "fastmcp", extra = ["tasks"] },
+    { name = "httpx" },
+    { name = "inspect-ai" },
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-google-genai" },
+    { name = "langchain-openai" },
+    { name = "langchain-postgres" },
+    { name = "langchain-text-splitters" },
+    { name = "langfuse" },
+    { name = "langgraph" },
+    { name = "langgraph-checkpoint-postgres" },
+    { name = "markitdown", extra = ["docx", "pdf", "pptx", "xls", "xlsx"] },
+    { name = "mypy" },
+    { name = "nest-asyncio" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "openai" },
+    { name = "pgvector" },
+    { name = "psycopg", extra = ["binary", "pool"] },
+    { name = "psycopg2-binary" },
+    { name = "pyjwt" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-repeat" },
+    { name = "pytest-xdist" },
+    { name = "python-docx" },
+    { name = "python-magic" },
+    { name = "pyyaml" },
+    { name = "rapidfuzz" },
+    { name = "rich" },
+    { name = "sqlalchemy" },
+    { name = "sqlmodel" },
+    { name = "tabulate" },
+    { name = "textblob" },
+    { name = "tuspyserver" },
+    { name = "xxhash" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "lxml-stubs" },
+    { name = "types-aiofiles" },
+    { name = "types-pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofiles", specifier = ">=25.1.0" },
+    { name = "alembic", specifier = ">=1.14.0" },
+    { name = "alembic-postgresql-enum", specifier = ">=1.8.0" },
+    { name = "black", specifier = ">=25.1.0" },
+    { name = "cryptography", specifier = ">=46.0.4" },
+    { name = "deepagents", specifier = ">=0.4.8" },
+    { name = "deepdiff", extras = ["optimize"], specifier = ">=8.6.1" },
+    { name = "dotenv", specifier = ">=0.9.9" },
+    { name = "fastapi", extras = ["standard"], specifier = ">=0.120.2" },
+    { name = "fastmcp", extras = ["tasks"], specifier = ">=3.2.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "inspect-ai", specifier = ">=0.3.200" },
+    { name = "langchain", specifier = ">=1.2.15" },
+    { name = "langchain-anthropic", specifier = ">=1.4.0" },
+    { name = "langchain-google-genai", specifier = ">=4.2.1" },
+    { name = "langchain-openai", specifier = ">=1.1.14" },
+    { name = "langchain-postgres", specifier = ">=0.0.17" },
+    { name = "langchain-text-splitters", specifier = ">=1.1.2" },
+    { name = "langfuse", specifier = ">=4.2.0" },
+    { name = "langgraph", specifier = ">=1.1.6" },
+    { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.5" },
+    { name = "markitdown", extras = ["docx", "pdf", "pptx", "xls", "xlsx"], specifier = ">=0.1.5" },
+    { name = "mypy", specifier = ">=1.19.1" },
+    { name = "nest-asyncio", specifier = ">=1.6.0" },
+    { name = "nltk", specifier = ">=3.9.4" },
+    { name = "numpy", specifier = ">=1.24.0" },
+    { name = "openai", specifier = ">=2.26.0" },
+    { name = "pgvector", specifier = ">=0.2.5,<0.4" },
+    { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.10" },
+    { name = "psycopg2-binary", specifier = ">=2.9.9" },
+    { name = "pyjwt", specifier = ">=2.10.1" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-repeat", specifier = ">=0.9.4" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "python-docx", specifier = ">=1.1.0" },
+    { name = "python-magic", specifier = ">=0.4.27" },
+    { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "rapidfuzz", specifier = ">=3.0.0" },
+    { name = "rich", specifier = ">=14.2.0" },
+    { name = "sqlalchemy", specifier = ">=2.0.25" },
+    { name = "sqlmodel", specifier = ">=0.0.24" },
+    { name = "tabulate", specifier = ">=0.9.0" },
+    { name = "textblob", specifier = ">=0.18.0" },
+    { name = "tuspyserver", specifier = ">=4.2.3" },
+    { name = "xxhash", specifier = ">=3.5.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "lxml-stubs", specifier = ">=0.5.1" },
+    { name = "types-aiofiles", specifier = ">=25.1.0.20251011" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20260408" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Renames the project from "AI Reviewer" to "Draft Detective" across user-facing labels, documentation, package names, and GitHub URLs.

## Motivation

Project rebrand. This pass intentionally scopes only to safe-to-change surfaces — infrastructure identifiers and historical records are out of scope to avoid breaking existing tokens, deploys, and document markers.

## What's Changed

### Backend
- `pyproject.toml` — package name → `draft-detective`
- `lib/api/mcp/instance.py` — MCP server label `"AI Reviewer / Draft Detective"` → `"Draft Detective"`
- `lib/services/docx/manipulator.py` — DOCX comment author, group title, "View in Draft Detective" link text
- `lib/config_keys/about_page.py` — GitHub URLs updated to `agencyenterprise/draft-detective`
- `evals_inspectai/common/api_client.py` — module docstring + `DEFAULT_USER_EMAIL` (`eval@draft-detective.local`)
- `uv.lock` — regenerated after package rename

### Frontend
- `frontend/package.json` — package name → `draft-detective`, repo URL updated

### Docs / config
- `README.md`, `DEVELOPMENT.md`, `docs/index.md`, `docs/railway-deployment.md`, `k8s/README.md`, `addin/README.md` — title and intro lines updated
- `addin/manifest.xml`, `manifest-template.xml`, `manifest-dev.xml`, `manifest-dev.local.xml` — Office add-in `DisplayName`, `ProviderName`, descriptions, button labels, tooltips

## Risks and Mitigations

**Out of scope (intentionally not changed):**
- JWT issuer/audience (`ai-reviewer` / `ai-reviewer-api`) in `lib/api/auth.py`, `lib/api/mcp/helpers.py`, `frontend/auth.ts`, tests, evals — changing these would invalidate all existing tokens. Should be done in a coordinated follow-up.
- Container/image names, K8s namespaces, Railway service refs, CI image tags — infrastructure identifiers; require deploy coordination.
- Office add-in document property keys (`AIReviewer_*`) in `frontend/lib/addin/office-utils.ts` — would orphan markers in existing user documents.
- `CHANGELOG.md`, demo video script, `tests/evals/data/README.md` — historical records.
- Add-in manifest icon/source URLs pointing to `ai-reviewer-app-production.up.railway.app` — pinned to current Railway domain; should follow when the Railway service is renamed.

**Verification:** `uv run mypy` clean on all touched Python files; `uv sync` succeeded with the new package name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)