### PR TITLE
fix(document-processing): make markdown conversion resilient to per-file failures

### DIFF
--- a/lib/workflows/document_processing/nodes/convert_to_markdown.py
+++ b/lib/workflows/document_processing/nodes/convert_to_markdown.py
@@ -9,6 +9,7 @@ from lib.services.markdown_conversion import convert_file_document_to_markdown
 from lib.workflows.context import ContextSchema
 from lib.workflows.decorators import register_node
 from lib.workflows.document_processing.state import DocumentProcessingState
+from lib.workflows.models import WorkflowError
 
 logger = logging.getLogger(__name__)
 
@@ -17,59 +18,95 @@ logger = logging.getLogger(__name__)
 async def convert_to_markdown(
     state: DocumentProcessingState, runtime: Runtime[ContextSchema]
 ):
-    tasks = [
-        _convert_to_markdown_task(state.file, is_main_document=True),
-        *[
-            _convert_to_markdown_task(file, is_main_document=False)
-            for file in state.supporting_files or []
-        ],
-    ]
+    main_file = state.file
+    supporting = state.supporting_files or []
 
+    # Main file first (sequentially) — the rest of the pipeline can't proceed
+    # without it, so a failure here must abort the workflow.
+    main_result = await _convert_and_persist(main_file)
+    if isinstance(main_result, Exception):
+        logger.error(
+            f"Main document conversion failed for {main_file.file_name} "
+            f"(file_id={main_file.file_id}): {main_result}"
+        )
+        raise main_result
+    converted_main = main_result
+
+    # Supporting files run with bounded concurrency. Failures are reported
+    # per-file via WorkflowError but do not abort the workflow — downstream
+    # nodes work from whichever supporting files converted successfully.
     results, errors = await run_tasks(
-        tasks,
-        desc="Converting documents",
-        max_concurrent=10,
+        [_convert_and_persist(f) for f in supporting],
+        desc="Converting supporting documents",
+        max_concurrent=4,
     )
-    files: list[FileDocument] = [file for file in results if file is not None]
 
-    failed_errors = [e for e in errors if e is not None]
-    if failed_errors:
-        error_msg = f"Failed to convert {len(failed_errors)} document(s)"
-        logger.error(f"{error_msg}: {failed_errors[0]}")
-        raise failed_errors[0]
+    converted_supporting: list[FileDocument] = []
+    workflow_errors: list[WorkflowError] = []
+    workflow_run_id = runtime.context.workflow_run_id
 
-    [file, *supporting_files] = files
+    for original, result, error in zip(supporting, results, errors):
+        # `_convert_and_persist` never raises — it returns the exception so
+        # `run_tasks` produces a result, never an entry in `errors`. We still
+        # check `error` defensively in case run_tasks itself produced one.
+        failure: BaseException | None = error
+        if isinstance(result, Exception):
+            failure = result
+        elif isinstance(result, FileDocument):
+            converted_supporting.append(result)
 
-    # Persist markdown artifacts to database for caching
-    await _persist_markdown_artifacts(files)
+        if failure is not None:
+            workflow_errors.append(
+                WorkflowError(
+                    task_name="convert_to_markdown",
+                    error=(
+                        f"Failed to convert supporting file {original.file_name} "
+                        f"(file_id={original.file_id}): {failure}"
+                    ),
+                    workflow_run_id=workflow_run_id,
+                )
+            )
 
-    return {"file": file, "supporting_files": supporting_files}
+    if workflow_errors:
+        logger.warning(
+            f"{len(workflow_errors)}/{len(supporting)} supporting documents "
+            f"failed to convert; continuing with {len(converted_supporting)} "
+            f"successful conversions"
+        )
+
+    return {
+        "file": converted_main,
+        "supporting_files": converted_supporting,
+        "errors": workflow_errors,
+    }
 
 
-async def _persist_markdown_artifacts(files: list[FileDocument]) -> None:
+async def _convert_and_persist(
+    file_document: FileDocument,
+) -> FileDocument | Exception:
+    """Convert a single file to markdown and cache the result in the DB.
+
+    Persisting incrementally (rather than waiting for every file in the batch
+    to finish) means a worker restart mid-conversion doesn't throw away the
+    work already completed: `convert_file_document_to_markdown` short-circuits
+    when the cached markdown is already present.
+
+    Returns the converted FileDocument on success, or the exception on failure.
+    Returning instead of raising lets the caller report per-file errors
+    without aborting the rest of the batch.
     """
-    Persist markdown artifacts to the files table for all converted documents.
+    try:
+        converted = await convert_file_document_to_markdown(file_document)
+    except Exception as exc:
+        logger.error(
+            f"Markdown conversion failed for {file_document.file_name} "
+            f"(file_id={file_document.file_id}): {exc}",
+            exc_info=True,
+        )
+        return exc
 
-    Args:
-        file: The main document with markdown content
-        supporting_files: List of supporting documents with markdown content
-    """
-
-    for file in files:
-        await update_file_artifacts(file_id=file.file_id, markdown=file.markdown)
-
-
-async def _convert_to_markdown_task(
-    file_document: FileDocument, is_main_document: bool = True
-) -> FileDocument:
-    """
-    Convert document to markdown.
-
-    Args:
-        file_document: The document to convert
-        is_main_document: Whether this is the main document (unused, kept for interface consistency)
-
-    Returns:
-        FileDocument with converted markdown content and metadata
-    """
-    return await convert_file_document_to_markdown(file_document)
+    if converted.markdown:
+        await update_file_artifacts(
+            file_id=converted.file_id, markdown=converted.markdown
+        )
+    return converted


### PR DESCRIPTION
## Summary

When a single supporting document fails markdown conversion, the entire `document_processing` workflow currently aborts (raise on the first error in `convert_to_markdown`), wasting all the conversions that had already succeeded in the same batch. Reported on dev by Dulani after several runs got stuck partway through a 43-reference report.

This PR makes the conversion node resilient: only the **main** document is allowed to hard-fail the workflow; supporting-file errors are collected per-file and the run continues with the files that did convert.

## Motivation

- Dulani's runs on dev kept failing visibly around reference 16/17 of 43. Two failed `document_processing` runs in the DB confirmed `failure_reason=NO_HEARTBEAT` (worker died, likely OOM), and `workflow_progress` showed the node stalling at 24/43.
- Even when a single file *does* fail with a clean Python exception, the node's all-or-nothing `raise failed_errors[0]` throws away every successful conversion in the same batch — every retry restarts from scratch.
- Lowering parallel pressure on the converter helps avoid the OOM root cause; resilient per-file handling means a single bad reference no longer torpedoes the entire run.

## What's Changed

### Backend
- **`lib/workflows/document_processing/nodes/convert_to_markdown.py`** — rewritten:
  - Main file converts first, sequentially. A failure here still raises (downstream pipeline can't run without the main doc).
  - Supporting files run in parallel via `run_tasks` with `max_concurrent` reduced from `10` → `4` to relieve memory pressure during vision-OCR-heavy batches.
  - New helper `_convert_and_persist` converts one file, persists its markdown to the DB *immediately* via `update_file_artifacts`, and **returns** any exception instead of raising. Incremental persistence means a worker restart resumes from already-converted files (`convert_file_document_to_markdown` short-circuits on cached markdown).
  - Per-file failures are converted into `WorkflowError` entries on `state.errors` with `task_name=\"convert_to_markdown\"` and a message including `file_name` + `file_id`, so the share/UI can surface which references failed (follow-up FE work).
  - Removed the now-redundant `_persist_markdown_artifacts` and `_convert_to_markdown_task` helpers.

### Frontend
- None.

## Risks and Mitigations

- **Downstream nodes now receive a possibly-shorter `supporting_files` list.** Audited callers — `file_artifacts_service.get_supporting_files()` already prefers the DB cache and falls back to workflow state, so a partial list is consistent with how cached/uncached mixtures are already handled. Workflows reading `supporting_files` operate on whatever's present.
- **Main-document failure semantics unchanged.** Main file still raises and aborts the workflow, preserving today's behavior for the only case where partial success is unsafe.
- **No DB schema or API contract changes.** Errors flow through the existing `WorkflowError` channel.
- **Concurrency drop (10 → 4)** slightly increases wall-clock time for large batches. Trade-off is fewer OOM-driven worker deaths; net throughput should improve given the previous failure mode wasted entire 10-min runs.
- mypy clean (`lib/workflows/document_processing/`). No tests reference the removed internal helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)