### PR TITLE
refactor(workflow-runs): cut workflow state reads over to state_json (RANDZ-561 PR 2)

### DIFF
--- a/lib/services/references.py
+++ b/lib/services/references.py
@@ -9,8 +9,8 @@ from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
 from lib.services.workflow_runs import (
     create_workflow_run,
     get_project_workflow_run_by_type,
-    get_workflow_run_state_by_thread_id,
     persist_workflow_run_state,
+    read_workflow_run_state,
 )
 from lib.workflows.checkpointer import get_checkpointer
 from lib.workflows.models import WorkflowRunType
@@ -55,15 +55,15 @@ async def _get_document_processing_workflow_state(project_id: str, revision: int
     from lib.workflows.document_processing.state import DocumentProcessingState
 
     run = await get_project_workflow_run_by_type(
-        project_id, WorkflowRunType.DOCUMENT_PROCESSING, revision=revision
+        project_id,
+        WorkflowRunType.DOCUMENT_PROCESSING,
+        revision=revision,
+        include_state=True,
     )
     if run is None:
         return None
 
-    state = await get_workflow_run_state_by_thread_id(
-        run.langgraph_thread_id, WorkflowRunType.DOCUMENT_PROCESSING
-    )
-    return state
+    return await read_workflow_run_state(run)
 
 
 async def _get_file_matching_workflow_state(
@@ -87,14 +87,15 @@ async def _get_file_matching_workflow_state(
     from lib.workflows.reference_file_matching.state import ReferenceFileMatchingConfig
 
     run = await get_project_workflow_run_by_type(
-        project_id, WorkflowRunType.REFERENCE_FILE_MATCHING, revision=revision
+        project_id,
+        WorkflowRunType.REFERENCE_FILE_MATCHING,
+        revision=revision,
+        include_state=True,
     )
 
     state = None
     if run is not None:
-        state = await get_workflow_run_state_by_thread_id(
-            run.langgraph_thread_id, WorkflowRunType.REFERENCE_FILE_MATCHING
-        )
+        state = await read_workflow_run_state(run)
 
     if state is not None:
         return run, cast(ReferenceFileMatchingState, state)
@@ -168,16 +169,17 @@ async def _get_extraction_workflow_state(
     Get the ReferenceExtraction workflow run and state for a project.
     """
     run = await get_project_workflow_run_by_type(
-        project_id, WorkflowRunType.REFERENCE_EXTRACTION, revision=revision
+        project_id,
+        WorkflowRunType.REFERENCE_EXTRACTION,
+        revision=revision,
+        include_state=True,
     )
 
     if run is None:
         logger.info(f"No ReferenceExtraction workflow found for project {project_id}")
         return None, None
 
-    state = await get_workflow_run_state_by_thread_id(
-        run.langgraph_thread_id, WorkflowRunType.REFERENCE_EXTRACTION
-    )
+    state = await read_workflow_run_state(run)
 
     if state is None:
         logger.info(f"No extraction state found in workflow for project {project_id}")
@@ -253,14 +255,15 @@ async def _get_downloader_workflow_state(
 ) -> Tuple[Optional[WorkflowRun], Optional[ReferenceDownloaderState]]:
     """Get the ReferenceDownloader workflow run and state for a project."""
     run = await get_project_workflow_run_by_type(
-        project_id, WorkflowRunType.REFERENCE_DOWNLOADER, revision=revision
+        project_id,
+        WorkflowRunType.REFERENCE_DOWNLOADER,
+        revision=revision,
+        include_state=True,
     )
     if run is None:
         return None, None
 
-    state = await get_workflow_run_state_by_thread_id(
-        run.langgraph_thread_id, WorkflowRunType.REFERENCE_DOWNLOADER
-    )
+    state = await read_workflow_run_state(run)
     return run, cast(Optional[ReferenceDownloaderState], state)
 
 

--- a/lib/services/workflow_reaper.py
+++ b/lib/services/workflow_reaper.py
@@ -31,6 +31,7 @@ from typing import AsyncIterator
 
 from langchain_core.runnables.config import RunnableConfig
 from sqlalchemy import or_, select, text
+from sqlalchemy.orm import undefer
 from sqlmodel import and_, col
 
 from lib.config.database import get_async_db_session
@@ -44,6 +45,7 @@ from lib.services.workflow_runs import (
     fail_workflow_run,
     get_workflow_run_state_by_thread_id,
     persist_workflow_run_state,
+    read_workflow_run_state,
 )
 from lib.workflows.checkpointer import get_checkpointer
 from lib.workflows.registry import create_graph, get_workflow_manifest
@@ -119,23 +121,29 @@ async def _find_stuck_runs(
     running_cutoff = now - timedelta(seconds=running_grace_seconds)
     pending_cutoff = now - timedelta(seconds=pending_grace_seconds)
     async with get_async_db_session() as session:
-        stmt = select(WorkflowRun).where(
-            or_(
-                and_(
-                    col(WorkflowRun.status) == WorkflowRunStatus.RUNNING,
-                    or_(
-                        and_(
-                            col(WorkflowRun.heartbeat_at).is_(None),
-                            col(WorkflowRun.started_at) < running_cutoff,
+        stmt = (
+            select(WorkflowRun)
+            .where(
+                or_(
+                    and_(
+                        col(WorkflowRun.status) == WorkflowRunStatus.RUNNING,
+                        or_(
+                            and_(
+                                col(WorkflowRun.heartbeat_at).is_(None),
+                                col(WorkflowRun.started_at) < running_cutoff,
+                            ),
+                            col(WorkflowRun.heartbeat_at) < running_cutoff,
                         ),
-                        col(WorkflowRun.heartbeat_at) < running_cutoff,
                     ),
-                ),
-                and_(
-                    col(WorkflowRun.status) == WorkflowRunStatus.PENDING,
-                    col(WorkflowRun.created_at) < pending_cutoff,
-                ),
+                    and_(
+                        col(WorkflowRun.status) == WorkflowRunStatus.PENDING,
+                        col(WorkflowRun.created_at) < pending_cutoff,
+                    ),
+                )
             )
+            # _run_manifest_on_cancel hydrates state_json off these rows after
+            # the session closes, so load it in-session.
+            .options(undefer(col(WorkflowRun.state_json)))  # type: ignore[arg-type]  # SQLModel Mapped[...] is a QueryableAttribute at runtime
         )
         return list((await session.execute(stmt)).scalars().all())
 
@@ -153,9 +161,7 @@ async def _run_manifest_on_cancel(run: WorkflowRun) -> None:
         return
 
     try:
-        state = await get_workflow_run_state_by_thread_id(
-            run.langgraph_thread_id, run.type
-        )
+        state = await read_workflow_run_state(run)
     except Exception as e:
         logger.error(
             f"Reaper: failed to load state for {run.id}: {e}", exc_info=True

--- a/lib/services/workflow_runs.py
+++ b/lib/services/workflow_runs.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from langgraph.types import StateSnapshot
 from pydantic import BaseModel
 from sqlalchemy import case, func, select, update
+from sqlalchemy.orm import undefer
 from sqlmodel import and_, col
 
 from lib.config.database import get_async_db_session
@@ -53,21 +54,6 @@ async def _compute_cost_for_state(
     except Exception as e:  # pragma: no cover — never let cost calc break the response
         logger.warning(f"Failed to compute workflow cost: {e}")
         return None
-
-
-def _canonical_run_ids_per_thread(runs: List[WorkflowRun]) -> set[uuid.UUID]:
-    """Return the set of run IDs that are the most recent owners of their thread_id.
-
-    Multiple WorkflowRun rows can share a langgraph_thread_id (re-runs reuse threads),
-    so older runs see the latest run's state from the checkpointer — their cost would
-    be misleading. Only attribute cost to the latest run per thread.
-    """
-    latest: dict[str, WorkflowRun] = {}
-    for run in runs:
-        existing = latest.get(run.langgraph_thread_id)
-        if existing is None or run.created_at > existing.created_at:
-            latest[run.langgraph_thread_id] = run
-    return {r.id for r in latest.values()}
 
 
 def _convert_state_snapshot(
@@ -128,6 +114,25 @@ def hydrate_workflow_run_state(run: WorkflowRun) -> WorkflowState | None:
         return None
 
 
+async def read_workflow_run_state(run: WorkflowRun) -> WorkflowState | None:
+    """Single read path for a run's workflow state.
+
+    PR 2 (RANDZ-561) reader cutover: state is read from the row's `state_json`
+    (written by the dual-write since PR 1). Writes still go to both `state_json`
+    and the LangGraph checkpointer, so reverting the cutover is a one-line body
+    swap here — no data migration or write-path rollback:
+
+        return await get_workflow_run_state_by_thread_id(
+            run.langgraph_thread_id, run.type
+        )
+
+    `run` must have been loaded with `state_json` undeferred (see the model's
+    deferred-strategy note in lib/models/workflow_run.py) so this stays an
+    in-memory hydrate rather than an illegal async lazy-load on a detached row.
+    """
+    return hydrate_workflow_run_state(run)
+
+
 async def get_workflow_run_state_by_thread_id(
     thread_id: str, type: WorkflowRunType
 ) -> WorkflowState | None:
@@ -155,7 +160,7 @@ async def get_workflow_run_state_by_thread_id(
 
 
 async def get_workflow_run(
-    workflow_run_id: str, user: Optional[User] = None
+    workflow_run_id: str, user: Optional[User] = None, include_state: bool = False
 ) -> WorkflowRun:
     async with get_async_db_session() as session:
         stmt = (
@@ -163,6 +168,10 @@ async def get_workflow_run(
             .outerjoin(Project)
             .where(col(WorkflowRun.id) == workflow_run_id)
         )
+        if include_state:
+            # state_json is deferred by default; load it in-session so callers
+            # can hydrate it after this session closes (no async lazy-load).
+            stmt = stmt.options(undefer(col(WorkflowRun.state_json)))  # type: ignore[arg-type]  # SQLModel Mapped[...] is a QueryableAttribute at runtime
         result = (await session.execute(stmt)).one_or_none()
 
     if result is None:
@@ -179,8 +188,8 @@ async def get_workflow_run(
 async def get_workflow_run_state(
     workflow_run_id: str, user: User | None = None
 ) -> WorkflowState | None:
-    run = await get_workflow_run(workflow_run_id, user)
-    return await get_workflow_run_state_by_thread_id(run.langgraph_thread_id, run.type)
+    run = await get_workflow_run(workflow_run_id, user, include_state=True)
+    return await read_workflow_run_state(run)
 
 
 async def create_workflow_run(
@@ -335,12 +344,17 @@ async def get_project_workflow_run_by_type(
     project_id: str,
     type: WorkflowRunType,
     revision: int,
+    include_state: bool = False,
 ) -> Optional[WorkflowRun]:
     """
     Get the most relevant workflow run for a project, type, and revision.
 
     Priority: RUNNING > PENDING > latest COMPLETED
     This ensures UI shows correct status when multiple runs exist.
+
+    Pass `include_state=True` to undefer `state_json` so the returned run can be
+    hydrated via `read_workflow_run_state` after the session closes. Left off by
+    default to keep hot status/cancel paths from loading multi-MB payloads.
     """
 
     async with get_async_db_session() as session:
@@ -365,6 +379,8 @@ async def get_project_workflow_run_by_type(
             )
             .limit(1)
         )
+        if include_state:
+            stmt = stmt.options(undefer(col(WorkflowRun.state_json)))  # type: ignore[arg-type]  # SQLModel Mapped[...] is a QueryableAttribute at runtime
         active_run = (await session.execute(stmt)).scalar_one_or_none()
 
         if active_run:
@@ -383,6 +399,8 @@ async def get_project_workflow_run_by_type(
             .order_by(col(WorkflowRun.created_at).desc())
             .limit(1)
         )
+        if include_state:
+            stmt = stmt.options(undefer(col(WorkflowRun.state_json)))  # type: ignore[arg-type]  # SQLModel Mapped[...] is a QueryableAttribute at runtime
         return (await session.execute(stmt)).scalar_one_or_none()
 
 
@@ -410,6 +428,7 @@ async def get_project_workflow_runs_by_type(
     project_id: str,
     workflow_type: WorkflowRunType,
     revision: int,
+    include_state: bool = False,
 ) -> List[WorkflowRun]:
     """
     Get all workflow runs of a specific type for a project and revision.
@@ -428,6 +447,8 @@ async def get_project_workflow_runs_by_type(
             )
             .order_by(col(WorkflowRun.created_at).desc())
         )
+        if include_state:
+            stmt = stmt.options(undefer(col(WorkflowRun.state_json)))  # type: ignore[arg-type]  # SQLModel Mapped[...] is a QueryableAttribute at runtime
         return list((await session.execute(stmt)).scalars().all())
 
 
@@ -443,20 +464,13 @@ async def get_project_workflow_runs_by_type_with_details(
     Used for displaying workflow run history in the UI with error status.
     """
     runs = await get_project_workflow_runs_by_type(
-        project_id, workflow_type, revision=revision
+        project_id, workflow_type, revision=revision, include_state=True
     )
 
-    # Fetch all workflow states in parallel to avoid N+1 query pattern
-    states = await asyncio.gather(
-        *[
-            get_workflow_run_state_by_thread_id(run.langgraph_thread_id, run.type)
-            for run in runs
-        ]
-    )
-
-    canonical_ids = _canonical_run_ids_per_thread(list(runs))
-    cost_states = [s if r.id in canonical_ids else None for r, s in zip(runs, states)]
-    costs = await asyncio.gather(*[_compute_cost_for_state(s) for s in cost_states])
+    # Each run carries its own state_json, so state (and cost) are read per run
+    # directly — no checkpointer fan-out, and no thread-sharing band-aid needed.
+    states = await asyncio.gather(*[read_workflow_run_state(run) for run in runs])
+    costs = await asyncio.gather(*[_compute_cost_for_state(s) for s in states])
     return [
         WorkflowRunDetail(run=run, state=state, cost=cost)
         for run, state, cost in zip(runs, states, costs)
@@ -508,6 +522,8 @@ async def get_project_workflow_runs(
                 ranked_runs_subquery.c.rn == 1,
             )
         )
+        # Load state_json in-session so read_workflow_run_state can hydrate it.
+        .options(undefer(col(WorkflowRun.state_json)))  # type: ignore[arg-type]  # SQLModel Mapped[...] is a QueryableAttribute at runtime
     )
 
     async with get_async_db_session() as session:
@@ -518,12 +534,9 @@ async def get_project_workflow_runs(
         run for run in runs if include_internal or is_user_visible_workflow(run.type)
     ]
 
-    # Fetch all workflow states in parallel to avoid N+1 query pattern
+    # Each run carries its own state_json — read state per run directly.
     states = await asyncio.gather(
-        *[
-            get_workflow_run_state_by_thread_id(run.langgraph_thread_id, run.type)
-            for run in visible_runs
-        ]
+        *[read_workflow_run_state(run) for run in visible_runs]
     )
 
     costs = await asyncio.gather(*[_compute_cost_for_state(s) for s in states])

--- a/tests/unit/services/test_read_workflow_run_state.py
+++ b/tests/unit/services/test_read_workflow_run_state.py
@@ -1,0 +1,81 @@
+"""Unit tests for the read_workflow_run_state chokepoint (RANDZ-561 PR 2).
+
+The original History UI bug was that re-runs of a workflow type reused a single
+langgraph_thread_id, so reading per-run state from the checkpointer returned the
+*same* (latest) thread state for every run. Reading from each row's own
+state_json fixes this: two runs that share a thread_id but carry distinct
+state_json must hydrate to distinct states.
+"""
+
+import uuid
+
+import pytest
+
+from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
+from lib.services.workflow_runs import read_workflow_run_state
+from lib.workflows.models import WorkflowRunType
+from lib.workflows.reference_file_matching.state import (
+    ReferenceFileMatch,
+    ReferenceFileMatchingConfig,
+    ReferenceFileMatchingState,
+    MatchSource,
+)
+
+
+def _make_state(file_id: str, reference_id: str) -> ReferenceFileMatchingState:
+    return ReferenceFileMatchingState(
+        type=WorkflowRunType.REFERENCE_FILE_MATCHING,
+        config=ReferenceFileMatchingConfig(project_id=str(uuid.uuid4())),
+        file_id=file_id,
+        supporting_file_ids=[],
+        matches=[
+            ReferenceFileMatch(
+                reference_id=reference_id,
+                file_id=file_id,
+                source=MatchSource.AUTO_MATCHED,
+            )
+        ],
+    )
+
+
+def _make_run(thread_id: str, state: ReferenceFileMatchingState) -> WorkflowRun:
+    return WorkflowRun(
+        id=uuid.uuid4(),
+        langgraph_thread_id=thread_id,
+        project_id=None,
+        type=WorkflowRunType.REFERENCE_FILE_MATCHING,
+        status=WorkflowRunStatus.COMPLETED,
+        state_json=state.model_dump(mode="json"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reads_each_runs_own_state_despite_shared_thread_id():
+    shared_thread = str(uuid.uuid4())
+    state_a = _make_state(file_id="file-a", reference_id="ref-a")
+    state_b = _make_state(file_id="file-b", reference_id="ref-b")
+    run_a = _make_run(shared_thread, state_a)
+    run_b = _make_run(shared_thread, state_b)
+
+    hydrated_a = await read_workflow_run_state(run_a)
+    hydrated_b = await read_workflow_run_state(run_b)
+
+    assert isinstance(hydrated_a, ReferenceFileMatchingState)
+    assert isinstance(hydrated_b, ReferenceFileMatchingState)
+    # Each run hydrates to its OWN state, not the shared thread's latest.
+    assert hydrated_a.file_id == "file-a"
+    assert hydrated_b.file_id == "file-b"
+
+
+@pytest.mark.asyncio
+async def test_returns_none_when_state_json_missing():
+    run = WorkflowRun(
+        id=uuid.uuid4(),
+        langgraph_thread_id=str(uuid.uuid4()),
+        project_id=None,
+        type=WorkflowRunType.REFERENCE_FILE_MATCHING,
+        status=WorkflowRunStatus.COMPLETED,
+        state_json=None,
+    )
+
+    assert await read_workflow_run_state(run) is None

--- a/tests/unit/services/test_workflow_reaper.py
+++ b/tests/unit/services/test_workflow_reaper.py
@@ -72,10 +72,21 @@ async def test_run_manifest_on_cancel_invokes_hook_when_state_present():
         patch.object(
             workflow_reaper, "get_workflow_manifest", return_value=manifest
         ),
+        # Initial read now comes from state_json via read_workflow_run_state.
+        patch.object(
+            workflow_reaper,
+            "read_workflow_run_state",
+            new=AsyncMock(return_value=state),
+        ),
+        # The post-cancel mirror re-reads the checkpointer (on_cancel still
+        # writes there) and persists it back to state_json.
         patch.object(
             workflow_reaper,
             "get_workflow_run_state_by_thread_id",
             new=AsyncMock(return_value=state),
+        ),
+        patch.object(
+            workflow_reaper, "persist_workflow_run_state", new=AsyncMock()
         ),
         patch.object(
             workflow_reaper, "create_graph", return_value=MagicMock()
@@ -106,7 +117,7 @@ async def test_run_manifest_on_cancel_noop_when_manifest_missing():
     with (
         patch.object(workflow_reaper, "get_workflow_manifest", return_value=None),
         patch.object(
-            workflow_reaper, "get_workflow_run_state_by_thread_id", new=state_loader
+            workflow_reaper, "read_workflow_run_state", new=state_loader
         ),
     ):
         await _run_manifest_on_cancel(run)
@@ -127,7 +138,7 @@ async def test_run_manifest_on_cancel_noop_when_state_missing():
         ),
         patch.object(
             workflow_reaper,
-            "get_workflow_run_state_by_thread_id",
+            "read_workflow_run_state",
             new=AsyncMock(return_value=None),
         ),
     ):
@@ -149,7 +160,7 @@ async def test_run_manifest_on_cancel_swallows_hook_exception():
         ),
         patch.object(
             workflow_reaper,
-            "get_workflow_run_state_by_thread_id",
+            "read_workflow_run_state",
             new=AsyncMock(return_value=MagicMock()),
         ),
         patch.object(
@@ -179,7 +190,7 @@ async def test_run_manifest_on_cancel_swallows_state_load_exception():
         ),
         patch.object(
             workflow_reaper,
-            "get_workflow_run_state_by_thread_id",
+            "read_workflow_run_state",
             new=AsyncMock(side_effect=RuntimeError("db down")),
         ),
     ):


### PR DESCRIPTION
## Summary

PR 2 of the `workflow_runs.state_json` refactor (RANDZ-561). Flips workflow-state **reads** from the LangGraph checkpointer to the per-run `state_json` JSONB column (dual-written since PR 1 / #556). **Writes are unchanged** — both the checkpointer and `state_json` keep receiving everything, so this cutover is reversible by swapping a single helper's body.

## Motivation

PR 1 added `state_json` and dual-writes, but reads still went through the checkpointer. That left the original **History UI bug** in place: re-runs of a workflow type reuse one `langgraph_thread_id`, so reading per-run state from the checkpointer returns the *same latest thread state* for every run on that thread. Because each run already wrote its own independent `state_json`, simply reading from `state_json` makes each run report its own state — fixing History without touching thread IDs, and with a trivial rollback path if anything looks off in production.

The higher-risk pieces from the Linear issue (fresh `langgraph_thread_id` per run, `prior_self_state` seeding, the `on_cancel`-returns-state refactor, replacing the `references.py` mutations, and all PR 3 cleanup) are intentionally **deferred** to a follow-up after this soaks.

## What's Changed

### Backend
- **`lib/services/workflow_runs.py`**
  - Add `read_workflow_run_state(run)` — the single read chokepoint (hydrates `state_json`); its docstring documents the one-line revert back to `get_workflow_run_state_by_thread_id`.
  - `get_workflow_run_state`, `get_project_workflow_runs`, and `get_project_workflow_runs_by_type_with_details` now read per-run state via the chokepoint, undeferring `state_json` in their queries.
  - Remove `_canonical_run_ids_per_thread` — the cost band-aid only existed because shared-thread checkpointer reads cross-attributed state; with per-run `state_json` it's obsolete (and would now wrongly zero cost for older runs).
  - Add opt-in `include_state` flags to `get_workflow_run`, `get_project_workflow_run_by_type`, and `get_project_workflow_runs_by_type` so hot status/cancel paths stay deferred and don't haul multi-MB payloads.
- **`lib/services/references.py`** — the four `_get_*_workflow_state` readers use the chokepoint with `include_state=True`. The four `aupdate_state` mutations are **left untouched** (they keep dual-writing).
- **`lib/services/workflow_reaper.py`** — `_run_manifest_on_cancel`'s initial state read flips to the chokepoint; `_find_stuck_runs` undefers `state_json`. `on_cancel` and the post-cancel mirror are unchanged.

### Tests
- **`tests/unit/services/test_workflow_reaper.py`** — updated to stub the new read path (`read_workflow_run_state`) while keeping the mirror's checkpointer re-read.
- **`tests/unit/services/test_read_workflow_run_state.py`** (new) — regression test: two runs sharing a `langgraph_thread_id` with distinct `state_json` hydrate to their own states; plus the missing-`state_json` → `None` case.

## Risks and Mitigations
- **Detached deferred-column load.** `state_json` is mapper-level deferred; hydrating a run after its session closes would be an illegal async lazy-load. Mitigated by undeferring `state_json` in every query feeding the chokepoint (and gating it behind `include_state` so other paths stay cheap).
- **Reversibility.** Writes are unchanged, so reverting the read flip is a one-line body swap in `read_workflow_run_state` — no data migration or write-path rollback.
- **Pre-merge operator steps (from the Linear issue):** apply migration, deploy PR 1, run the `state_json` backfill, and let in-flight workflows yield once post-deploy before merging this.

## Verification
- `uv run mypy .` — clean (359 files).
- `uv run pytest` on affected suites (workflow_runs, references, reaper, runner, deferred-column integration) — 204 passed.
- Still recommended pre-merge: E2E eval + a manual History-UI check that per-run rows show distinct state (requires running backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
