### PR TITLE
feat: add Tavily search alongside OpenAI web_search in literature agents

### DIFF
--- a/lib/agents/citation_suggester.py
+++ b/lib/agents/citation_suggester.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from langchain.agents import create_agent
 from langchain_core.messages import HumanMessage
@@ -194,7 +194,7 @@ class CitationSuggesterAgent(LangChainAgent):
     ) -> CitationSuggestionResponse:
         prompt = _citation_suggester_agent_prompt.invoke(prompt_kwargs)
 
-        tools: list = [{"type": "web_search"}]
+        tools: list[Any] = [{"type": "web_search"}]
         tavily_tool = get_tavily_tool()
         if tavily_tool is not None:
             tools.append(tavily_tool)

--- a/lib/agents/citation_suggester.py
+++ b/lib/agents/citation_suggester.py
@@ -8,6 +8,7 @@ from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
 from lib.agents.literature_review import ReferenceType
+from lib.config.env import get_tavily_tool
 from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
@@ -193,9 +194,14 @@ class CitationSuggesterAgent(LangChainAgent):
     ) -> CitationSuggestionResponse:
         prompt = _citation_suggester_agent_prompt.invoke(prompt_kwargs)
 
+        tools: list = [{"type": "web_search"}]
+        tavily_tool = get_tavily_tool()
+        if tavily_tool is not None:
+            tools.append(tavily_tool)
+
         agent = create_agent(
             self.llm,
-            [{"type": "web_search"}],
+            tools,
             context_schema=ContextSchema,
             response_format=CitationSuggestionResponse,
         )

--- a/lib/agents/evidence_weighter.py
+++ b/lib/agents/evidence_weighter.py
@@ -8,6 +8,7 @@ from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
 from lib.agents.live_literature_review import ClaimReferenceFactors, QualityLevel
+from lib.config.env import get_tavily_tool
 from lib.config.llm_models import gpt_5_mini_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
@@ -163,9 +164,14 @@ class EvidenceWeighterAgent(LangChainAgent):
     ) -> EvidenceWeighterResponse:
         prompt = _evidence_weighter_agent_prompt.invoke(prompt_kwargs)
 
+        tools: list = [{"type": "web_search"}]
+        tavily_tool = get_tavily_tool()
+        if tavily_tool is not None:
+            tools.append(tavily_tool)
+
         agent = create_agent(
             self.llm,
-            [{"type": "web_search"}],
+            tools,
             context_schema=ContextSchema,
             response_format=EvidenceWeighterResponse,
         )

--- a/lib/agents/evidence_weighter.py
+++ b/lib/agents/evidence_weighter.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from langchain.agents import create_agent
 from langchain_core.messages import HumanMessage
@@ -164,7 +164,7 @@ class EvidenceWeighterAgent(LangChainAgent):
     ) -> EvidenceWeighterResponse:
         prompt = _evidence_weighter_agent_prompt.invoke(prompt_kwargs)
 
-        tools: list = [{"type": "web_search"}]
+        tools: list[Any] = [{"type": "web_search"}]
         tavily_tool = get_tavily_tool()
         if tavily_tool is not None:
             tools.append(tavily_tool)

--- a/lib/agents/literature_review.py
+++ b/lib/agents/literature_review.py
@@ -8,6 +8,7 @@ from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnableConfig
 from pydantic import BaseModel, Field
 
+from lib.config.env import get_tavily_tool
 from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
@@ -191,9 +192,14 @@ class LiteratureReviewAgent(LangChainAgent):
     ) -> LiteratureReviewResponse:
         prompt = _literature_review_agent_prompt.invoke(prompt_kwargs)
 
+        tools: list = [{"type": "web_search"}]
+        tavily_tool = get_tavily_tool()
+        if tavily_tool is not None:
+            tools.append(tavily_tool)
+
         agent = create_agent(
             self.llm,
-            [{"type": "web_search"}],
+            tools,
             context_schema=ContextSchema,
             response_format=LiteratureReviewResponse,
         )

--- a/lib/agents/literature_review.py
+++ b/lib/agents/literature_review.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 
 from langchain.agents import create_agent
 from langchain_core.messages import HumanMessage
@@ -192,7 +192,7 @@ class LiteratureReviewAgent(LangChainAgent):
     ) -> LiteratureReviewResponse:
         prompt = _literature_review_agent_prompt.invoke(prompt_kwargs)
 
-        tools: list = [{"type": "web_search"}]
+        tools: list[Any] = [{"type": "web_search"}]
         tavily_tool = get_tavily_tool()
         if tavily_tool is not None:
             tools.append(tavily_tool)

--- a/lib/agents/live_literature_review.py
+++ b/lib/agents/live_literature_review.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from langchain.agents import create_agent
 from langchain_core.messages import HumanMessage
@@ -184,7 +184,7 @@ class LiveLiteratureReviewAgent(LangChainAgent):
     ) -> LiveLiteratureReviewResponse:
         prompt = _live_literature_review_agent_prompt.invoke(prompt_kwargs)
 
-        tools: list = [{"type": "web_search"}]
+        tools: list[Any] = [{"type": "web_search"}]
         tavily_tool = get_tavily_tool()
         if tavily_tool is not None:
             tools.append(tavily_tool)

--- a/lib/agents/live_literature_review.py
+++ b/lib/agents/live_literature_review.py
@@ -12,6 +12,7 @@ from lib.agents.literature_review import (
     ReferenceDirection,
     ReferenceType,
 )
+from lib.config.env import get_tavily_tool
 from lib.config.llm_models import gpt_5_mini_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
@@ -183,9 +184,14 @@ class LiveLiteratureReviewAgent(LangChainAgent):
     ) -> LiveLiteratureReviewResponse:
         prompt = _live_literature_review_agent_prompt.invoke(prompt_kwargs)
 
+        tools: list = [{"type": "web_search"}]
+        tavily_tool = get_tavily_tool()
+        if tavily_tool is not None:
+            tools.append(tavily_tool)
+
         agent = create_agent(
             self.llm,
-            [{"type": "web_search"}],
+            tools,
             context_schema=ContextSchema,
             response_format=LiveLiteratureReviewResponse,
         )

--- a/lib/agents/methodology_comparator.py
+++ b/lib/agents/methodology_comparator.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from langchain.agents import create_agent
 from langchain_core.messages import HumanMessage
@@ -217,7 +217,7 @@ class MethodologyComparisonAgent(LangChainAgent):
         """
         prompt = _methodology_comparison_agent_prompt.invoke(prompt_kwargs)
 
-        tools: list = [{"type": "web_search"}]
+        tools: list[Any] = [{"type": "web_search"}]
         tavily_tool = get_tavily_tool()
         if tavily_tool is not None:
             tools.append(tavily_tool)

--- a/lib/agents/methodology_comparator.py
+++ b/lib/agents/methodology_comparator.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 
 from lib.agents.literature_review import ReferenceType
 from lib.agents.methodology_extractor import ReproducibilityCategoryResponse
+from lib.config.env import get_tavily_tool
 from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
 from lib.workflows.context import ContextSchema
@@ -216,9 +217,14 @@ class MethodologyComparisonAgent(LangChainAgent):
         """
         prompt = _methodology_comparison_agent_prompt.invoke(prompt_kwargs)
 
+        tools: list = [{"type": "web_search"}]
+        tavily_tool = get_tavily_tool()
+        if tavily_tool is not None:
+            tools.append(tavily_tool)
+
         agent = create_agent(
             self.llm,
-            [{"type": "web_search"}],
+            tools,
             context_schema=ContextSchema,
             response_format=MethodologyComparisonResponse,
         )

--- a/lib/config/env.py
+++ b/lib/config/env.py
@@ -1,6 +1,7 @@
 import json
+import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field
@@ -97,6 +98,9 @@ class Config(BaseModel):
         description="Polling interval when the bucket is empty and the caller is blocking",
     )
 
+    # Tavily search integration (optional)
+    TAVILY_API_KEY: Optional[str] = None
+
 
 config = Config(
     OPENAI_API_KEY=os.getenv("OPENAI_API_KEY"),
@@ -132,9 +136,26 @@ config = Config(
         os.getenv("RATE_LIMITER_CHECK_EVERY_N_SECONDS", "0.25")
     ),
     MODEL_API_KEYS=json.loads(os.getenv("MODEL_API_KEYS", "{}")),
+    TAVILY_API_KEY=os.getenv("TAVILY_API_KEY"),
 )
 
 
 def get_model_api_key(model_name: str) -> str | None:
     """Return the API key configured for a specific model name, or None."""
     return config.MODEL_API_KEYS.get(model_name)
+
+
+_tavily_logger = logging.getLogger(__name__)
+
+
+def get_tavily_tool() -> Any | None:
+    """Return a LangChain TavilySearch tool if TAVILY_API_KEY is configured, else None."""
+    if not config.TAVILY_API_KEY:
+        return None
+    try:
+        from langchain_tavily import TavilySearch
+
+        return TavilySearch(max_results=5, search_depth="advanced")
+    except Exception:
+        _tavily_logger.warning("Failed to initialise TavilySearch tool; skipping.")
+        return None

--- a/lib/config/env.py
+++ b/lib/config/env.py
@@ -1,9 +1,9 @@
 import json
-import logging
 import os
 from typing import Any, Optional
 
 from dotenv import load_dotenv
+from langchain_tavily import TavilySearch
 from pydantic import BaseModel, Field
 
 load_dotenv()
@@ -145,17 +145,8 @@ def get_model_api_key(model_name: str) -> str | None:
     return config.MODEL_API_KEYS.get(model_name)
 
 
-_tavily_logger = logging.getLogger(__name__)
-
-
 def get_tavily_tool() -> Any | None:
     """Return a LangChain TavilySearch tool if TAVILY_API_KEY is configured, else None."""
     if not config.TAVILY_API_KEY:
         return None
-    try:
-        from langchain_tavily import TavilySearch
-
-        return TavilySearch(max_results=5, search_depth="advanced")
-    except Exception:
-        _tavily_logger.warning("Failed to initialise TavilySearch tool; skipping.")
-        return None
+    return TavilySearch(max_results=5, search_depth="advanced")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "langchain>=1.2.15",
     "langchain-text-splitters>=1.1.2",
     "langchain-openai>=1.1.14",
+    "langchain-tavily>=0.1.0",
     "langchain-anthropic>=1.4.0",
     "langchain-google-genai>=4.2.1",
     "langchain-postgres>=0.0.17",
@@ -60,7 +61,7 @@ exclude = [
 ]
 
 [[tool.mypy.overrides]]
-module = ["nltk.*", "nest_asyncio"]
+module = ["nltk.*", "nest_asyncio", "langchain_tavily"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -763,6 +763,7 @@ dependencies = [
     { name = "langchain-google-genai" },
     { name = "langchain-openai" },
     { name = "langchain-postgres" },
+    { name = "langchain-tavily" },
     { name = "langchain-text-splitters" },
     { name = "langfuse" },
     { name = "langgraph" },
@@ -821,6 +822,7 @@ requires-dist = [
     { name = "langchain-google-genai", specifier = ">=4.2.1" },
     { name = "langchain-openai", specifier = ">=1.1.14" },
     { name = "langchain-postgres", specifier = ">=0.0.17" },
+    { name = "langchain-tavily", specifier = ">=0.1.0" },
     { name = "langchain-text-splitters", specifier = ">=1.1.2" },
     { name = "langfuse", specifier = ">=4.2.0" },
     { name = "langgraph", specifier = ">=1.1.6" },
@@ -1806,6 +1808,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
+]
+
+[[package]]
+name = "langchain-tavily"
+version = "0.2.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/6c/b309ef3062b189a82463dc93553804566e71aa393f9ba8954750793c1a6f/langchain_tavily-0.2.18.tar.gz", hash = "sha256:cd7859ae1a6ce79236580ef67072ff5fc43c7ded94e7eac38ff04209ca85a320", size = 25378, upload-time = "2026-04-16T15:23:24.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/9c/0c043e4434b1823f0ac194f66036cbb0569275a99dcb890e0891ecd34fb2/langchain_tavily-0.2.18-py3-none-any.whl", hash = "sha256:dccf3ad1c50e2cb2a89bec11727555805c9df8abd42c1f3ad42ccad86e28aa44", size = 30814, upload-time = "2026-04-16T15:23:23.424Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable parallel search provider alongside the existing OpenAI `web_search` tool in five agents: literature review, live literature review, evidence weighter, citation suggester, and methodology comparator. When `TAVILY_API_KEY` is set, agents get both search tools; otherwise behavior is unchanged.

## What's Changed

### Backend

- **`lib/config/env.py`**: Added `TAVILY_API_KEY` optional config field and `get_tavily_tool()` helper function that returns a LangChain `TavilySearch` tool when the key is configured, or `None` otherwise.
- **`lib/agents/literature_review.py`**: Import `get_tavily_tool`; conditionally append Tavily tool to the tools list passed to `create_agent`.
- **`lib/agents/live_literature_review.py`**: Same pattern as above.
- **`lib/agents/evidence_weighter.py`**: Same pattern as above.
- **`lib/agents/citation_suggester.py`**: Same pattern as above.
- **`lib/agents/methodology_comparator.py`**: Same pattern as above.
- **`pyproject.toml`**: Added `langchain-tavily>=0.1.0` dependency; added `langchain_tavily` to mypy ignore list.

## Dependency Changes

- Added `langchain-tavily>=0.1.0` to `pyproject.toml`

## Environment Variable Changes

- Added optional `TAVILY_API_KEY` — when set, enables Tavily search in the five agents listed above

## Notes for Reviewers

- This is an **additive** change: existing OpenAI `web_search` behavior is fully preserved.
- The `get_tavily_tool()` helper is designed to be reused by other migration units (e.g., reference-validation).
- All modified files pass mypy with no errors.


### Automated Review

- Passed after 2 attempt(s)
- Final review: The implementation correctly adds Tavily as a parallel search option to all 5 literature agents (literature_review, live_literature_review, evidence_weighter, citation_suggester, methodology_comparator) using an additive strategy. The lazy import issue from attempt 1 is fixed — `from langchain_tavily import TavilySearch` is now at the top level of env.py. The `tools: list[Any]` typing is correct. Dependencies (pyproject.toml, uv.lock) and the mypy override are all properly updated. The only minor concerns are a per-call TavilySearch instantiation pattern and a potential env.py overlap with the prerequisite unit, but neither is blocking.
