### PR TITLE
feat(workflow-runs): show estimated cost per analysis

### DIFF
--- a/frontend/components/results/tabs/analyses-tab.tsx
+++ b/frontend/components/results/tabs/analyses-tab.tsx
@@ -13,6 +13,7 @@ import { StatusIndicator } from '@/components/ui/status-indicator';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { StartWorkflowButton } from '@/components/workflows/start-workflow-button';
 import { WorkflowConfigDialog, WorkflowConfigFormValues } from '@/components/workflows/workflow-config-dialog';
+import { WorkflowRunCost } from '@/components/workflows/workflow-run-cost';
 import { WorkflowRunHistory } from '@/components/workflows/workflow-run-history';
 import { useShare } from '@/context/share-context';
 import { ProjectDetailed, startMultipleWorkflowsApiWorkflowsStartMultiplePost } from '@/lib/generated-api';
@@ -142,10 +143,13 @@ export function AnalysesTab({
                   <span className="font-medium">Status:</span>
                   <StatusIndicator status={getDisplayStatus(selectedWorkflowRun)} />
                 </div>
-                <WorkflowDuration run={selectedWorkflowRun.run} />
                 <div>
                   Last updated {formatDistanceToNow(selectedWorkflowRun.run.last_updated_at, { addSuffix: true })}
                 </div>
+                <WorkflowDuration run={selectedWorkflowRun.run} />
+                {selectedWorkflowRun.cost && (
+                  <WorkflowRunCost key={selectedWorkflowRun.run.id} cost={selectedWorkflowRun.cost} />
+                )}
               </div>
             </div>
             <div className="border-t pt-4 space-y-4">

--- a/frontend/components/workflows/workflow-run-cost.tsx
+++ b/frontend/components/workflows/workflow-run-cost.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { CostBreakdown } from '@/lib/generated-api';
+import { cn } from '@/lib/utils';
+
+interface WorkflowRunCostProps {
+  cost: CostBreakdown | null | undefined;
+  className?: string;
+  /** Hide the "Cost:" label prefix (useful in compact contexts like history items). */
+  compact?: boolean;
+}
+
+function formatUsd(value: number | string | null | undefined): string {
+  const n = typeof value === 'string' ? parseFloat(value) : (value ?? 0);
+  if (n === 0) return '$0.0000';
+  if (n < 0.0001) return `<$0.0001`;
+  return `$${n.toFixed(4)}`;
+}
+
+function formatTokens(n: number): string {
+  return n.toLocaleString();
+}
+
+export function WorkflowRunCost({ cost, className, compact }: WorkflowRunCostProps) {
+  if (!cost) return null;
+
+  const total = Number(cost.total_cost_usd ?? 0);
+  const inputTokens = cost.total_input_tokens ?? 0;
+  const outputTokens = cost.total_output_tokens ?? 0;
+  const cacheReadTokens = cost.total_cache_read_tokens ?? 0;
+  const byModel = cost.by_model ?? {};
+  const totalTokens = inputTokens + outputTokens + cacheReadTokens;
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>
+          <span className={cn('inline-flex items-center gap-1 cursor-help', className)}>
+            {!compact && <span className="font-medium">Cost:</span>}
+            <span>{formatUsd(total)}</span>
+          </span>
+        </TooltipPrimitive.Trigger>
+        <TooltipPrimitive.Portal>
+          <TooltipPrimitive.Content
+            sideOffset={4}
+            className="z-50 max-w-md p-3 bg-white text-foreground border rounded-md shadow-md animate-in fade-in-0 zoom-in-95"
+          >
+            <div className="space-y-2 text-xs">
+              <div className="font-medium border-b pb-1.5 mb-1.5">
+                Total: {formatUsd(total)} · {formatTokens(totalTokens)} tokens
+              </div>
+
+              <CostRow label="Input" tokens={inputTokens} cost={cost.input_cost_usd ?? 0} />
+              <CostRow label="Output" tokens={outputTokens} cost={cost.output_cost_usd ?? 0} />
+              {cacheReadTokens > 0 && (
+                <CostRow label="Cache read" tokens={cacheReadTokens} cost={cost.cache_read_cost_usd ?? 0} />
+              )}
+
+              {Object.keys(byModel).length > 1 && (
+                <div className="pt-2 mt-2 border-t">
+                  <div className="font-medium mb-1">By model</div>
+                  {Object.entries(byModel).map(([model, breakdown]) => (
+                    <div key={model} className="flex justify-between gap-4">
+                      <span className="truncate">{model}</span>
+                      <span>{formatUsd(breakdown.total_cost_usd ?? 0)}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </TooltipPrimitive.Content>
+        </TooltipPrimitive.Portal>
+      </TooltipPrimitive.Root>
+    </TooltipProvider>
+  );
+}
+
+function CostRow({ label, tokens, cost }: { label: string; tokens: number; cost: number | string }) {
+  return (
+    <div className="flex justify-between gap-4">
+      <span className="text-muted-foreground">{label}</span>
+      <span>
+        {formatTokens(tokens)} · {formatUsd(cost)}
+      </span>
+    </div>
+  );
+}

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -1610,6 +1610,48 @@ export const ConfidenceInRecommendation = {
 export type ConfidenceInRecommendation = (typeof ConfidenceInRecommendation)[keyof typeof ConfidenceInRecommendation];
 
 /**
+ * CostBreakdown
+ *
+ * Aggregated cost across all models used in a workflow run.
+ */
+export type CostBreakdown = {
+  /**
+   * Total Cost Usd
+   */
+  total_cost_usd?: string;
+  /**
+   * Input Cost Usd
+   */
+  input_cost_usd?: string;
+  /**
+   * Output Cost Usd
+   */
+  output_cost_usd?: string;
+  /**
+   * Cache Read Cost Usd
+   */
+  cache_read_cost_usd?: string;
+  /**
+   * Total Input Tokens
+   */
+  total_input_tokens?: number;
+  /**
+   * Total Output Tokens
+   */
+  total_output_tokens?: number;
+  /**
+   * Total Cache Read Tokens
+   */
+  total_cache_read_tokens?: number;
+  /**
+   * By Model
+   */
+  by_model?: {
+    [key: string]: ModelCostBreakdown;
+  };
+};
+
+/**
  * CreateProjectRequest
  *
  * Request body for creating a project.
@@ -3497,6 +3539,42 @@ export type MethodologyComparisonResponse = {
    * List of sources cited from web search
    */
   references?: Array<ReferenceMinimal>;
+};
+
+/**
+ * ModelCostBreakdown
+ *
+ * Cost and token totals for a single model.
+ */
+export type ModelCostBreakdown = {
+  /**
+   * Input Tokens
+   */
+  input_tokens?: number;
+  /**
+   * Output Tokens
+   */
+  output_tokens?: number;
+  /**
+   * Cache Read Tokens
+   */
+  cache_read_tokens?: number;
+  /**
+   * Input Cost Usd
+   */
+  input_cost_usd?: string;
+  /**
+   * Output Cost Usd
+   */
+  output_cost_usd?: string;
+  /**
+   * Cache Read Cost Usd
+   */
+  cache_read_cost_usd?: string;
+  /**
+   * Total Cost Usd
+   */
+  total_cost_usd?: string;
 };
 
 /**
@@ -5597,6 +5675,7 @@ export type WorkflowRunDetail = {
     | Reviewer2State
     | SimpleDeepAgentState
     | null;
+  cost?: CostBreakdown | null;
 };
 
 /**

--- a/lib/services/workflow_cost/breakdown.py
+++ b/lib/services/workflow_cost/breakdown.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+from typing import Dict
+
+from pydantic import BaseModel, Field
+
+
+class UsageRecord(BaseModel):
+    """Token usage extracted from a single AIMessage."""
+
+    model_name: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+
+
+class ModelCostBreakdown(BaseModel):
+    """Cost and token totals for a single model."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    input_cost_usd: Decimal = Field(default=Decimal("0"))
+    output_cost_usd: Decimal = Field(default=Decimal("0"))
+    cache_read_cost_usd: Decimal = Field(default=Decimal("0"))
+    total_cost_usd: Decimal = Field(default=Decimal("0"))
+
+
+class CostBreakdown(BaseModel):
+    """Aggregated cost across all models used in a workflow run."""
+
+    total_cost_usd: Decimal = Field(default=Decimal("0"))
+    input_cost_usd: Decimal = Field(default=Decimal("0"))
+    output_cost_usd: Decimal = Field(default=Decimal("0"))
+    cache_read_cost_usd: Decimal = Field(default=Decimal("0"))
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    by_model: Dict[str, ModelCostBreakdown] = Field(default_factory=dict)

--- a/lib/services/workflow_cost/extractor.py
+++ b/lib/services/workflow_cost/extractor.py
@@ -1,0 +1,105 @@
+from typing import Any, List
+
+from langchain_core.messages import BaseMessage
+
+from lib.services.workflow_cost.breakdown import UsageRecord
+
+
+def _get_attr_or_key(obj: Any, key: str) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _resolve_model_name(message: Any) -> str | None:
+    """Read model name from response_metadata. Returns None if not found."""
+    response_metadata = _get_attr_or_key(message, "response_metadata") or {}
+    if not isinstance(response_metadata, dict):
+        return None
+    # Anthropic uses "model_name", OpenAI uses "model"
+    return response_metadata.get("model_name") or response_metadata.get("model")
+
+
+def _extract_record(message: Any) -> UsageRecord | None:
+    """Build a UsageRecord from a single message, or return None if no usage data."""
+    usage_metadata = _get_attr_or_key(message, "usage_metadata")
+    if not usage_metadata or not isinstance(usage_metadata, dict):
+        return None
+
+    model_name = _resolve_model_name(message)
+    if not model_name:
+        return None
+
+    input_details = usage_metadata.get("input_token_details") or {}
+    cache_read = int(input_details.get("cache_read", 0) or 0)
+
+    # On Anthropic, usage_metadata.input_tokens includes cache_read + cache_creation.
+    # Subtract cache_read so it's priced at the cached rate; any cache_creation tokens
+    # remain in input_tokens and are priced as regular input.
+    raw_input = int(usage_metadata.get("input_tokens", 0) or 0)
+    input_tokens = max(raw_input - cache_read, 0)
+    output_tokens = int(usage_metadata.get("output_tokens", 0) or 0)
+
+    return UsageRecord(
+        model_name=model_name,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read,
+    )
+
+
+def walk_state_for_usage(state: Any) -> List[UsageRecord]:
+    """Recursively walk a workflow state and collect token usage from all messages.
+
+    Handles:
+    - Live BaseMessage instances (during runtime)
+    - Serialized message dicts (loaded from checkpointer)
+    - Messages nested anywhere: top-level lists, dicts, Pydantic models
+    """
+    records: List[UsageRecord] = []
+    _walk(state, records, _seen=set())
+    return records
+
+
+def _walk(node: Any, records: List[UsageRecord], _seen: set) -> None:
+    if node is None or isinstance(node, (str, int, float, bool, bytes)):
+        return
+
+    obj_id = id(node)
+    if obj_id in _seen:
+        return
+    _seen.add(obj_id)
+
+    # Live BaseMessage
+    if isinstance(node, BaseMessage):
+        record = _extract_record(node)
+        if record is not None:
+            records.append(record)
+        return
+
+    # Serialized message dict (has usage_metadata key)
+    if isinstance(node, dict) and "usage_metadata" in node:
+        record = _extract_record(node)
+        if record is not None:
+            records.append(record)
+        # Don't return — keep walking in case there are nested message lists too
+
+    if isinstance(node, dict):
+        for value in node.values():
+            _walk(value, records, _seen)
+        return
+
+    if isinstance(node, (list, tuple, set)):
+        for item in node:
+            _walk(item, records, _seen)
+        return
+
+    # Pydantic model — iterate field values directly (preserves BaseMessage instances)
+    node_type = type(node)
+    if hasattr(node_type, "model_fields"):
+        for field_name in node_type.model_fields:
+            _walk(getattr(node, field_name, None), records, _seen)
+        return
+
+    if hasattr(node, "__dict__"):
+        _walk(vars(node), records, _seen)

--- a/lib/services/workflow_cost/pricing.py
+++ b/lib/services/workflow_cost/pricing.py
@@ -1,0 +1,156 @@
+import asyncio
+import logging
+import re
+from decimal import Decimal
+from typing import Any, Iterable, Optional
+
+from lib.services.workflow_cost.breakdown import (
+    CostBreakdown,
+    ModelCostBreakdown,
+    UsageRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+# Cached compiled (pattern, model) tuples loaded from Langfuse. None means not loaded.
+# Tests can set this directly to bypass the network fetch.
+_MODELS_CACHE: Optional[list[tuple[re.Pattern[str], Any]]] = None
+_MODELS_LOCK = asyncio.Lock()
+
+
+async def _ensure_models_loaded() -> list[tuple[re.Pattern[str], Any]]:
+    """Lazy-load and cache the Langfuse model price catalog for the process lifetime."""
+    global _MODELS_CACHE
+    cached = _MODELS_CACHE
+    if cached is not None:
+        return cached
+    async with _MODELS_LOCK:
+        cached = _MODELS_CACHE
+        if cached is not None:
+            return cached
+
+        # Imported lazily to avoid creating the Langfuse client at import time
+        # (langfuse is None when env vars are not configured).
+        from lib.config.langfuse import langfuse
+
+        if langfuse is None:
+            logger.info("Langfuse not configured; cost calculation disabled")
+            _MODELS_CACHE = []
+            return _MODELS_CACHE
+
+        models: list = []
+        page = 1
+        while True:
+            res = await langfuse.async_api.models.list(page=page, limit=100)
+            models.extend(res.data)
+            if len(models) >= res.meta.total_items:
+                break
+            page += 1
+
+        compiled: list[tuple[re.Pattern[str], Any]] = []
+        for m in models:
+            try:
+                compiled.append((re.compile(m.match_pattern), m))
+            except re.error as e:
+                logger.warning(
+                    "skipping invalid Langfuse model pattern %r: %s",
+                    m.match_pattern,
+                    e,
+                )
+        logger.info("loaded %d model price entries from Langfuse", len(compiled))
+        _MODELS_CACHE = compiled
+        return _MODELS_CACHE
+
+
+def _match_model(
+    name: str, models: list[tuple[re.Pattern[str], Any]]
+) -> Optional[Any]:
+    for pattern, model in models:
+        if pattern.fullmatch(name):
+            return model
+    return None
+
+
+def _rate(prices: dict, *keys: str) -> Decimal:
+    for k in keys:
+        price = prices.get(k)
+        if price is not None:
+            return Decimal(str(price.price))
+    return Decimal("0")
+
+
+def _cost_for_record(
+    record: UsageRecord, models: list[tuple[re.Pattern[str], Any]]
+) -> ModelCostBreakdown | None:
+    model = _match_model(record.model_name, models)
+    if model is None:
+        logger.warning(
+            "Langfuse has no pricing for model %r; skipping cost calc",
+            record.model_name,
+        )
+        return None
+
+    prices = model.prices
+    input_rate = _rate(prices, "input")
+    output_rate = _rate(prices, "output")
+    # Fall back to input rate when no cache_read price is published.
+    cache_read_rate = _rate(prices, "input_cache_read", "input_cached_tokens", "input")
+
+    input_cost = input_rate * record.input_tokens
+    output_cost = output_rate * record.output_tokens
+    cache_read_cost = cache_read_rate * record.cache_read_tokens
+
+    return ModelCostBreakdown(
+        input_tokens=record.input_tokens,
+        output_tokens=record.output_tokens,
+        cache_read_tokens=record.cache_read_tokens,
+        input_cost_usd=input_cost,
+        output_cost_usd=output_cost,
+        cache_read_cost_usd=cache_read_cost,
+        total_cost_usd=input_cost + output_cost + cache_read_cost,
+    )
+
+
+def _accumulate(target: ModelCostBreakdown, addition: ModelCostBreakdown) -> None:
+    target.input_tokens += addition.input_tokens
+    target.output_tokens += addition.output_tokens
+    target.cache_read_tokens += addition.cache_read_tokens
+    target.input_cost_usd += addition.input_cost_usd
+    target.output_cost_usd += addition.output_cost_usd
+    target.cache_read_cost_usd += addition.cache_read_cost_usd
+    target.total_cost_usd += addition.total_cost_usd
+
+
+async def compute_cost(records: Iterable[UsageRecord]) -> CostBreakdown | None:
+    """Aggregate UsageRecords into a CostBreakdown using Langfuse pricing.
+
+    Returns None when no records can be priced (no input or all models unknown).
+    """
+    records_list = list(records)
+    if not records_list:
+        return None
+
+    models = await _ensure_models_loaded()
+    if not models:
+        return None
+
+    breakdown = CostBreakdown()
+    has_any = False
+    for record in records_list:
+        per_model = _cost_for_record(record, models)
+        if per_model is None:
+            continue
+        has_any = True
+
+        bucket = breakdown.by_model.setdefault(record.model_name, ModelCostBreakdown())
+        _accumulate(bucket, per_model)
+
+        breakdown.total_input_tokens += per_model.input_tokens
+        breakdown.total_output_tokens += per_model.output_tokens
+        breakdown.total_cache_read_tokens += per_model.cache_read_tokens
+        breakdown.input_cost_usd += per_model.input_cost_usd
+        breakdown.output_cost_usd += per_model.output_cost_usd
+        breakdown.cache_read_cost_usd += per_model.cache_read_cost_usd
+        breakdown.total_cost_usd += per_model.total_cost_usd
+
+    return breakdown if has_any else None

--- a/lib/services/workflow_runs.py
+++ b/lib/services/workflow_runs.py
@@ -20,6 +20,9 @@ from lib.models.workflow_run import (
     WorkflowRunStatus,
     WorkflowRunType,
 )
+from lib.services.workflow_cost.breakdown import CostBreakdown
+from lib.services.workflow_cost.extractor import walk_state_for_usage
+from lib.services.workflow_cost.pricing import compute_cost
 from lib.services.workflow_progress import cancel_workflow_progress
 from lib.workflows.checkpointer import get_checkpointer
 from lib.workflows.dependency_resolver import get_required_dependents
@@ -33,6 +36,37 @@ logger = logging.getLogger(__name__)
 class WorkflowRunDetail(BaseModel):
     run: WorkflowRun
     state: WorkflowState | None
+    cost: CostBreakdown | None = None
+
+
+async def _compute_cost_for_state(
+    state: WorkflowState | None,
+) -> CostBreakdown | None:
+    if state is None:
+        return None
+    try:
+        records = walk_state_for_usage(state)
+        if not records:
+            return None
+        return await compute_cost(records)
+    except Exception as e:  # pragma: no cover — never let cost calc break the response
+        logger.warning(f"Failed to compute workflow cost: {e}")
+        return None
+
+
+def _canonical_run_ids_per_thread(runs: List[WorkflowRun]) -> set[uuid.UUID]:
+    """Return the set of run IDs that are the most recent owners of their thread_id.
+
+    Multiple WorkflowRun rows can share a langgraph_thread_id (re-runs reuse threads),
+    so older runs see the latest run's state from the checkpointer — their cost would
+    be misleading. Only attribute cost to the latest run per thread.
+    """
+    latest: dict[str, WorkflowRun] = {}
+    for run in runs:
+        existing = latest.get(run.langgraph_thread_id)
+        if existing is None or run.created_at > existing.created_at:
+            latest[run.langgraph_thread_id] = run
+    return {r.id for r in latest.values()}
 
 
 def _convert_state_snapshot(
@@ -377,7 +411,13 @@ async def get_project_workflow_runs_by_type_with_details(
         ]
     )
 
-    return [WorkflowRunDetail(run=run, state=state) for run, state in zip(runs, states)]
+    canonical_ids = _canonical_run_ids_per_thread(list(runs))
+    cost_states = [s if r.id in canonical_ids else None for r, s in zip(runs, states)]
+    costs = await asyncio.gather(*[_compute_cost_for_state(s) for s in cost_states])
+    return [
+        WorkflowRunDetail(run=run, state=state, cost=cost)
+        for run, state, cost in zip(runs, states, costs)
+    ]
 
 
 async def get_project_workflow_runs(
@@ -443,9 +483,10 @@ async def get_project_workflow_runs(
         ]
     )
 
+    costs = await asyncio.gather(*[_compute_cost_for_state(s) for s in states])
     return [
-        WorkflowRunDetail(run=run, state=state)
-        for run, state in zip(visible_runs, states)
+        WorkflowRunDetail(run=run, state=state, cost=cost)
+        for run, state, cost in zip(visible_runs, states, costs)
     ]
 
 

--- a/tests/unit/services/test_workflow_cost.py
+++ b/tests/unit/services/test_workflow_cost.py
@@ -1,0 +1,213 @@
+import re
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from pydantic import BaseModel
+
+from lib.services.workflow_cost import pricing
+from lib.services.workflow_cost.extractor import walk_state_for_usage
+from lib.services.workflow_cost.pricing import compute_cost
+
+
+CLAUDE_MODEL = "claude-3-5-sonnet-20241022"
+
+
+def _fake_model(name: str, *, input_price: float, output_price: float, cache_read_price: float) -> object:
+    """Build a Langfuse-shaped model object with a regex pattern matching `name` exactly."""
+    return SimpleNamespace(
+        model_name=name,
+        match_pattern=f"(?i)^{re.escape(name)}$",
+        prices={
+            "input": SimpleNamespace(price=input_price),
+            "output": SimpleNamespace(price=output_price),
+            "input_cache_read": SimpleNamespace(price=cache_read_price),
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def _stub_models_cache(monkeypatch):
+    """Bypass the Langfuse network fetch by populating the price cache with fixtures."""
+    fakes = [
+        _fake_model(CLAUDE_MODEL, input_price=3e-6, output_price=1.5e-5, cache_read_price=3e-7),
+        _fake_model("gpt-4o-2024-08-06", input_price=2.5e-6, output_price=1e-5, cache_read_price=1.25e-6),
+    ]
+    compiled = [(re.compile(m.match_pattern), m) for m in fakes]
+    monkeypatch.setattr(pricing, "_MODELS_CACHE", compiled)
+    yield
+    monkeypatch.setattr(pricing, "_MODELS_CACHE", None)
+
+
+def _ai_message(
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_read: int = 0,
+    model: str = CLAUDE_MODEL,
+) -> AIMessage:
+    # On Anthropic, usage_metadata.input_tokens *includes* cache reads, so the
+    # test fixture mirrors that.
+    return AIMessage(
+        content="",
+        response_metadata={"model_name": model},
+        usage_metadata={
+            "input_tokens": input_tokens + cache_read,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + cache_read + output_tokens,
+            "input_token_details": {"cache_read": cache_read},
+        },
+    )
+
+
+def test_extracts_usage_from_flat_message_list():
+    state = {
+        "messages": [
+            HumanMessage(content="hi"),
+            _ai_message(input_tokens=100, output_tokens=50),
+        ]
+    }
+    records = walk_state_for_usage(state)
+    assert len(records) == 1
+    assert records[0].input_tokens == 100
+    assert records[0].output_tokens == 50
+    assert records[0].model_name == CLAUDE_MODEL
+
+
+def test_extracts_usage_from_serialized_dict_form():
+    """State loaded from checkpointer may have messages as plain dicts."""
+    state = {
+        "messages": [
+            {
+                "type": "ai",
+                "content": "",
+                "response_metadata": {"model_name": CLAUDE_MODEL},
+                "usage_metadata": {
+                    "input_tokens": 200,
+                    "output_tokens": 80,
+                    "input_token_details": {"cache_read": 0, "cache_creation": 0},
+                },
+            }
+        ]
+    }
+    records = walk_state_for_usage(state)
+    assert len(records) == 1
+    assert records[0].input_tokens == 200
+    assert records[0].output_tokens == 80
+
+
+def test_walks_nested_messages_in_substate():
+    state = {
+        "validators": {
+            "claim_1": {"messages": [_ai_message(input_tokens=10, output_tokens=5)]},
+            "claim_2": {"messages": [_ai_message(input_tokens=20, output_tokens=8)]},
+        }
+    }
+    records = walk_state_for_usage(state)
+    assert len(records) == 2
+    assert sum(r.input_tokens for r in records) == 30
+    assert sum(r.output_tokens for r in records) == 13
+
+
+def test_skips_messages_without_usage_metadata():
+    state = {"messages": [HumanMessage(content="hi"), AIMessage(content="hello")]}
+    assert walk_state_for_usage(state) == []
+
+
+def test_skips_message_with_unknown_model():
+    """AIMessage without response_metadata.model_name is skipped (no model to price)."""
+    msg = AIMessage(
+        content="",
+        usage_metadata={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "input_token_details": {},
+        },
+    )
+    assert walk_state_for_usage({"messages": [msg]}) == []
+
+
+def test_walks_pydantic_state_model():
+    class State(BaseModel):
+        messages: list = []
+        other: dict = {}
+
+    state = State(
+        messages=[_ai_message(input_tokens=42, output_tokens=7)],
+        other={"messages": [_ai_message(input_tokens=8, output_tokens=3)]},
+    )
+    records = walk_state_for_usage(state)
+    assert len(records) == 2
+    assert sum(r.input_tokens for r in records) == 50
+
+
+def test_separates_cache_read_from_input():
+    msg = _ai_message(input_tokens=100, output_tokens=20, cache_read=500)
+    records = walk_state_for_usage({"messages": [msg]})
+    assert len(records) == 1
+    r = records[0]
+    assert r.input_tokens == 100
+    assert r.cache_read_tokens == 500
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_returns_none_when_empty():
+    assert await compute_cost([]) is None
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_known_model():
+    state = {
+        "messages": [
+            _ai_message(input_tokens=1000, output_tokens=500, cache_read=2000)
+        ]
+    }
+    records = walk_state_for_usage(state)
+    breakdown = await compute_cost(records)
+    assert breakdown is not None
+    expected_input = Decimal("3e-6") * 1000
+    expected_output = Decimal("1.5e-5") * 500
+    expected_cache_read = Decimal("3e-7") * 2000
+    expected_total = expected_input + expected_output + expected_cache_read
+    assert breakdown.total_cost_usd == expected_total
+    assert breakdown.total_input_tokens == 1000
+    assert breakdown.total_output_tokens == 500
+    assert breakdown.total_cache_read_tokens == 2000
+    assert CLAUDE_MODEL in breakdown.by_model
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_unknown_model_skipped():
+    msg = AIMessage(
+        content="",
+        response_metadata={"model_name": "made-up-model-xyz"},
+        usage_metadata={
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "total_tokens": 150,
+            "input_token_details": {},
+        },
+    )
+    records = walk_state_for_usage({"messages": [msg]})
+    assert len(records) == 1
+    assert await compute_cost(records) is None
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_aggregates_multiple_models():
+    state = {
+        "messages": [
+            _ai_message(input_tokens=100, output_tokens=50, model=CLAUDE_MODEL),
+            _ai_message(
+                input_tokens=200, output_tokens=80, model="gpt-4o-2024-08-06"
+            ),
+        ]
+    }
+    records = walk_state_for_usage(state)
+    breakdown = await compute_cost(records)
+    assert breakdown is not None
+    assert len(breakdown.by_model) == 2
+    assert breakdown.total_input_tokens == 300
+    assert breakdown.total_output_tokens == 130


### PR DESCRIPTION
## Summary

Surfaces the estimated USD cost of running each workflow in the analyses tab. The total is shown as a small text item next to status / duration / last-updated; hovering reveals a per-bucket and per-model breakdown.

[RANDZ-174](https://linear.app/ae-studio/issue/RANDZ-174/user-should-see-estimate-cost-time-to-analyze-documents)

## Motivation

Users had no visibility into how much each analysis costs to run, which is needed to forecast spend and to compare workflow variants. Token usage is already captured by LangChain on every `AIMessage` in workflow state, so we can derive cost without adding new tracking infrastructure.

## What's Changed

### Backend (`lib/services/workflow_cost/`, `lib/services/workflow_runs.py`)

- **`breakdown.py`** — Pydantic models `UsageRecord`, `ModelCostBreakdown`, `CostBreakdown` describing the API shape.
- **`extractor.py`** — `walk_state_for_usage(state)` recursively walks workflow state (Pydantic models, dicts, lists, live `BaseMessage` instances, serialized dict form) and collects `usage_metadata` from every AI message it finds. Cache-read tokens are split out of the raw input bucket so they price separately.
- **`pricing.py`** — `compute_cost(records)` is async; loads the Langfuse model catalog (`langfuse.async_api.models.list`) once per process, caches it behind an `asyncio.Lock`, and matches each record against the catalog's regex patterns. Falls back to `cost=None` when Langfuse isn't configured or the model has no pricing entry. Per-bucket prices come from each model's `prices` dict (`input`, `output`, `input_cache_read`).
- **`workflow_runs.py`** — Both `get_project_workflow_runs_by_type_with_details` and `get_project_workflow_runs` now compute cost in parallel via `asyncio.gather`. `WorkflowRunDetail` carries an optional `cost: CostBreakdown | None`. Cost is suppressed for runs whose `langgraph_thread_id` is shared with a more recent run (their checkpointed state has been overwritten, so the displayed number would be misleading).

### Frontend

- **`components/workflows/workflow-run-cost.tsx`** — New component that renders the formatted total and a hover tooltip with input / output / cache-read breakdown plus per-model rows. Uses Radix tooltip primitives directly (the shared `TooltipContent` hardcodes a primary-color arrow that clashed with the white background needed for the breakdown panel).
- **`components/results/tabs/analyses-tab.tsx`** — Renders `WorkflowRunCost` in the run header; `key={selectedWorkflowRun.run.id}` forces a remount when the user picks a different run from history.
- **`lib/generated-api/types.gen.ts`** — Regenerated via `pnpm run openapi-generate` to pick up `CostBreakdown`, `ModelCostBreakdown`, and the new `cost` field on `WorkflowRunDetail`.

### Tests

- **`tests/unit/services/test_workflow_cost.py`** — 11 unit tests covering live `BaseMessage`, serialized dicts, nested state, Pydantic model walking, missing `usage_metadata`, unknown models, cache-read token splitting, and multi-model aggregation. An autouse fixture stubs the Langfuse price cache with fake objects so tests never hit the network.

## Risks and Mitigations

- **Pricing source unavailable.** If Langfuse is down or unconfigured, `compute_cost` returns `None` and the UI hides the cost line — the workflow itself continues to function.
- **Unknown models.** Models not present in Langfuse's catalog log a warning and skip cost calc for that record (the rest of the run is still priced). Warnings are emitted every occurrence so they're noticeable in logs.
- **Process-lifetime cache.** Model prices are loaded once per process; restart the API to pick up Langfuse pricing changes. Easy to add a TTL later if needed.
- **Shared thread state.** Two `WorkflowRun` rows can share a `langgraph_thread_id` (re-runs reuse threads), which would cause both to display identical costs. The "canonical run per thread" filter prevents this — only the latest run for each thread shows cost; older ones return `None` and the UI hides the line. Fixing the underlying thread-reuse pattern in the workflow runner is out of scope for this PR.
- **Performance.** Cost is computed on read for every workflow run returned by the analyses-tab endpoint. After the first call the model cache is hot, so cost calc is just dictionary lookups + Decimal math — negligible overhead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)