### PR TITLE
feat(workflow-runs): show LLM call count and average cost

### DIFF
--- a/frontend/components/workflows/workflow-run-cost.tsx
+++ b/frontend/components/workflows/workflow-run-cost.tsx
@@ -32,6 +32,8 @@ export function WorkflowRunCost({ cost, className, compact }: WorkflowRunCostPro
   const cacheReadTokens = cost.total_cache_read_tokens ?? 0;
   const byModel = cost.by_model ?? {};
   const totalTokens = inputTokens + outputTokens + cacheReadTokens;
+  const requestCount = cost.request_count ?? 0;
+  const avgCost = requestCount > 0 ? total / requestCount : 0;
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -56,6 +58,15 @@ export function WorkflowRunCost({ cost, className, compact }: WorkflowRunCostPro
               <CostRow label="Output" tokens={outputTokens} cost={cost.output_cost_usd ?? 0} />
               {cacheReadTokens > 0 && (
                 <CostRow label="Cache read" tokens={cacheReadTokens} cost={cost.cache_read_cost_usd ?? 0} />
+              )}
+
+              {requestCount > 1 && (
+                <div className="pt-2 mt-2 border-t flex justify-between gap-4">
+                  <span className="text-muted-foreground">LLM calls</span>
+                  <span>
+                    {requestCount} · {formatUsd(avgCost)} avg
+                  </span>
+                </div>
               )}
 
               {Object.keys(byModel).length > 1 && (

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -1644,6 +1644,10 @@ export type CostBreakdown = {
    */
   total_cache_read_tokens?: number;
   /**
+   * Request Count
+   */
+  request_count?: number;
+  /**
    * By Model
    */
   by_model?: {
@@ -3575,6 +3579,10 @@ export type ModelCostBreakdown = {
    * Total Cost Usd
    */
   total_cost_usd?: string;
+  /**
+   * Request Count
+   */
+  request_count?: number;
 };
 
 /**
@@ -5638,6 +5646,14 @@ export type WorkflowRun = {
    * Short human-readable detail of the failure. Populated only when status == FAILED.
    */
   failure_message?: string | null;
+  /**
+   * State Json
+   *
+   * Serialized WorkflowState; written after every node yield. Schema is the WorkflowState subclass for `type`.
+   */
+  state_json?: {
+    [key: string]: unknown;
+  } | null;
 };
 
 /**

--- a/lib/services/workflow_cost/breakdown.py
+++ b/lib/services/workflow_cost/breakdown.py
@@ -23,6 +23,7 @@ class ModelCostBreakdown(BaseModel):
     output_cost_usd: Decimal = Field(default=Decimal("0"))
     cache_read_cost_usd: Decimal = Field(default=Decimal("0"))
     total_cost_usd: Decimal = Field(default=Decimal("0"))
+    request_count: int = 0
 
 
 class CostBreakdown(BaseModel):
@@ -35,4 +36,5 @@ class CostBreakdown(BaseModel):
     total_input_tokens: int = 0
     total_output_tokens: int = 0
     total_cache_read_tokens: int = 0
+    request_count: int = 0
     by_model: Dict[str, ModelCostBreakdown] = Field(default_factory=dict)

--- a/lib/services/workflow_cost/pricing.py
+++ b/lib/services/workflow_cost/pricing.py
@@ -144,6 +144,7 @@ async def compute_cost(records: Iterable[UsageRecord]) -> CostBreakdown | None:
 
         bucket = breakdown.by_model.setdefault(record.model_name, ModelCostBreakdown())
         _accumulate(bucket, per_model)
+        bucket.request_count += 1
 
         breakdown.total_input_tokens += per_model.input_tokens
         breakdown.total_output_tokens += per_model.output_tokens
@@ -152,5 +153,6 @@ async def compute_cost(records: Iterable[UsageRecord]) -> CostBreakdown | None:
         breakdown.output_cost_usd += per_model.output_cost_usd
         breakdown.cache_read_cost_usd += per_model.cache_read_cost_usd
         breakdown.total_cost_usd += per_model.total_cost_usd
+        breakdown.request_count += 1
 
     return breakdown if has_any else None

--- a/tests/unit/services/test_workflow_cost.py
+++ b/tests/unit/services/test_workflow_cost.py
@@ -211,3 +211,6 @@ async def test_compute_cost_aggregates_multiple_models():
     assert len(breakdown.by_model) == 2
     assert breakdown.total_input_tokens == 300
     assert breakdown.total_output_tokens == 130
+    assert breakdown.request_count == 2
+    assert breakdown.by_model[CLAUDE_MODEL].request_count == 1
+    assert breakdown.by_model["gpt-4o-2024-08-06"].request_count == 1


### PR DESCRIPTION
## Summary

Adds an "LLM calls" row to the workflow-run cost tooltip that shows the total number of priced LLM calls and the average cost per call when a run made more than one. Useful for fan-out workflows (e.g. the reference validator) where a single run can issue hundreds of LLM requests.

## Motivation

The cost tooltip already accumulated USD across all messages in a run, but users had no signal for how many LLM calls drove that total or what the per-call cost was. For workflows like the reference validator (deep agent + web_search + structured output) the call count is much higher than the unit-of-work count, and surfacing both helps reason about cost.

The label is "LLM calls" (not "Requests") to make it clear this counts model round-trips, not items processed — e.g. validating 294 references typically issues ~589 LLM calls because each reference goes through a multi-turn tool-calling loop.

## What's Changed

### Backend

- `lib/services/workflow_cost/breakdown.py` — added `request_count` to `CostBreakdown` and `ModelCostBreakdown` so it can be aggregated overall and per-model.
- `lib/services/workflow_cost/pricing.py` — increments `request_count` for each priced `UsageRecord` (skips records without pricing, matching existing cost behavior).
- `tests/unit/services/test_workflow_cost.py` — extends the multi-model test to assert `request_count` is summed correctly across the breakdown and per model.

### Frontend

- `frontend/components/workflows/workflow-run-cost.tsx` — renders an "LLM calls: N · $X avg" row in the tooltip when `request_count > 1`.
- `frontend/lib/generated-api/types.gen.ts` — regenerated types pick up the new `request_count` fields.

## Risks and Mitigations

- **Stale checkpoints**: cost is already hidden when `langgraph_thread_id` is shared with a more recent run, so the new counter inherits that safeguard.
- **Unknown models**: records with no Langfuse pricing are skipped today; they're still skipped for `request_count`, so the displayed count matches the priced subset (consistent with the dollar total).
- **Schema change**: `request_count` defaults to `0`, so older serialized states deserialize without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)