### PR TITLE
feat(docx-export): include suggested action and long description in comments

### DIFF
--- a/lib/services/docx/manipulator.py
+++ b/lib/services/docx/manipulator.py
@@ -186,9 +186,20 @@ def issue_to_comment(
     workflow_name = _get_workflow_display_name(issue)
     title = f"{issue.title} ({workflow_name})" if workflow_name else issue.title
 
+    # Include the suggested action and long_description (the "more details" content
+    # shown in the UI) so the Word export carries the full context authors need —
+    # e.g. for Reference Error Checker, which fields are wrong, the suggested action,
+    # and the suggested updated reference.
+    parts = [f"{title}\n\n{issue.description}"]
+    if issue.suggested_action:
+        parts.append(f"Suggested Action: {issue.suggested_action}")
+    if issue.long_description:
+        parts.append(issue.long_description)
+    comment_text = "\n\n".join(parts)
+
     return DocxComment(
         paragraph_index=paragraph_index,
-        comment_text=f"{title}\n\n{issue.description}",
+        comment_text=comment_text,
         severity=_map_severity_enum_to_comment_severity(issue.severity),
         share_link=share_link,
     )

--- a/tests/unit/services/test_docx_generation.py
+++ b/tests/unit/services/test_docx_generation.py
@@ -35,6 +35,8 @@ def _make_issue(
     chunk_indices: list[int] | None = None,
     start_line: int | None = None,
     end_line: int | None = None,
+    long_description: str | None = None,
+    suggested_action: str | None = None,
 ) -> Issue:
     """Create an Issue instance for testing without hitting the DB."""
     now = datetime.now(UTC)
@@ -45,6 +47,8 @@ def _make_issue(
         issue_hash=uuid.uuid4().hex[:64],
         title=title,
         description=description,
+        long_description=long_description,
+        suggested_action=suggested_action,
         severity=severity,
         workflow_type=workflow_type,
         chunk_indices=chunk_indices,
@@ -84,6 +88,53 @@ class TestIssueToComment:
         assert "This claim lacks evidence" in comment.comment_text
         assert comment.severity == CommentSeverity.HIGH
         assert comment.get_author() == "🚨 High Priority"
+
+    def test_includes_suggested_action_and_long_description_in_order(self):
+        """Comment carries description, then suggested action, then long_description."""
+        issue = _make_issue(
+            title="Reference has incorrect fields",
+            description="The publication year does not match public sources.",
+            suggested_action="Update the year to 2021.",
+            long_description="### Field validations\n\n- **Year**: 2019 → 2021",
+            severity=SeverityEnum.HIGH,
+            workflow_type=WorkflowRunType.REFERENCE_VALIDATION_V2,
+            start_line=1,
+            end_line=3,
+        )
+        chunks = [_FakeChunk(0, "The reference here", 1, 3)]
+        paragraph_line_ranges = {0: (1, 3)}
+
+        comment = issue_to_comment(issue, chunks, paragraph_line_ranges)
+
+        assert comment is not None
+        text = comment.comment_text
+        assert "Suggested Action: Update the year to 2021." in text
+        assert "### Field validations" in text
+        assert "2019 → 2021" in text
+        # Order: description → suggested action → long_description
+        assert (
+            text.index("does not match public sources")
+            < text.index("Suggested Action:")
+            < text.index("### Field validations")
+        )
+
+    def test_omits_long_description_when_absent(self):
+        """No trailing separator/content when long_description is None."""
+        issue = _make_issue(
+            title="Unsupported Claim",
+            description="This claim lacks evidence",
+            severity=SeverityEnum.HIGH,
+            workflow_type=WorkflowRunType.CLAIM_REFERENCE_VALIDATION,
+            start_line=1,
+            end_line=3,
+        )
+        chunks = [_FakeChunk(0, "The claim content here", 1, 3)]
+        paragraph_line_ranges = {0: (1, 3)}
+
+        comment = issue_to_comment(issue, chunks, paragraph_line_ranges)
+
+        assert comment is not None
+        assert comment.comment_text.endswith("This claim lacks evidence")
 
     def test_falls_back_to_chunk_indices_for_legacy_issue(self):
         """Issues pre-dating the line-range migration only carry chunk_indices."""


### PR DESCRIPTION
## Summary

When downloading review results as Word (.docx), each comment only included the issue's short `description`. For **Reference Error Checker** the comment was just "X Priority, Reference has incorrect fields (Reference Error Checker)" + the reference text — missing the detail authors need (which fields are wrong, the suggested action, the suggested updated reference), even though it's all visible in the UI.

Reported via user feedback in [Slack](https://agencyenterprise.slack.com/archives/C09D541FSKZ/p1780502270850139). Refs RANDZ-579.

## Motivation

A common QAM workflow is to run a paper's reference section in Draft Detective, download the section with Word comments, and send that to authors. The exported comments should therefore carry everything authors need to revise. Agreed in-thread to include the full detail — Word collapses long comments behind a "show more" button anyway.

## What's Changed

### Backend
- **`lib/services/docx/manipulator.py`** — In `issue_to_comment`, the comment body is now built from, in order, separated by double line breaks:
  1. `{title}` + `description` (unchanged)
  2. `Suggested Action: {suggested_action}` — appended when present
  3. `long_description` (the UI "more details" content) — appended when present

  Both extra fields are `Optional` and appended only when set, so issues without them are unchanged. Applies to every workflow's export.

### Tests
- **`tests/unit/services/test_docx_generation.py`** — Added `suggested_action`/`long_description` to the test helper and tests asserting both are included and correctly ordered, plus that nothing trailing is added when they're absent.

## Risks and Mitigations
- **Risk:** longer comments. **Mitigation:** intended and discussed with the user; Word collapses long comments. Empty/None fields are skipped, so existing issues without these fields render identically to before.

## Verification
- `tests/unit/services/test_docx_generation.py` — 14 passed.
- `uv run mypy .` — clean (359 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)