### PR TITLE
fix(workflow-cost): add timeout to Langfuse pricing fetch

### DIFF
--- a/lib/services/workflow_cost/pricing.py
+++ b/lib/services/workflow_cost/pricing.py
@@ -16,6 +16,18 @@ logger = logging.getLogger(__name__)
 # Tests can set this directly to bypass the network fetch.
 _MODELS_CACHE: Optional[list[tuple[re.Pattern[str], Any]]] = None
 _MODELS_LOCK = asyncio.Lock()
+_MODELS_FETCH_TIMEOUT_SECONDS = 5.0
+
+
+async def _fetch_all_models(langfuse: Any) -> list:
+    models: list = []
+    page = 1
+    while True:
+        res = await langfuse.async_api.models.list(page=page, limit=100)
+        models.extend(res.data)
+        if len(models) >= res.meta.total_items:
+            return models
+        page += 1
 
 
 async def _ensure_models_loaded() -> list[tuple[re.Pattern[str], Any]]:
@@ -38,14 +50,17 @@ async def _ensure_models_loaded() -> list[tuple[re.Pattern[str], Any]]:
             _MODELS_CACHE = []
             return _MODELS_CACHE
 
-        models: list = []
-        page = 1
-        while True:
-            res = await langfuse.async_api.models.list(page=page, limit=100)
-            models.extend(res.data)
-            if len(models) >= res.meta.total_items:
-                break
-            page += 1
+        try:
+            models = await asyncio.wait_for(
+                _fetch_all_models(langfuse), timeout=_MODELS_FETCH_TIMEOUT_SECONDS
+            )
+        except Exception:
+            # Cache the failure so we don't re-hang on every cost calculation.
+            logger.warning(
+                "Failed to load Langfuse model pricing; disabling cost calc for this process"
+            )
+            _MODELS_CACHE = []
+            return _MODELS_CACHE
 
         compiled: list[tuple[re.Pattern[str], Any]] = []
         for m in models:


### PR DESCRIPTION
## Summary

Project loads were hanging indefinitely when the Langfuse API was unreachable. The lazy-loaded pricing fetch in `lib/services/workflow_cost/pricing.py` called `langfuse.async_api.models.list(...)` without a timeout, so a stalled TCP connection blocked every subsequent cost calculation (which runs as part of `WorkflowRunsService` list endpoints used by project pages).

## Motivation

Reproduced locally by pointing `LANGFUSE_HOST` at a non-routable address (`http://10.255.255.1:81`) — loading a project froze for many minutes. Cost data is non-critical; a Langfuse outage should not take down project loads.

## What's Changed

### Backend

- `lib/services/workflow_cost/pricing.py`
  - Added `_MODELS_FETCH_TIMEOUT_SECONDS = 5.0`.
  - Extracted the pagination loop into a module-level `_fetch_all_models(langfuse)` helper.
  - Wrapped the fetch in `asyncio.wait_for(..., timeout=5.0)`.
  - On any failure (timeout or otherwise), log a warning and cache `_MODELS_CACHE = []` so future calls return immediately with cost calc disabled.

### Frontend

None.

## Risks and Mitigations

- **Transient Langfuse outages disable cost calc until process restart.** Same shape as the existing "Langfuse not configured" path. Trade-off chosen to avoid eating a 5s timeout on every cost calculation while Langfuse is down. A TTL-based retry can be added later if needed.
- **5s timeout could be too tight on a slow network.** Cold-start fetch is one paginated call; 5s is comfortable under normal conditions. Failure mode is just "no cost displayed," which is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)