### PR TITLE
feat(skills): add Tier 1 assessment skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
   },
   "plugins": [
     {
-      "name": "skills",
+      "name": "draft-detective",
       "source": {
         "source": "github",
         "repo": "agencyenterprise/draft-detective"
       },
-      "description": "Document review skills from Draft Detective: validate bibliographic references against authoritative sources, and report document issues in a consistent structured format."
+      "description": "Document review skills from Draft Detective: AI-powered checks that help authors catch issues in their documents before publication."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "skills",
+  "name": "draft-detective",
   "version": "0.1.0",
-  "description": "Document review skills from Draft Detective: validate bibliographic references against authoritative sources, and report document issues in a consistent structured format.",
+  "description": "Document review skills from Draft Detective: AI-powered checks that help authors catch issues in their documents before publication.",
   "author": {
     "name": "Draft Detective"
   },
@@ -12,6 +12,10 @@
     "citations",
     "references",
     "fact-checking",
-    "bibliography"
+    "bibliography",
+    "figures",
+    "tables",
+    "document-structure",
+    "recommendations"
   ]
 }

--- a/skills/document-contents/SKILL.md
+++ b/skills/document-contents/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: document-contents
+description: Use this skill to check that a document contains all required top-level sections — About This, Acknowledgements, Methods, Results, Conclusion, References, and a conditional Appendix. Invoke when asked to verify a document's structure or that its required sections/content are present.
+---
+
+# Document Contents
+
+You are a specialist document reviewer. Check that the document contains each required section below and report any that are missing. Read or search the document's content as needed to evaluate each section.
+
+## Required Sections
+
+Check whether the document contains each of the required sections listed below. For every section that is **missing**, report one issue. For sections that are present, do **not** create an issue.
+
+Evaluate each section by looking for a heading (at any level) or a clearly labelled block of text that serves the purpose of that section. Treat variations in capitalisation and minor wording differences as a match (e.g. "Reference List", "Bibliography", or "Works Cited" all satisfy the **References** requirement).
+
+### 1 — About This
+
+A preface, foreword, or introductory section that explains the purpose, context, and scope of the publication. Common headings: "About This Report", "About This Publication", "Preface", "Foreword", "Introduction".
+
+**If missing → issue title:** "Missing Section: About This"
+
+### 2 — Acknowledgements
+
+A section that credits individuals, organisations, or funding bodies that contributed to the work. Common headings: "Acknowledgements", "Acknowledgments", "Thanks".
+
+**If missing → issue title:** "Missing Section: Acknowledgements"
+
+### 3 — Methods
+
+A section describing the research methodology, data sources, or analytical approach used in the study. Common headings: "Methods", "Methodology", "Research Design", "Data and Methods", "Approach".
+
+**If missing → issue title:** "Missing Section: Methods"
+
+### 4 — Results
+
+A section presenting the key findings or outcomes of the research. Common headings: "Results", "Findings", "Key Findings", "Outcomes".
+
+**If missing → issue title:** "Missing Section: Results"
+
+### 5 — Conclusion
+
+A section summarising the main conclusions, implications, or recommendations. Common headings: "Conclusion", "Conclusions", "Discussion", "Summary", "Recommendations".
+
+**If missing → issue title:** "Missing Section: Conclusion"
+
+### 6 — References
+
+A section listing the bibliographic references cited in the document. Common headings: "References", "Bibliography", "Works Cited", "Reference List", "Sources".
+
+**If missing → issue title:** "Missing Section: References"
+
+### 7 — Appendix (conditional)
+
+Only check for this section if the body text **explicitly mentions** an appendix (e.g. "see Appendix A", "as shown in the appendix"). If such a reference exists but no appendix section is present in the document, add an issue. If there is no reference to an appendix in the body text, skip this check entirely. Common headings: "Appendix", "Appendix A", "Supplementary Material".
+
+**If referenced but missing → issue title:** "Missing Section: Appendix"
+
+## Reporting
+
+For each missing section, report one issue following the conventions defined in the issues skill (`/skills/issues/SKILL.md`). Do not create issues for sections that are present.

--- a/skills/figures-tables-check/SKILL.md
+++ b/skills/figures-tables-check/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: figures-tables-check
+description: Use this skill to check that every figure and table in a document is properly titled/captioned, consistently numbered, referenced in the body text, and that all body-text references resolve to an actual figure or table. Invoke when asked to review or validate the figures and tables in a document for completeness and consistency.
+---
+
+# Figures & Tables Check
+
+You are a specialist document reviewer. Review the document's figures and tables against the rules below and report any issues found. Read or search the document's content as needed to evaluate each rule.
+
+## Rules
+
+Evaluate the document against **every** rule below. For each rule that **fails**, report one issue. For rules that pass, do **not** create an issue.
+
+### Rule 1 — Every figure/table has a title or caption
+
+Every figure and every table in the document must have a descriptive title or caption directly associated with it. Look for labels such as "Figure X:", "Fig. X:", "Table X:" followed by a caption or title string.
+
+**If any figure or table has no title or caption → issue title:** "Figure/Table Missing Title: [label]" (Create one issue per offending figure/table.)
+
+### Rule 2 — All figures and tables are numbered consistently
+
+All figures must follow one numbering scheme throughout the document, and all tables must follow one numbering scheme throughout the document.
+
+Accepted schemes (any is valid; mixing within the same element type is not):
+
+- **Sequential**: Figure 1, Figure 2, Figure 3 … (or Table 1, Table 2 …). Supplementary items may be numbered separately as Figure S1, S2 … or Table S1, S2 …
+- **By chapter**: Figure 4.1, Figure 4.2 … (or Table 4.1, Table 4.2 … where the first digit is the chapter number)
+- **By section / appendix prefix**: items carry the prefix of the section or appendix they belong to — e.g. Figure A.1, A.2 … in Appendix A, Figure B.1, B.2 … in Appendix B, or Table 3.1, 3.2 … in Chapter 3. The prefix (a letter for an appendix, a digit for a chapter) just identifies the section; the trailing number is the sequence within it.
+
+Flag the document if:
+
+- Numbering skips values without explanation (e.g. Figure 1, Figure 3 with no Figure 2 anywhere; or Figure A.1, A.3 with no A.2 in Appendix A)
+- A genuinely arbitrary mix appears within the same element type and section — e.g. plain sequential Figure 1, Figure 2 interleaved with an unrelated Figure 3.1 in the *same* body section, where 3.1 does not correspond to any chapter or appendix prefix
+- An appendix/section prefix does not match its section (e.g. figures in Appendix B numbered A.1, A.2)
+- A figure or table has no number at all
+
+**If inconsistent numbering is found → issue title:** "Inconsistent Numbering: [brief description]"
+
+### Rule 3 — Every figure/table is referenced in the body text
+
+Every figure and table that appears in the document must be cited at least once in the body text (e.g. "see Figure 3", "as shown in Table 2", "(Table S1)"). Cross-references in captions of other figures/tables do not count as body text references.
+
+**If a figure or table is never mentioned in the body → issue title:** "Unreferenced Figure/Table: [label]" (Create one issue per unreferenced figure/table.)
+
+### Rule 4 — Every figure/table mentioned in the body is present in the document
+
+Every figure and table cited in the body text must actually exist in the document. Check that each reference of the form "Figure X", "Fig. X", "Table X" etc. has a corresponding labelled figure or table.
+
+**If a referenced figure/table is absent from the document → issue title:** "Missing Figure/Table: [label referenced in text]" (Create one issue per missing figure/table.)
+
+## Exclusion — Abbreviation / Acronym tables
+
+Many documents contain a dedicated **Abbreviations**, **Acronyms**, or **List of Abbreviations** section. This section typically presents a two-column table (abbreviation | definition) or a simple definition list and is **not** a regular numbered figure or table.
+
+**Exclude these abbreviation/acronym tables from all rules above.** Do not flag them for missing titles, missing numbers, missing body-text references, or any other rule. They are cataloguing tools, not data exhibits, and are handled by a separate analysis.
+
+## Reporting
+
+For each rule that fails, report one issue following the conventions defined in the issues skill (`/skills/issues/SKILL.md`). Do not create issues for rules that pass.

--- a/skills/recommendation-check/SKILL.md
+++ b/skills/recommendation-check/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: recommendation-check
+description: Use this skill to check that each recommendation in a document is directly supported by the document's own findings, classifying it as supported, partially supported, or unsupported. Invoke when asked to verify that recommendations are backed by the evidence presented in the same document.
+---
+
+# Recommendation Check
+
+You are a specialist document reviewer. Evaluate whether each recommendation in the document is directly supported by findings presented elsewhere in the **same** document.
+
+This complements citation-grounding analyses: those check that claims are backed by external sources; this one checks that recommendations are backed by the document's own findings. Read or search the document's content as needed to evaluate the recommendations.
+
+## What counts as a finding
+
+A "finding" is empirical evidence, analysis, data, or a substantive observation presented in the body of the document (e.g. results, case study outcomes, quantitative analysis, expert interviews summarized within the document). A finding must come from the document itself — external citations alone do not count, since other analyses cover citation grounding.
+
+## Procedure
+
+1. **Locate recommendations.** Recommendations typically live in a section titled "Recommendations", "Findings and Recommendations", "Conclusions and Recommendations", or similar. They may also appear in the executive summary, conclusions, or policy implications. A document often contains **multiple recommendation sections** — for example, a high-level summary near the beginning and a detailed version at the end. **Check all of them**, and treat each distinct recommendation as a separate item even when multiple appear in the same paragraph or bullet list. If the same recommendation is restated in multiple sections (e.g. once in a summary and again in a detailed section), evaluate **each occurrence separately** — wording often differs slightly between restatements, and a difference in phrasing can change whether the document's findings actually support it.
+
+2. **For each recommendation, search the document for supporting findings.** Read the body, results, and analysis sections to identify the finding(s) that directly justify the recommendation. Quote the supporting text and note where it appears.
+
+3. **Classify each recommendation as one of:**
+
+   - **supported** — at least one finding in the document directly backs **the recommendation as worded**, including any specific numeric thresholds, percentages, time horizons, or scope qualifiers it contains. If the recommendation introduces a new specific (e.g. "cap at 6 hours", "increase by at least 25 percent", "within 18 months") that is not itself stated or clearly implied by a finding, do **not** classify as supported — choose partially_supported instead.
+
+   - **partially_supported** — a relevant finding exists in the document and substantively backs the *direction* of the recommendation, but one of the following applies:
+     * The recommendation adds a specific threshold, magnitude, or time horizon that is not directly grounded in a finding.
+     * The recommendation addresses only part of what the findings cover, or covers more than the findings do (a small inferential extension).
+     * The recommendation extrapolates from a measured population/site to a closely related but unmeasured one (e.g. from one ward to another ward in the same hospital, or from a pilot region to neighbouring regions of the same kind).
+     * The recommendation is stated weakly or generically but the underlying direction is consistent with the findings.
+
+   - **unsupported** — use this classification when **any** of the following apply:
+     * **Out-of-scope population, geography, or domain.** The recommendation explicitly applies to a group, location, or domain the document's findings did not cover at all (e.g. recommending changes for "contractors worldwide" when the study covered only in-house staff at a single organisation, or for "oncology wards" when only cardiology was studied). Even when the underlying intervention is shown to work in the studied scope, extending to an entirely unstudied scope is **unsupported, not partially_supported**.
+     * **No relevant finding.** The document contains no finding that addresses the subject of the recommendation at all (e.g. recommending equipment replacement when no equipment audit was performed).
+     * **Contradicted by findings.** The available findings directly contradict the recommendation (e.g. recommending an intervention to restore beach width when findings explicitly state no beach-width change was observed).
+
+   **Boundary rule (when in doubt between partially_supported and unsupported):** If the recommendation's *subject* (the population, location, domain, or measurement) was studied at all in the document — even partially — it is at most partially_supported. If the *subject itself* was never measured, it is unsupported.
+
+## Reporting
+
+Report issues following the conventions defined in the issues skill (`/skills/issues/SKILL.md`), using the severity for each classification below:
+
+- For each **supported** recommendation, emit one issue with **severity: none** — these are informational and confirm the recommendation is properly grounded.
+- For each **partially_supported** recommendation, emit one issue with **severity: medium**.
+- For each **unsupported** recommendation, emit one issue with **severity: high**.
+
+Emit one issue per recommendation occurrence (a recommendation restated in multiple sections produces multiple issues, evaluated independently).


### PR DESCRIPTION
## Summary

Implements **Tier 1** of [RANDZ-585](https://linear.app/ae-studio/issue/RANDZ-585) (sub-task of [RANDZ-562](https://linear.app/ae-studio/issue/RANDZ-562) — *Convert assessment workflow types into skills*): the three assessment workflows whose entire logic is already a single `user_prompt` over the document are ported to portable skills under `skills/`.

## Motivation

`figures_tables_check`, `document_structure`, and `recommendation_check` all run on `SimpleDeepAgentManifest` — their logic is nothing but a prompt fed to a generic deep agent that reads the document and emits issues. That is structurally identical to a skill, so they are near-mechanical ports and the lowest-risk first step in the broader effort to move assessment types to skills (following the existing `reference-validation` and `issues` skills).

## What's Changed

### Skills (new)
- `skills/figures-tables-check/SKILL.md` — figures/tables have titles, consistent numbering, body-text references, and resolve to real elements. Lifted from `figures_tables_check`.
- `skills/document-contents/SKILL.md` — required top-level sections are present (About This, Acknowledgements, Methods, Results, Conclusion, References, conditional Appendix). Lifted from `document_structure` ("Document Contents").
- `skills/recommendation-check/SKILL.md` — recommendations are supported by the document's own findings (supported / partially_supported / unsupported, with severity mapping). Lifted from `recommendation_check`.

Each skill copies the workflow prompt verbatim, drops the backend-specific `/main.md` path in favor of a generic "read the document" instruction, and references the `issues` skill (`/skills/issues/SKILL.md`) for output format — matching the convention in `simple_deep_agent/agent.py`.

### Plugin manifests
- `.claude-plugin/plugin.json` — renamed the plugin from `skills` to `draft-detective`; generic description; added `figures`, `tables`, `document-structure`, `recommendations` keywords.
- `.claude-plugin/marketplace.json` — matching `draft-detective` name and generic description.

## Risks and Mitigations

- **Skill namespace change.** Renaming the plugin changes the skill prefix from `skills:*` to `draft-detective:*`. Anything referencing the old prefix would need updating; a repo search found no such references.
- **Prompt drift.** The skills duplicate the workflow prompts rather than sharing a source, so the two can diverge. Scoped intentionally — deduping the manifests against the skills is deferred to a later tier. The workflows are unchanged and continue to function.
- **No behavioral change to the backend.** Skills are auto-discovered (the deep agent globs `skills/`); this PR only adds files and renames the plugin.