### PR TITLE
chore(workflows): update beta flags for claim ref validation and recommendation check

### DIFF
--- a/lib/workflows/claim_reference_validation_v2/manifest.py
+++ b/lib/workflows/claim_reference_validation_v2/manifest.py
@@ -108,7 +108,7 @@ class ClaimReferenceValidationV2Manifest(
         "be verified."
     )
     needs_web_search = False
-    is_experimental = True
+    is_experimental = False
     required_dependencies = [
         WorkflowRunType.DOCUMENT_PROCESSING,
         WorkflowRunType.REFERENCE_FILE_MATCHING,

--- a/lib/workflows/recommendation_check/manifest.py
+++ b/lib/workflows/recommendation_check/manifest.py
@@ -113,6 +113,6 @@ class RecommendationCheckManifest(SimpleDeepAgentManifest):
         "where the evidence is weak, indirect, or contradictory."
     )
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
-    is_experimental = False
+    is_experimental = True
 
     user_prompt = _USER_PROMPT


### PR DESCRIPTION
## Summary
- Remove beta flag from Claim Reference Validation V2
- Mark Recommendation Check as beta

## Motivation
Claim Reference Validation is mature enough to no longer be considered beta. Recommendation Check is a newer workflow that warrants the beta label.

## What's Changed

### Backend
- `lib/workflows/claim_reference_validation_v2/manifest.py` — set `is_experimental = False`
- `lib/workflows/recommendation_check/manifest.py` — set `is_experimental = True`

## Risks and Mitigations
Low risk. These are display-only flags that control whether a "Beta" badge appears in the UI. No functional behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)