### PR TITLE
feat(workflows): add per-manifest max_concurrency override

### DIFF
--- a/lib/workflows/manifest.py
+++ b/lib/workflows/manifest.py
@@ -4,6 +4,7 @@ from typing import List, Type, TypeVar
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph, RunnableConfig
 
+from lib.config.env import config as env_config
 from lib.workflows.models import (
     BaseWorkflowConfig,
     BaseWorkflowState,
@@ -54,6 +55,12 @@ class WorkflowManifest[WorkflowStateType, WorkflowConfigType](ABC):
     # Exceeding this transitions the run to FAILED with failure_reason=timeout.
     # Override in subclasses for workflows that legitimately run longer.
     max_duration_seconds: float = 1 * 60 * 60  # 1 hour
+
+    # Maximum number of LangGraph nodes this workflow runs in parallel.
+    # Defaults to the global env_config.LANGGRAPH_MAX_CONCURRENCY. Override in
+    # workflows that fan out heavy per-item LLM calls (e.g. one web-search
+    # agent per reference) to stay under provider rate limits.
+    max_concurrency: int = env_config.LANGGRAPH_MAX_CONCURRENCY
 
     @property
     def is_qa_screener(self) -> bool:

--- a/lib/workflows/reference_validation_v2/manifest.py
+++ b/lib/workflows/reference_validation_v2/manifest.py
@@ -40,6 +40,9 @@ class ReferenceValidationV2Manifest(
     description = "Are your references accurate? Uses web search to check each citation exists online and that the author, title, publisher, and year match public sources. Useful for catching typos or hallucinated references."
     needs_web_search = True
     required_dependencies = [WorkflowRunType.REFERENCE_EXTRACTION]
+    # Each reference fans out a gpt-5.5 + web_search deep agent; cap how many
+    # run in parallel so large bibliographies don't trip provider 429s.
+    max_concurrency = 20
 
     def get_state_type(self) -> Type[ReferenceValidationV2State]:
         return ReferenceValidationV2State

--- a/lib/workflows/runner.py
+++ b/lib/workflows/runner.py
@@ -177,13 +177,19 @@ async def run_workflow(
     manifest = get_workflow_manifest(workflow_type, raise_exception=False)
     max_duration = manifest.max_duration_seconds if manifest else 1 * 60 * 60
 
+    # Workflows that fan out heavy per-item LLM calls can pin a lower
+    # concurrency than the global default to stay under provider rate limits.
+    max_concurrency = (
+        manifest.max_concurrency if manifest else env_config.LANGGRAPH_MAX_CONCURRENCY
+    )
+
     async with get_checkpointer() as checkpointer:
         app = graph.compile(checkpointer=checkpointer).with_config(
             {
                 "run_name": f"{workflow_type.value}",
                 "callbacks": [langfuse_handler, error_logging_callback],
                 "metadata": {"langfuse_session_id": project_id},
-                "max_concurrency": env_config.LANGGRAPH_MAX_CONCURRENCY,
+                "max_concurrency": max_concurrency,
             }
         )
 


### PR DESCRIPTION
## Summary

Running **Reference Error Checker** (`reference_validation_v2`) on a large bibliography produced many OpenAI HTTP 429 "Too Many Requests" errors — a user reported 34/59 references erroring in one run. This adds a **per-workflow concurrency cap** so a single heavy workflow can run fewer LLM calls in parallel than the global default, and pins Reference Error Checker to 20.

Reported by Emily in [Slack](https://agencyenterprise.slack.com/archives/C09D541FSKZ/p1780500218396239). Refs RANDZ-578.

## Motivation

The workflow fans out **one deep agent per reference** (`distribute_validations` emits a `Send` per reference). Each agent is gpt-5.5 + reasoning + the `web_search` tool + document context, running an agentic loop — so each reference is several heavy model requests. Parallelism was bounded only by the **global** `LANGGRAPH_MAX_CONCURRENCY`. The existing rate limiter caps requests-per-second, not tokens-per-minute, so many concurrent reasoning/web-search calls can still blow the provider's TPM limit. Per-item failures are caught and marked `ERROR` with no retry, which is why a chunk of references failed permanently.

Capping concurrency for this workflow lowers peak token throughput — the most likely 429 driver — without touching any other workflow.

## What's Changed

### Backend
- **`lib/workflows/manifest.py`** — Added `max_concurrency: int` to the base `WorkflowManifest`, defaulting to `env_config.LANGGRAPH_MAX_CONCURRENCY`. Workflows inherit the global default unless they override it.
- **`lib/workflows/runner.py`** — When compiling the graph, use the manifest's `max_concurrency` (falling back to the global value only when no manifest is found).
- **`lib/workflows/reference_validation_v2/manifest.py`** — Set `max_concurrency = 20` to cap concurrent per-reference web-search agents.

## Risks and Mitigations

- **Risk:** 20 is still too high (or unnecessarily low) for the deploy's actual TPM ceiling. **Mitigation:** it's a single-line manifest constant, trivially tunable once the RAND logs confirm whether the 429s were TPM- or RPM-based.
- **Scope:** only `reference_validation_v2` changes behavior; every other workflow keeps inheriting the global default.
- **Follow-up (out of scope):** retrying only the `ERROR` references with backoff, and a token-aware rate limiter (the current one bounds request rate, not tokens).

## Verification
- `uv run mypy .` — clean (359 files).
- Runtime check: `reference_validation_v2` resolves to 20; other workflows inherit the global value; no import cycle from the new `env_config` import in `manifest.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)