### PR TITLE
refactor(results): render revision switcher inside analysis options menu

### DIFF
--- a/frontend/components/results/components/analysis-options-menu.tsx
+++ b/frontend/components/results/components/analysis-options-menu.tsx
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { toast } from 'sonner';
 import { downloadDocxFile, DocxType, useDownloadDocx } from './use-download-docx';
 import { ReplaceMainDocumentDialog } from './replace-main-document-dialog';
+import { RevisionSwitcher } from './revision-switcher';
 
 type ProjectWithDetails = Project & {
   publication_date?: Date | null;
@@ -39,9 +40,17 @@ export interface AnalysisOptionsMenuProps {
   project: ProjectWithDetails;
   results: WorkflowRunDetail[];
   readOnly: boolean;
+  selectedRevision?: number;
+  onRevisionChange?: (revision: number) => void;
 }
 
-export function AnalysisOptionsMenu({ project, results, readOnly }: AnalysisOptionsMenuProps) {
+export function AnalysisOptionsMenu({
+  project,
+  results,
+  readOnly,
+  selectedRevision,
+  onRevisionChange,
+}: AnalysisOptionsMenuProps) {
   const { filter } = useDocumentExplorerStore();
   const projectId = project.id;
   const share = useShareStatus(projectId, !readOnly);
@@ -145,6 +154,15 @@ export function AnalysisOptionsMenu({ project, results, readOnly }: AnalysisOpti
       <div className="flex items-center gap-1">
         <div className="flex items-center gap-2">
           {!readOnly && <ShareStatusBadge isEnabled={share.isEnabled} onClick={() => share.setIsDialogOpen(true)} />}
+
+          {selectedRevision && onRevisionChange && (
+            <RevisionSwitcher
+              currentRevision={project.current_revision ?? 1}
+              totalRevisions={project.current_revision ?? 1}
+              selectedRevision={selectedRevision}
+              onRevisionChange={onRevisionChange}
+            />
+          )}
 
           <Tooltip>
             <TooltipTrigger asChild>

--- a/frontend/components/results/components/revision-switcher.tsx
+++ b/frontend/components/results/components/revision-switcher.tsx
@@ -22,7 +22,7 @@ export function RevisionSwitcher({
     <Tooltip>
       <TooltipTrigger asChild>
         <Select value={String(selectedRevision)} onValueChange={(v) => onRevisionChange(Number(v))}>
-          <SelectTrigger className="h-8 w-auto gap-1 text-xs">
+          <SelectTrigger className="h-7 w-auto gap-1 text-xs">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/frontend/components/results/results-visualization.tsx
+++ b/frontend/components/results/results-visualization.tsx
@@ -15,7 +15,6 @@ import { format } from 'date-fns';
 import { BookOpen, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { AnalysisOptionsMenu } from './components/analysis-options-menu';
-import { RevisionSwitcher } from './components/revision-switcher';
 import { TabType } from './constants';
 import { AnalysesTab, FilesTab, ReferenceReviewTab, SummaryTab } from './tabs';
 import { DocumentExplorerTab } from './tabs/document-explorer-tab';
@@ -204,20 +203,18 @@ export function ResultsVisualization({
           </Tabs>
 
           <div className="flex items-center gap-2">
-            {selectedRevision && onRevisionChange && (
-              <RevisionSwitcher
-                currentRevision={projectDetail.project.current_revision ?? 1}
-                totalRevisions={projectDetail.project.current_revision ?? 1}
-                selectedRevision={selectedRevision}
-                onRevisionChange={onRevisionChange}
-              />
-            )}
             {readOnly && (
               <Badge variant="secondary" className="h-7 text-xs">
                 Read-only view
               </Badge>
             )}
-            <AnalysisOptionsMenu project={projectDetail.project} results={results} readOnly={readOnly} />
+            <AnalysisOptionsMenu
+              project={projectDetail.project}
+              results={results}
+              readOnly={readOnly}
+              selectedRevision={selectedRevision}
+              onRevisionChange={onRevisionChange}
+            />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

Reorganizes the project results header action row so the revision selector lives alongside the other action controls, and matches its height to the surrounding buttons.

## Motivation

The revision selector was rendered separately in the header row (before `AnalysisOptionsMenu`), and was slightly taller than the neighboring controls. Folding it into `AnalysisOptionsMenu` keeps all header actions in one cohesive, consistently-styled group.

## What's Changed

### Frontend

- `frontend/components/results/components/analysis-options-menu.tsx` — Added `selectedRevision` and `onRevisionChange` props and now renders `RevisionSwitcher` inside the menu, grouped with the sharing badge and Download DOCX button.
- `frontend/components/results/results-visualization.tsx` — Removed the standalone `RevisionSwitcher` (and its import) from the header row; forwards `selectedRevision`/`onRevisionChange` to `AnalysisOptionsMenu` instead.
- `frontend/components/results/components/revision-switcher.tsx` — `SelectTrigger` height `h-8` → `h-7` to match the other action controls.

## Risks and Mitigations

Low risk — purely a presentational/layout refactor. No behavior or API changes; the revision switcher still only renders when there is more than one revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)