### PR TITLE
feat(workflow-types): ballpark run-duration estimate per assessment

### DIFF
--- a/frontend/components/analysis-wizard/step-analyses.tsx
+++ b/frontend/components/analysis-wizard/step-analyses.tsx
@@ -106,6 +106,7 @@ export function StepAnalyses() {
       </div>
 
       <WorkflowTypeSelector
+        projectId={wizard.projectId ?? undefined}
         selectedTypes={selectedWorkflowTypes}
         onSelectionChange={setSelectedWorkflowTypes}
         headerDescription=""

--- a/frontend/components/workflows/utils.ts
+++ b/frontend/components/workflows/utils.ts
@@ -40,3 +40,25 @@ export const WORKFLOWS_REQUIRING_SUPPORTING_DOCUMENTS: WorkflowRunType[] = [
 export function hasSupportingDocumentsRequirement(selectedTypes: WorkflowRunType[]): boolean {
   return selectedTypes.some((type) => WORKFLOWS_REQUIRING_SUPPORTING_DOCUMENTS.includes(type));
 }
+
+/**
+ * Formats an estimated duration (in seconds) into a short, human-friendly
+ * ballpark label like "~1 min", "~3 min", or "~1.5 hr". Returns null when there
+ * is no estimate to show, so callers can simply skip rendering.
+ *
+ * Sub-minute durations are floored to "~1 min" — showing seconds is noise at
+ * this granularity.
+ */
+export function formatEstimatedDuration(seconds: number | null | undefined): string | null {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) {
+    return null;
+  }
+  const minutes = seconds / 60;
+  if (minutes < 60) {
+    return `~${Math.max(1, Math.round(minutes))} min`;
+  }
+  const hours = minutes / 60;
+  // One decimal below 10 hours (e.g. "~1.5 hr"), whole numbers above.
+  const rounded = hours < 10 ? Math.round(hours * 10) / 10 : Math.round(hours);
+  return `~${rounded} hr`;
+}

--- a/frontend/components/workflows/workflow-config-dialog.tsx
+++ b/frontend/components/workflows/workflow-config-dialog.tsx
@@ -126,6 +126,7 @@ export function WorkflowConfigDialog({ isOpen, type, projectId, onConfirm, onCan
             {(field) => (
               <WorkflowTypeSelector
                 restrictToType={type}
+                projectId={projectId}
                 selectedTypes={field.state.value}
                 onSelectionChange={field.handleChange}
                 disabledTypes={type ? [type] : undefined}

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -27,6 +27,7 @@ import {
   MessageSquareWarning,
   ALargeSmall,
   BookOpen,
+  Clock,
   type LucideIcon,
   FileCheckIcon,
   TableIcon,
@@ -35,7 +36,7 @@ import { cn } from '@/lib/utils';
 import { WorkflowRunType, WorkflowTypeDescription } from '@/lib/generated-api';
 import { Badge } from '../ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-import { WORKFLOWS_REQUIRING_SUPPORTING_DOCUMENTS } from './utils';
+import { WORKFLOWS_REQUIRING_SUPPORTING_DOCUMENTS, formatEstimatedDuration } from './utils';
 
 const workflowTypeIcons: Record<WorkflowRunType, LucideIcon> = {
   [WorkflowRunType.DocumentProcessing]: FileText,
@@ -82,6 +83,8 @@ interface WorkflowTypeCheckboxProps {
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
   disabled?: boolean;
+  /** Median run time in seconds, from historical runs. Hidden when unavailable. */
+  estimatedSeconds?: number | null;
 }
 
 export function WorkflowTypeCheckbox({
@@ -89,9 +92,11 @@ export function WorkflowTypeCheckbox({
   checked,
   onCheckedChange,
   disabled = false,
+  estimatedSeconds,
 }: WorkflowTypeCheckboxProps) {
   const Icon = getWorkflowIcon(workflowType.type);
   const requiresSupportingFiles = needsSupportingFiles(workflowType.type);
+  const estimatedDuration = formatEstimatedDuration(estimatedSeconds);
 
   return (
     <label
@@ -139,11 +144,26 @@ export function WorkflowTypeCheckbox({
 
           <p className="text-sm text-muted-foreground">{workflowType.description}</p>
 
-          {(workflowType.is_experimental ||
+          {(estimatedDuration ||
+            workflowType.is_experimental ||
             workflowType.needs_web_search ||
             requiresSupportingFiles ||
             workflowType.is_qa_screener) && (
             <div className="flex flex-wrap items-center gap-2 pt-1">
+              {estimatedDuration && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="outline" className="flex items-center gap-1 text-xs">
+                      <Clock className="size-3" />
+                      {estimatedDuration}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-xs">
+                    Rough estimate based on how long this assessment has taken on past documents. Actual time varies
+                    with document size and current load.
+                  </TooltipContent>
+                </Tooltip>
+              )}
               {workflowType.is_qa_screener && (
                 <Tooltip>
                   <TooltipTrigger asChild>

--- a/frontend/components/workflows/workflow-type-selector.tsx
+++ b/frontend/components/workflows/workflow-type-selector.tsx
@@ -3,12 +3,15 @@
 import { useMemo } from 'react';
 import { WorkflowRunType, WorkflowTypeDescription } from '@/lib/generated-api';
 import { useWorkflowTypes } from '@/lib/hooks/use-workflow-types';
+import { useWorkflowDurationEstimates } from '@/lib/hooks/use-workflow-duration-estimates';
 import { WorkflowTypeCheckbox } from './workflow-type-checkbox';
 import { useExperimentalFeatures } from '@/context/experimental-features-context';
 
 interface WorkflowTypeSelectorProps {
   /** When set, only this workflow type is listed (e.g. config dialog for a specific analysis). */
   restrictToType?: WorkflowRunType;
+  /** When provided, an estimated run time is shown per assessment. */
+  projectId?: string;
   selectedTypes: WorkflowRunType[];
   onSelectionChange: (types: WorkflowRunType[]) => void;
   disabled?: boolean;
@@ -20,6 +23,7 @@ interface WorkflowTypeSelectorProps {
 
 export function WorkflowTypeSelector({
   restrictToType,
+  projectId,
   selectedTypes,
   onSelectionChange,
   disabled = false,
@@ -29,6 +33,7 @@ export function WorkflowTypeSelector({
   error,
 }: WorkflowTypeSelectorProps) {
   const { workflowTypes: allTypes, categories, isPending: isLoadingWorkflowTypes } = useWorkflowTypes();
+  const { getEstimatedSeconds } = useWorkflowDurationEstimates(projectId);
   const { showExperimentalFeatures } = useExperimentalFeatures();
 
   const workflowTypes = useMemo(() => {
@@ -57,6 +62,7 @@ export function WorkflowTypeSelector({
       checked={selectedTypes.includes(workflowType.type)}
       onCheckedChange={(checked) => handleCheckedChange(workflowType.type, checked === true)}
       disabled={controlsDisabled || disabledTypes.includes(workflowType.type)}
+      estimatedSeconds={getEstimatedSeconds(workflowType.type)}
     />
   );
 

--- a/frontend/lib/generated-api/sdk.gen.ts
+++ b/frontend/lib/generated-api/sdk.gen.ts
@@ -74,6 +74,9 @@ import type {
   GetAppConfigApiAppConfigsKeyGetResponses,
   GetCurrentUserInfoApiUsersMeGetData,
   GetCurrentUserInfoApiUsersMeGetResponses,
+  GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetData,
+  GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetErrors,
+  GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetResponses,
   GetFeedbackApiFeedbackGetData,
   GetFeedbackApiFeedbackGetErrors,
   GetFeedbackApiFeedbackGetResponses,
@@ -511,6 +514,31 @@ export const getWorkflowTypesApiWorkflowTypesGet = <ThrowOnError extends boolean
     responseStyle: 'data',
     security: [{ scheme: 'bearer', type: 'http' }],
     url: '/api/workflow-types',
+    ...options,
+  });
+
+/**
+ * Get Duration Estimates
+ *
+ * Estimated run duration for every workflow type, derived from past runs.
+ *
+ * Lets the UI show a ballpark "how long will this take" before a workflow is
+ * started. `project_id` is accepted for future project-specific refinement but
+ * is not yet factored into the estimate. The underlying aggregate is cached, so
+ * the (potentially heavy) history scan runs at most once per hour.
+ */
+export const getDurationEstimatesApiWorkflowTypesDurationEstimatesGet = <ThrowOnError extends boolean = true>(
+  options: Options<GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetData, ThrowOnError>,
+) =>
+  (options.client ?? client).get<
+    GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetResponses,
+    GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetErrors,
+    ThrowOnError,
+    'data'
+  >({
+    responseStyle: 'data',
+    security: [{ scheme: 'bearer', type: 'http' }],
+    url: '/api/workflow-types/duration-estimates',
     ...options,
   });
 

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -5500,6 +5500,35 @@ export type WorkflowCategoryOrder = {
 };
 
 /**
+ * WorkflowDurationEstimate
+ *
+ * Estimated duration for a single workflow type.
+ */
+export type WorkflowDurationEstimate = {
+  type: WorkflowRunType;
+  /**
+   * Estimated Seconds
+   */
+  estimated_seconds: number | null;
+  /**
+   * Sample Size
+   */
+  sample_size: number;
+};
+
+/**
+ * WorkflowDurationEstimatesResponse
+ *
+ * Duration estimates for every workflow type with historical data.
+ */
+export type WorkflowDurationEstimatesResponse = {
+  /**
+   * Estimates
+   */
+  estimates: Array<WorkflowDurationEstimate>;
+};
+
+/**
  * WorkflowError
  *
  * Error object for the overall workflow or specific chunks.
@@ -6301,6 +6330,38 @@ export type GetWorkflowTypesApiWorkflowTypesGetResponses = {
 
 export type GetWorkflowTypesApiWorkflowTypesGetResponse =
   GetWorkflowTypesApiWorkflowTypesGetResponses[keyof GetWorkflowTypesApiWorkflowTypesGetResponses];
+
+export type GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetData = {
+  body?: never;
+  path?: never;
+  query: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  url: '/api/workflow-types/duration-estimates';
+};
+
+export type GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetError =
+  GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetErrors[keyof GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetErrors];
+
+export type GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: WorkflowDurationEstimatesResponse;
+};
+
+export type GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetResponse =
+  GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetResponses[keyof GetDurationEstimatesApiWorkflowTypesDurationEstimatesGetResponses];
 
 export type DownloadFileApiFilesDownloadFileIdGetData = {
   body?: never;

--- a/frontend/lib/hooks/use-workflow-duration-estimates.ts
+++ b/frontend/lib/hooks/use-workflow-duration-estimates.ts
@@ -1,0 +1,36 @@
+import { useQuery } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { getDurationEstimatesApiWorkflowTypesDurationEstimatesGet, WorkflowRunType } from '../generated-api';
+
+/**
+ * Fetches the empirical "how long will this take" estimate for every workflow
+ * type. Estimates are derived from past runs and change slowly, so they are
+ * cached aggressively on the client. Disabled until a projectId is available.
+ */
+export function useWorkflowDurationEstimates(projectId: string | undefined) {
+  const query = useQuery({
+    queryKey: ['workflow-duration-estimates', projectId],
+    enabled: !!projectId,
+    staleTime: 1000 * 60 * 10, // 10 minutes — estimates drift slowly
+    queryFn: async () => {
+      return await getDurationEstimatesApiWorkflowTypesDurationEstimatesGet({
+        query: { project_id: projectId! },
+      });
+    },
+  });
+
+  const estimatesByType = useMemo(() => {
+    const map = new Map<WorkflowRunType, number | null>();
+    for (const estimate of query.data?.estimates ?? []) {
+      map.set(estimate.type, estimate.estimated_seconds);
+    }
+    return map;
+  }, [query.data]);
+
+  const getEstimatedSeconds = useCallback(
+    (type: WorkflowRunType): number | null => estimatesByType.get(type) ?? null,
+    [estimatesByType],
+  );
+
+  return { ...query, estimatesByType, getEstimatedSeconds };
+}

--- a/lib/api/routers/workflow_types.py
+++ b/lib/api/routers/workflow_types.py
@@ -1,15 +1,33 @@
 from typing import Optional
 
+import aiotools
 from fastapi import APIRouter, Depends
 
 from lib.api.auth import get_current_user_optional
 from lib.models.user import User
+from lib.services.workflow_duration_estimates import (
+    WorkflowDurationEstimatesResponse,
+    get_workflow_duration_estimates,
+)
 from lib.services.workflow_types import (
     WorkflowTypesResponse,
     get_workflow_types_for_user,
 )
 
 router = APIRouter(tags=["workflow-types"])
+
+# Cache the duration-estimates aggregate (a full workflow_runs scan) at the
+# endpoint layer. aiotools.lru_cache is functools.lru_cache for coroutines and
+# adds a TTL, so the heavy query runs at most once per hour. Keyed by project_id
+# so it stays correct once estimates become project-specific.
+_ESTIMATES_CACHE_TTL_SECONDS = 3600
+
+
+@aiotools.lru_cache(maxsize=128, expire_after=_ESTIMATES_CACHE_TTL_SECONDS)
+async def _cached_duration_estimates(
+    project_id: str,
+) -> WorkflowDurationEstimatesResponse:
+    return await get_workflow_duration_estimates(project_id)
 
 
 @router.get("/api/workflow-types", response_model=WorkflowTypesResponse)
@@ -20,3 +38,22 @@ async def get_workflow_types(user: Optional[User] = Depends(get_current_user_opt
     QA Screener workflows are only visible to RAND and ADMIN roles.
     """
     return get_workflow_types_for_user(user)
+
+
+@router.get(
+    "/api/workflow-types/duration-estimates",
+    response_model=WorkflowDurationEstimatesResponse,
+)
+async def get_duration_estimates(
+    project_id: str,
+    user: Optional[User] = Depends(get_current_user_optional),
+):
+    """
+    Estimated run duration for every workflow type, derived from past runs.
+
+    Lets the UI show a ballpark "how long will this take" before a workflow is
+    started. `project_id` is accepted for future project-specific refinement but
+    is not yet factored into the estimate. The response is cached for an hour at
+    the endpoint layer (see `_cached_duration_estimates`).
+    """
+    return await _cached_duration_estimates(project_id)

--- a/lib/services/workflow_duration_estimates.py
+++ b/lib/services/workflow_duration_estimates.py
@@ -1,0 +1,101 @@
+"""Pre-run duration estimates for workflow types.
+
+Estimates are derived empirically from the wall-clock duration of past
+COMPLETED runs (`completed_at - started_at`), aggregated per workflow type.
+
+The aggregate scans the whole `workflow_runs` history. Callers that serve this
+on a hot path (e.g. the API endpoint) are expected to cache the result; this
+module always recomputes.
+"""
+
+import logging
+
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlmodel import and_, col
+
+from lib.config.database import get_async_db_session
+from lib.models.workflow_run import WorkflowRun, WorkflowRunStatus
+from lib.workflows.models import WorkflowRunType
+
+logger = logging.getLogger(__name__)
+
+# Median ≈ the "typical" run. Robust to the occasional very slow outlier, which
+# a mean would let drag the estimate up.
+_ESTIMATE_PERCENTILE = 0.5
+
+
+class WorkflowDurationEstimate(BaseModel):
+    """Estimated duration for a single workflow type."""
+
+    type: WorkflowRunType
+    estimated_seconds: float | None
+    sample_size: int
+
+
+class WorkflowDurationEstimatesResponse(BaseModel):
+    """Duration estimates for every workflow type with historical data."""
+
+    estimates: list[WorkflowDurationEstimate]
+
+
+async def get_workflow_duration_estimates(
+    project_id: str | None = None,
+) -> WorkflowDurationEstimatesResponse:
+    """Median run duration (seconds) and sample size per workflow type.
+
+    Only COMPLETED runs are counted (CANCELLED / FAILED / timed-out runs would
+    skew the estimate), and runs missing either timestamp are excluded. Always
+    recomputes — callers on a hot path should cache the result.
+
+    `project_id` is accepted but not yet used: the estimate is currently a
+    global aggregate. It is part of the signature so the estimate can later be
+    refined with project-specific characteristics (document size, reference
+    count, etc.) without changing the API surface.
+    """
+    # Subtract two epoch extractions rather than the datetimes directly so the
+    # expression stays plain numeric arithmetic (cleaner typing, same result).
+    duration_seconds = func.extract(
+        "epoch", col(WorkflowRun.completed_at)
+    ) - func.extract("epoch", col(WorkflowRun.started_at))
+
+    stmt = (
+        select(
+            col(WorkflowRun.type),
+            func.percentile_cont(_ESTIMATE_PERCENTILE)
+            .within_group(duration_seconds.asc())
+            .label("estimate"),
+            func.count().label("sample_size"),
+        )
+        .where(
+            and_(
+                col(WorkflowRun.status) == WorkflowRunStatus.COMPLETED,
+                col(WorkflowRun.started_at).is_not(None),
+                col(WorkflowRun.completed_at).is_not(None),
+            )
+        )
+        .group_by(col(WorkflowRun.type))
+    )
+
+    async with get_async_db_session() as session:
+        rows = (await session.execute(stmt)).all()
+
+    estimates: list[WorkflowDurationEstimate] = []
+    for row in rows:
+        raw_type, estimate, sample_size = row[0], row[1], row[2]
+        if estimate is None:
+            continue
+        try:
+            workflow_type = WorkflowRunType(raw_type)
+        except ValueError:
+            # Deprecated/unknown type still present in old rows — skip it.
+            continue
+        estimates.append(
+            WorkflowDurationEstimate(
+                type=workflow_type,
+                estimated_seconds=float(estimate),
+                sample_size=int(sample_size),
+            )
+        )
+
+    return WorkflowDurationEstimatesResponse(estimates=estimates)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "fastmcp[tasks]>=3.2.0",
     "cryptography>=46.0.4",
     "pytest-cov>=7.1.0",
+    "aiotools>=2.2.3",
 ]
 
 [tool.mypy]

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiotools"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/82/c14fa975a4d9c3695d2fad07207a64bd9015ee53ee5cd488a7fc91ec6604/aiotools-2.2.3.tar.gz", hash = "sha256:cb6756db339dde5c9bb5091a4ee5fa25e577f074175f4f272c0b4e99e5d6f0de", size = 148598, upload-time = "2025-10-20T08:33:54.763Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/23/73b496e20e1c615aaaa28fa016a2e1cfd802167632653945a853c7f46387/aiotools-2.2.3-py3-none-any.whl", hash = "sha256:f164eb41d17517d8d03da2715e827dd03a0aa99be48c9f7f4463f1129803e18e", size = 46149, upload-time = "2025-10-20T08:33:53.202Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.3"
 source = { registry = "https://pypi.org/simple" }
@@ -250,6 +262,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
 ]
 
 [[package]]
@@ -829,6 +850,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "aiotools" },
     { name = "alembic" },
     { name = "alembic-postgresql-enum" },
     { name = "black" },
@@ -888,6 +910,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=25.1.0" },
+    { name = "aiotools", specifier = ">=2.2.3" },
     { name = "alembic", specifier = ">=1.14.0" },
     { name = "alembic-postgresql-enum", specifier = ">=1.8.0" },
     { name = "black", specifier = ">=25.1.0" },


### PR DESCRIPTION
## Summary

Adds a ballpark "how long will this take" estimate for each assessment type, shown as a `~X min` badge in the two assessment pickers: **Step 3 of project creation** and the **Start Workflow dialog**. The estimate is the median wall-clock duration of past **COMPLETED** runs of that type.

Linear: [RANDZ-549](https://linear.app/ae-studio/issue/RANDZ-549/have-a-ballpark-estimate-of-time-for-running-each-analysis-put-on)

## Motivation

Users picking assessments had no sense of how long each one takes. A rough, data-driven estimate per type sets expectations before they kick off a run.

We deliberately kept it to a **flat per-type median**. During development we backtested size-aware models (raw file bytes and converted-markdown length, both with linear-regression and size-bucketed-median strategies, evaluated out-of-sample on local *and* production data). Document size does **not** usefully predict LLM-workflow wall-clock duration (r² ≈ 0 for the high-volume types; bucketing was net-negative out-of-sample) because per-call latency and concurrency dominate, not content length. So the flat median is, empirically, about as good as it gets on today's data — without the added complexity.

## What's Changed

### Backend
- **`lib/services/workflow_duration_estimates.py`** (new) — `get_workflow_duration_estimates()` computes the median duration + sample size per type via a single `percentile_cont` aggregate over `workflow_runs` (COMPLETED only, both timestamps present). Pure/uncached; returns all types with history.
- **`lib/api/routers/workflow_types.py`** — new `GET /api/workflow-types/duration-estimates?project_id=` endpoint. Cached for an hour via `aiotools.lru_cache` (coroutine-aware + TTL, unlike `functools.lru_cache`). `project_id` is accepted now for future project-specific refinement but is not yet used.
- **`pyproject.toml` / `uv.lock`** — add `aiotools` dependency.

### Frontend
- **`lib/hooks/use-workflow-duration-estimates.ts`** (new) — React Query hook (client-cached, disabled until a `projectId` exists), exposing `getEstimatedSeconds(type)`.
- **`components/workflows/utils.ts`** — `formatEstimatedDuration()` helper formatting seconds into `~X min` / `~X hr`, flooring sub-minute values to `~1 min`.
- **`components/workflows/workflow-type-selector.tsx`** — accepts `projectId`, fetches estimates, passes `estimatedSeconds` to each checkbox.
- **`components/workflows/workflow-type-checkbox.tsx`** — renders a Clock `~X min` badge (with tooltip) per assessment.
- **`components/analysis-wizard/step-analyses.tsx`** & **`components/workflows/workflow-config-dialog.tsx`** — pass `projectId` so both flows show estimates.
- **`lib/generated-api/*`** — regenerated client (additive only) for the new endpoint.

## Risks and Mitigations
- **Thin / noisy data per type.** In production many types have few completed runs with timestamps, so some medians sit on small samples. The API already returns `sample_size`; a follow-up can gate the badge on a minimum sample size. Low risk — purely informational UI.
- **`~1 min` floor hides spread.** Most real medians fall under a minute and collapse to `~1 min`. Intentional for now (seconds-level precision is noise); revisit if more granularity is wanted.
- **Stale estimates.** Server cache is 1h TTL and the client caches 10 min; estimates lag reality by at most that. Acceptable for a ballpark.
- **No schema/migration changes**, no change to workflow execution — read-only aggregate over existing data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)