### PR TITLE
feat(results): make Export to DOCX more prominent

### DIFF
--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -142,11 +142,30 @@ export function AnalysisOptionsMenu({ project, results, readOnly }: AnalysisOpti
 
   return (
     <>
-      <div className="flex items-center gap-2">
-        {!readOnly && <ShareStatusBadge isEnabled={share.isEnabled} onClick={() => share.setIsDialogOpen(true)} />}
+      <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
+          {!readOnly && <ShareStatusBadge isEnabled={share.isEnabled} onClick={() => share.setIsDialogOpen(true)} />}
 
-        <DropdownMenu>
-          {(hasDocx || !readOnly) && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              {/* Wrapper span so the tooltip still fires while the button is disabled */}
+              <span tabIndex={0}>
+                <Button variant="default" size="xs" onClick={handleDownloadClick} disabled={!hasDocx || isDownloading}>
+                  <Download />
+                  {isDownloading ? 'Downloading...' : 'Download DOCX'}
+                </Button>
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {hasDocx
+                ? 'Download the original Word document with the analysis results (issues and suggested edits) added as comments'
+                : 'DOCX export is only available when the source document is a Word file (.docx or .doc)'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+
+        {!readOnly && (
+          <DropdownMenu>
             <Tooltip>
               <TooltipTrigger asChild>
                 <DropdownMenuTrigger asChild>
@@ -157,49 +176,34 @@ export function AnalysisOptionsMenu({ project, results, readOnly }: AnalysisOpti
               </TooltipTrigger>
               <TooltipContent>See more options</TooltipContent>
             </Tooltip>
-          )}
 
-          <DropdownMenuContent className="w-56">
-            {hasDocx && (
+            <DropdownMenuContent className="w-56">
               <MenuItemWithTooltip
-                icon={Download}
-                onClick={handleDownloadClick}
-                disabled={isDownloading}
-                tooltip="Download reviewed DOCX"
+                icon={Pencil}
+                onClick={() => setIsEditDialogOpen(true)}
+                tooltip="Edit project title, publication date, domain, and target audience"
               >
-                {isDownloading ? 'Downloading...' : 'Download DOCX'}
+                Edit project details
               </MenuItemWithTooltip>
-            )}
 
-            {!readOnly && (
-              <>
-                <MenuItemWithTooltip
-                  icon={Pencil}
-                  onClick={() => setIsEditDialogOpen(true)}
-                  tooltip="Edit project title, publication date, domain, and target audience"
-                >
-                  Edit project details
-                </MenuItemWithTooltip>
+              <MenuItemWithTooltip
+                icon={RefreshCw}
+                onClick={() => setIsReplaceDialogOpen(true)}
+                tooltip="Upload a new version of the main document and re-run assessments"
+              >
+                Replace main document
+              </MenuItemWithTooltip>
 
-                <MenuItemWithTooltip
-                  icon={RefreshCw}
-                  onClick={() => setIsReplaceDialogOpen(true)}
-                  tooltip="Upload a new version of the main document and re-run assessments"
-                >
-                  Replace main document
-                </MenuItemWithTooltip>
-
-                <MenuItemWithTooltip
-                  icon={Link}
-                  onClick={() => share.setIsDialogOpen(true)}
-                  tooltip={share.isEnabled ? 'View or copy the share link' : 'Create a public link'}
-                >
-                  {share.isEnabled ? 'Manage share link' : 'Share this assessment'}
-                </MenuItemWithTooltip>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+              <MenuItemWithTooltip
+                icon={Link}
+                onClick={() => share.setIsDialogOpen(true)}
+                tooltip={share.isEnabled ? 'View or copy the share link' : 'Create a public link'}
+              >
+                {share.isEnabled ? 'Manage share link' : 'Share this assessment'}
+              </MenuItemWithTooltip>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
       </div>
 
       <ShareDialog

--- a/frontend/components/results/results-visualization.tsx
+++ b/frontend/components/results/results-visualization.tsx
@@ -213,7 +213,7 @@ export function ResultsVisualization({
               />
             )}
             {readOnly && (
-              <Badge variant="secondary" className="text-xs">
+              <Badge variant="secondary" className="h-7 text-xs">
                 Read-only view
               </Badge>
             )}

--- a/frontend/components/share/share-status-badge.tsx
+++ b/frontend/components/share/share-status-badge.tsx
@@ -17,7 +17,7 @@ export function ShareStatusBadge({ isEnabled, onClick }: ShareStatusBadgeProps) 
       <TooltipTrigger asChild>
         <Badge
           variant="outline"
-          className="cursor-pointer gap-1 bg-green-50 text-green-700 border-green-200 hover:bg-green-100 dark:bg-green-950 dark:text-green-300 dark:border-green-800 dark:hover:bg-green-900"
+          className="h-7 cursor-pointer gap-1 bg-green-50 text-green-700 border-green-200 hover:bg-green-100 dark:bg-green-950 dark:text-green-300 dark:border-green-800 dark:hover:bg-green-900"
           onClick={onClick}
         >
           <Link className="h-3 w-3" />


### PR DESCRIPTION
## Summary

Surfaces the "Download DOCX" action as a permanent, at-a-glance button instead of burying it inside the three-dot overflow menu, addressing [RANDZ-581](https://linear.app/ae-studio/issue/RANDZ-581/make-export-to-docx-more-prominent-to-users).

## Motivation

Requested by Emily in the 2026-06-05 Demo & Acceptance call. In the current QAM workflow, QAMs run the assessment, download the DOCX, and send it to authors — the DOCX is the primary way suggested edits reach authors, who don't use the UI directly. Both Emily and Dulani heard that the export was hard to find because it lived behind the overflow menu; new users didn't realize it existed. Emily suggested rendering it as a button next to the existing sharing control.

## What's Changed

### Frontend

- **`frontend/components/results/components/analysis-options-menu.tsx`** — Moved "Download DOCX" out of the three-dot menu into a permanent `outline`/`xs` button placed next to the sharing badge. It reuses the existing `handleDownloadClick` flow (share-warning → filter-warning → download), so behavior is unchanged. When the source document is not a Word file, the button stays visible but **disabled**, with a tooltip explaining why (wrapped in a `span` so the tooltip still fires while disabled). The enabled-state tooltip now explains the export contains the analysis results (issues and suggested edits) as comments. The overflow menu now renders only for non-read-only users, since its remaining items (Edit, Replace, Share) were already gated to `!readOnly`.
- **`frontend/components/share/share-status-badge.tsx`** — Added `h-7` so the "Sharing enabled" badge matches the new button height.
- **`frontend/components/results/results-visualization.tsx`** — Added `h-7` to the "Read-only view" badge to match the same height.

## Risks and Mitigations

- **Low risk, UI-only change.** No backend, API, or download-logic changes — the existing download flow and dialogs are reused as-is.
- The DOCX availability check (`hasDocx`) is unchanged; non-Word documents now show a disabled button with explanation rather than hiding the control, which is clearer for users.
- Shared/read-only viewers retain DOCX download access via the visible button; the now-empty overflow menu is correctly hidden for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)