### PR TITLE
refactor(workflows): make skill files the single source of truth for deep-agent prompts

### DIFF
--- a/lib/workflows/document_structure/manifest.py
+++ b/lib/workflows/document_structure/manifest.py
@@ -3,70 +3,13 @@
 Checks that a document contains all required top-level sections:
 About This, Acknowledgements, Methods, Results, Conclusion, References,
 and Appendix (only flagged as missing if referenced in the body text).
+
+The rules checked live in the `document-contents` skill
+(`skills/document-contents/SKILL.md`), which is the single source of truth.
 """
 
 from lib.workflows.models import WorkflowRunType
 from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
-
-_USER_PROMPT = """\
-Check whether the document contains each of the required sections listed below.
-For every section that is **missing**, report one issue.
-For sections that are present, do **not** create an issue.
-
-## Required Sections
-
-Evaluate each section by looking for a heading (at any level) or a clearly
-labelled block of text that serves the purpose of that section.  Treat
-variations in capitalisation and minor wording differences as a match
-(e.g. "Reference List", "Bibliography", or "Works Cited" all satisfy
-the **References** requirement).
-
-### 1 — About This
-A preface, foreword, or introductory section that explains the purpose,
-context, and scope of the publication.
-Common headings: "About This Report", "About This Publication", "Preface",
-"Foreword", "Introduction".
-**If missing → issue title:** "Missing Section: About This"
-
-### 2 — Acknowledgements
-A section that credits individuals, organisations, or funding bodies that
-contributed to the work.
-Common headings: "Acknowledgements", "Acknowledgments", "Thanks".
-**If missing → issue title:** "Missing Section: Acknowledgements"
-
-### 3 — Methods
-A section describing the research methodology, data sources, or analytical
-approach used in the study.
-Common headings: "Methods", "Methodology", "Research Design",
-"Data and Methods", "Approach".
-**If missing → issue title:** "Missing Section: Methods"
-
-### 4 — Results
-A section presenting the key findings or outcomes of the research.
-Common headings: "Results", "Findings", "Key Findings", "Outcomes".
-**If missing → issue title:** "Missing Section: Results"
-
-### 5 — Conclusion
-A section summarising the main conclusions, implications, or recommendations.
-Common headings: "Conclusion", "Conclusions", "Discussion",
-"Summary", "Recommendations".
-**If missing → issue title:** "Missing Section: Conclusion"
-
-### 6 — References
-A section listing the bibliographic references cited in the document.
-Common headings: "References", "Bibliography", "Works Cited",
-"Reference List", "Sources".
-**If missing → issue title:** "Missing Section: References"
-
-### 7 — Appendix (conditional)
-Only check for this section if the body text **explicitly mentions** an
-appendix (e.g. "see Appendix A", "as shown in the appendix").
-If such a reference exists but no appendix section is present in the
-document, add an issue.  If there is no reference to an appendix in the
-body text, skip this check entirely.
-Common headings: "Appendix", "Appendix A", "Supplementary Material".
-**If referenced but missing → issue title:** "Missing Section: Appendix"
-"""
 
 
 class DocumentStructureManifest(SimpleDeepAgentManifest):
@@ -78,4 +21,4 @@ class DocumentStructureManifest(SimpleDeepAgentManifest):
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
     is_experimental = False
 
-    user_prompt = _USER_PROMPT
+    skill = "document-contents"

--- a/lib/workflows/figures_tables_check/manifest.py
+++ b/lib/workflows/figures_tables_check/manifest.py
@@ -5,108 +5,13 @@ Validates that every figure and table in the document is consistent:
 - Every figure/table mentioned in the body has an associated image/table present.
 - Every figure/table has a title/caption.
 - All figures/tables are numbered sequentially or by chapter.
+
+The rules checked live in the `figures-tables-check` skill
+(`skills/figures-tables-check/SKILL.md`), which is the single source of truth.
 """
 
 from lib.workflows.models import WorkflowRunType
 from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
-
-_USER_PROMPT = """\
-Evaluate the document against **every** rule below.
-For each rule that **fails**, report one issue.
-For rules that pass, do **not** create an issue.
-
----
-
-## Rules
-
-### Rule 1 — Every figure/table has a title or caption
-
-Every figure and every table in the document must have a descriptive title
-or caption directly associated with it.
-Look for labels such as "Figure X:", "Fig. X:", "Table X:" followed by a
-caption or title string.
-
-**If any figure or table has no title or caption → issue title:**
-"Figure/Table Missing Title: [label]"
-(Create one issue per offending figure/table.)
-
----
-
-### Rule 2 — All figures and tables are numbered consistently
-
-All figures must follow one numbering scheme throughout the document, and
-all tables must follow one numbering scheme throughout the document.
-
-Accepted schemes (any is valid; mixing within the same element type is
-not):
-
-- **Sequential**: Figure 1, Figure 2, Figure 3 … (or Table 1, Table 2 …)
-  Supplementary items may be numbered separately as Figure S1, S2 …
-  or Table S1, S2 …
-- **By chapter**: Figure 4.1, Figure 4.2 … (or Table 4.1, Table 4.2 …
-  where the first digit is the chapter number)
-- **By section / appendix prefix**: items carry the prefix of the
-  section or appendix they belong to — e.g. Figure A.1, A.2 … in
-  Appendix A, Figure B.1, B.2 … in Appendix B, or Table 3.1, 3.2 … in
-  Chapter 3. The prefix (a letter for an appendix, a digit for a
-  chapter) just identifies the section; the trailing number is the
-  sequence within it.
-
-Flag the document if:
-- Numbering skips values without explanation (e.g. Figure 1, Figure 3 with
-  no Figure 2 anywhere; or Figure A.1, A.3 with no A.2 in Appendix A)
-- A genuinely arbitrary mix appears within the same element type and
-  section — e.g. plain sequential Figure 1, Figure 2 interleaved with an
-  unrelated Figure 3.1 in the *same* body section, where 3.1 does not
-  correspond to any chapter or appendix prefix
-- An appendix/section prefix does not match its section (e.g. figures in
-  Appendix B numbered A.1, A.2)
-- A figure or table has no number at all
-
-**If inconsistent numbering is found → issue title:**
-"Inconsistent Numbering: [brief description]"
-
----
-
-### Rule 3 — Every figure/table is referenced in the body text
-
-Every figure and table that appears in the document must be cited at least
-once in the body text (e.g. "see Figure 3", "as shown in Table 2",
-"(Table S1)").
-Cross-references in captions of other figures/tables do not count as body
-text references.
-
-**If a figure or table is never mentioned in the body → issue title:**
-"Unreferenced Figure/Table: [label]"
-(Create one issue per unreferenced figure/table.)
-
----
-
-### Rule 4 — Every figure/table mentioned in the body is present in the document
-
-Every figure and table cited in the body text must actually exist in the
-document.  Check that each reference of the form "Figure X", "Fig. X",
-"Table X" etc. has a corresponding labelled figure or table.
-
-**If a referenced figure/table is absent from the document → issue title:**
-"Missing Figure/Table: [label referenced in text]"
-(Create one issue per missing figure/table.)
-
----
-
-## Exclusion — Abbreviation / Acronym tables
-
-Many documents contain a dedicated **Abbreviations**, **Acronyms**, or
-**List of Abbreviations** section. This section typically presents a
-two-column table (abbreviation | definition) or a simple definition list
-and is **not** a regular numbered figure or table.
-
-**Exclude these abbreviation/acronym tables from all rules above.**
-Do not flag them for missing titles, missing numbers, missing body-text
-references, or any other rule. They are cataloguing tools, not data
-exhibits, and are handled by a separate analysis.
-
-"""
 
 
 class FiguresTablesCheckManifest(SimpleDeepAgentManifest):
@@ -118,4 +23,4 @@ class FiguresTablesCheckManifest(SimpleDeepAgentManifest):
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
     is_experimental = False
 
-    user_prompt = _USER_PROMPT
+    skill = "figures-tables-check"

--- a/lib/workflows/recommendation_check/manifest.py
+++ b/lib/workflows/recommendation_check/manifest.py
@@ -5,101 +5,13 @@ the findings/evidence presented elsewhere in the same document. Complements
 citation-grounding workflows: those check that claims are backed by external
 sources; this one checks that recommendations are backed by the document's
 own findings.
+
+The rules checked live in the `recommendation-check` skill
+(`skills/recommendation-check/SKILL.md`), which is the single source of truth.
 """
 
 from lib.workflows.models import WorkflowRunType
 from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
-
-_USER_PROMPT = """\
-Evaluate whether each recommendation in the document is directly supported \
-by findings presented elsewhere in the same document.
-
-A "finding" is empirical evidence, analysis, data, or a substantive observation \
-presented in the body of the document (e.g. results, case study outcomes, \
-quantitative analysis, expert interviews summarized within the document). \
-A finding must come from the document itself — external citations alone do \
-not count, since other analyses cover citation grounding.
-
-## Procedure
-
-1. **Locate recommendations.** Recommendations typically live in a section \
-titled "Recommendations", "Findings and Recommendations", "Conclusions and \
-Recommendations", or similar. They may also appear in the executive summary, \
-conclusions, or policy implications. A document often contains **multiple \
-recommendation sections** — for example, a high-level summary near the \
-beginning and a detailed version at the end. **Check all of them**, and treat \
-each distinct recommendation as a separate item even when multiple appear in \
-the same paragraph or bullet list. If the same recommendation is restated in \
-multiple sections (e.g. once in a summary and again in a detailed section), \
-evaluate **each occurrence separately** — wording often differs slightly \
-between restatements, and a difference in phrasing can change whether the \
-document's findings actually support it.
-
-2. **For each recommendation, search the document for supporting findings.** \
-Read the body, results, and analysis sections to identify the finding(s) \
-that directly justify the recommendation. Quote the supporting text and note \
-where it appears.
-
-3. **Classify each recommendation as one of:**
-
-   - **supported** — at least one finding in the document directly backs \
-**the recommendation as worded**, including any specific numeric thresholds, \
-percentages, time horizons, or scope qualifiers it contains. If the \
-recommendation introduces a new specific (e.g. "cap at 6 hours", "increase \
-by at least 25 percent", "within 18 months") that is not itself stated or \
-clearly implied by a finding, do **not** classify as supported — choose \
-partially_supported instead.
-
-   - **partially_supported** — a relevant finding exists in the document and \
-substantively backs the *direction* of the recommendation, but one of the \
-following applies:
-     * The recommendation adds a specific threshold, magnitude, or time \
-horizon that is not directly grounded in a finding.
-     * The recommendation addresses only part of what the findings cover, \
-or covers more than the findings do (a small inferential extension).
-     * The recommendation extrapolates from a measured population/site to \
-a closely related but unmeasured one (e.g. from one ward to another ward \
-in the same hospital, or from a pilot region to neighbouring regions of \
-the same kind).
-     * The recommendation is stated weakly or generically but the underlying \
-direction is consistent with the findings.
-
-   - **unsupported** — use this classification when **any** of the following \
-apply:
-     * **Out-of-scope population, geography, or domain.** The recommendation \
-explicitly applies to a group, location, or domain the document's findings \
-did not cover at all (e.g. recommending changes for "contractors worldwide" \
-when the study covered only in-house staff at a single organisation, or for \
-"oncology wards" when only cardiology was studied). Even when the underlying \
-intervention is shown to work in the studied scope, extending to an entirely \
-unstudied scope is **unsupported, not partially_supported**.
-     * **No relevant finding.** The document contains no finding that \
-addresses the subject of the recommendation at all (e.g. recommending \
-equipment replacement when no equipment audit was performed).
-     * **Contradicted by findings.** The available findings directly \
-contradict the recommendation (e.g. recommending an intervention to \
-restore beach width when findings explicitly state no beach-width change \
-was observed).
-
-   **Boundary rule (when in doubt between partially_supported and \
-unsupported):** If the recommendation's *subject* (the population, location, \
-domain, or measurement) was studied at all in the document — even partially \
-— it is at most partially_supported. If the *subject itself* was never \
-measured, it is unsupported.
-
-## Reporting
-
-- For each **supported** recommendation, emit one issue with \
-**severity: none** — these are informational and confirm the recommendation \
-is properly grounded.
-- For each **partially_supported** recommendation, emit one issue with \
-**severity: medium**.
-- For each **unsupported** recommendation, emit one issue with \
-**severity: high**.
-
-Emit one issue per recommendation occurrence (a recommendation restated in \
-multiple sections produces multiple issues, evaluated independently).
-"""
 
 
 class RecommendationCheckManifest(SimpleDeepAgentManifest):
@@ -115,4 +27,4 @@ class RecommendationCheckManifest(SimpleDeepAgentManifest):
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
     is_experimental = True
 
-    user_prompt = _USER_PROMPT
+    skill = "recommendation-check"

--- a/lib/workflows/simple_deep_agent/manifest_base.py
+++ b/lib/workflows/simple_deep_agent/manifest_base.py
@@ -1,8 +1,9 @@
 """Base manifest for simple single-node deep-agent workflows.
 
 Subclasses only need to declare class-level attributes (type, name, description,
-user_prompt) and the usual WorkflowManifest metadata fields.
-The graph, node, state construction, and issue conversion are all handled here.
+and either `skill` or `user_prompt`) and the usual WorkflowManifest metadata
+fields. The graph, node, state construction, and issue conversion are all
+handled here.
 """
 
 from typing import TYPE_CHECKING, ClassVar, List, Optional, Type
@@ -16,6 +17,7 @@ from lib.workflows.decorators import register_node
 from lib.workflows.manifest import WorkflowManifest
 from lib.workflows.models import DocumentIssue
 from lib.workflows.simple_deep_agent.agent import SimpleDeepAgent
+from lib.workflows.simple_deep_agent.skill_prompt import load_skill_prompt
 from lib.workflows.simple_deep_agent.state import (
     SimpleDeepAgentConfig,
     SimpleDeepAgentState,
@@ -35,7 +37,12 @@ class SimpleDeepAgentManifest(
         type: WorkflowRunType
         name: str
         description: str
-        user_prompt: str   — the rules/criteria to check (used as the human message)
+        and exactly one prompt source:
+            skill: str         — name of the skill under `skills/` whose
+                                 SKILL.md body holds the rules/criteria
+                                 (the single source of truth, preferred), OR
+            user_prompt: str   — the rules/criteria inline (used as the human
+                                 message)
 
     Optional overrides:
         system_prompt: str  — overrides the default generic system prompt
@@ -43,9 +50,24 @@ class SimpleDeepAgentManifest(
         (plus any WorkflowManifest fields: required_dependencies, order, etc.)
     """
 
-    user_prompt: ClassVar[str]
+    skill: ClassVar[Optional[str]] = None
+    user_prompt: ClassVar[Optional[str]] = None
     system_prompt: ClassVar[Optional[str]] = None
     include_supporting_files: ClassVar[bool] = False
+
+    def resolve_user_prompt(self) -> str:
+        """Resolve the rules/criteria used as the deep agent's user prompt.
+
+        Prefers the referenced skill (the single source of truth) and falls
+        back to an inline `user_prompt`. Exactly one must be defined.
+        """
+        if self.skill is not None:
+            return load_skill_prompt(self.skill)
+        if self.user_prompt is not None:
+            return self.user_prompt
+        raise ValueError(
+            f"{type(self).__name__} must define either `skill` or `user_prompt`"
+        )
 
     def get_state_type(self) -> Type[SimpleDeepAgentState]:
         return SimpleDeepAgentState
@@ -62,7 +84,7 @@ class SimpleDeepAgentManifest(
             agent = SimpleDeepAgent(
                 context=runtime.context,
                 system_prompt=manifest.system_prompt,
-                user_prompt=manifest.user_prompt,
+                user_prompt=manifest.resolve_user_prompt(),
                 include_supporting_files=manifest.include_supporting_files,
             )
             result, messages = await agent.ainvoke({})

--- a/lib/workflows/simple_deep_agent/skill_prompt.py
+++ b/lib/workflows/simple_deep_agent/skill_prompt.py
@@ -1,0 +1,38 @@
+"""Load a skill's markdown body for use as a deep-agent workflow prompt.
+
+Skills under the repo-root `skills/` directory are the single source of truth
+for the rules a deep-agent workflow checks. A workflow references a skill by
+name (e.g. ``"figures-tables-check"``) and the rules live only in
+``skills/<name>/SKILL.md`` — never duplicated in the manifest.
+"""
+
+from pathlib import Path
+
+# Repo root: lib/workflows/simple_deep_agent/skill_prompt.py -> parents[3]
+_SKILLS_DIR = Path(__file__).parents[3] / "skills"
+
+
+def load_skill_prompt(skill_name: str) -> str:
+    """Return the markdown body of ``skills/<skill_name>/SKILL.md``.
+
+    The YAML frontmatter block is stripped; the remaining markdown is the
+    rules/criteria used as the deep agent's user prompt.
+    """
+    skill_path = _SKILLS_DIR / skill_name / "SKILL.md"
+    if not skill_path.is_file():
+        raise FileNotFoundError(f"Skill '{skill_name}' not found at {skill_path}")
+    return _strip_frontmatter(skill_path.read_text())
+
+
+def _strip_frontmatter(content: str) -> str:
+    """Remove a leading YAML frontmatter block (``--- ... ---``) if present."""
+    if not content.startswith("---"):
+        return content
+
+    lines = content.splitlines()
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[i + 1 :]).lstrip("\n")
+
+    # No closing delimiter found — return content unchanged.
+    return content

--- a/tests/unit/workflows/simple_deep_agent/test_skill_prompt.py
+++ b/tests/unit/workflows/simple_deep_agent/test_skill_prompt.py
@@ -1,0 +1,71 @@
+"""Tests for resolving deep-agent prompts from skill files (source of truth)."""
+
+import pytest
+
+from lib.workflows.models import WorkflowRunType
+from lib.workflows.registry import get_workflow_manifest
+from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
+from lib.workflows.simple_deep_agent.skill_prompt import (
+    _strip_frontmatter,
+    load_skill_prompt,
+)
+
+# The Tier 1 workflows whose rules live in a skill file.
+_SKILL_BACKED_WORKFLOWS = [
+    WorkflowRunType.FIGURES_TABLES_CHECK,
+    WorkflowRunType.DOCUMENT_STRUCTURE,
+    WorkflowRunType.RECOMMENDATION_CHECK,
+]
+
+
+def test_strip_frontmatter_removes_leading_yaml_block():
+    content = "---\nname: foo\ndescription: bar\n---\n\n# Title\n\nBody text"
+    assert _strip_frontmatter(content) == "# Title\n\nBody text"
+
+
+def test_strip_frontmatter_no_frontmatter_is_unchanged():
+    content = "# Title\n\nBody text"
+    assert _strip_frontmatter(content) == content
+
+
+def test_strip_frontmatter_unterminated_block_is_unchanged():
+    content = "---\nname: foo\nno closing delimiter"
+    assert _strip_frontmatter(content) == content
+
+
+def test_load_skill_prompt_missing_skill_raises():
+    with pytest.raises(FileNotFoundError):
+        load_skill_prompt("does-not-exist")
+
+
+@pytest.mark.parametrize("workflow_type", _SKILL_BACKED_WORKFLOWS)
+def test_skill_backed_manifest_resolves_prompt(workflow_type: WorkflowRunType):
+    manifest = get_workflow_manifest(workflow_type)
+    assert isinstance(manifest, SimpleDeepAgentManifest)
+    assert manifest.skill is not None
+    assert manifest.user_prompt is None
+
+    prompt = manifest.resolve_user_prompt()
+    assert prompt.strip()
+    # Frontmatter must be stripped — the prompt is markdown, not YAML.
+    assert not prompt.lstrip().startswith("---")
+
+
+def test_resolve_user_prompt_requires_a_source():
+    class _Bare(SimpleDeepAgentManifest):
+        type = WorkflowRunType.FIGURES_TABLES_CHECK
+        name = "bare"
+        description = "no prompt source"
+
+    with pytest.raises(ValueError, match="skill.*user_prompt"):
+        _Bare().resolve_user_prompt()
+
+
+def test_inline_user_prompt_still_supported():
+    class _Inline(SimpleDeepAgentManifest):
+        type = WorkflowRunType.FIGURES_TABLES_CHECK
+        name = "inline"
+        description = "inline prompt"
+        user_prompt = "Check the thing."
+
+    assert _Inline().resolve_user_prompt() == "Check the thing."


### PR DESCRIPTION
## Summary

The three Tier 1 assessment workflows (`figures_tables_check`, `document_structure`, `recommendation_check`) had their rules in **two** places: the `skills/<name>/SKILL.md` files and a duplicated `_USER_PROMPT` copy in each workflow manifest. This PR makes the skill file the single source of truth — the manifests reference a skill by name and the rules live only in the SKILL.md.

## Motivation

Duplicated rules drift. After the Tier 1 skills were added ([#591](https://github.com/agencyenterprise/draft-detective/pull/591)), editing a rule meant editing it in two files and keeping them in sync by hand. The deep agent already mounts the entire `skills/` directory into its runtime filesystem, so the content was always available — the manifest just shouldn't re-embed it.

## What's Changed

### Backend
- **`lib/workflows/simple_deep_agent/skill_prompt.py`** (new) — `load_skill_prompt(name)` reads `skills/<name>/SKILL.md` and strips the YAML frontmatter, returning the markdown body.
- **`lib/workflows/simple_deep_agent/manifest_base.py`** — adds a `skill` class attribute and `resolve_user_prompt()`, which loads from the referenced skill (preferred) or falls back to an inline `user_prompt`. `build_graph` now calls `resolve_user_prompt()`. Inline prompts remain supported.
- **`lib/workflows/figures_tables_check/manifest.py`**, **`document_structure/manifest.py`**, **`recommendation_check/manifest.py`** — dropped the embedded `_USER_PROMPT` blocks (~280 duplicated lines) in favor of a one-line `skill = "<name>"` reference.
- **`tests/unit/workflows/simple_deep_agent/test_skill_prompt.py`** (new) — covers frontmatter stripping, missing-skill errors, each manifest resolving a non-empty prompt, the "must define a source" guard, and the inline fallback.

## Verification

- `uv run mypy .` clean (362 files); new unit tests pass.
- **Prompt diff** — the resolved prompt is semantically identical to the old inline prompt; the only changes are whitespace reflowing plus a header/footer that duplicate the existing system prompt.
- **Before/after e2e evals** — ran all 30 samples across the three evals against both the old (inline) and new (skill-backed) code. **26/30 samples scored identically**; the 4 deltas were bidirectional (some better, some worse) — the signature of `gpt-5.4` run-to-run nondeterminism, not a systematic change. `document_structure` was 100% identical.

## Risks and Mitigations

- **Skill files are now load-bearing for the backend** (not just standalone skills). A missing/renamed skill makes the workflow fail fast at runtime (`FileNotFoundError`); the unit tests guard the current three.
- **Minor: redundant tool call.** Because the skill body is both injected into the prompt *and* mounted in the skills filesystem, the agent sometimes re-reads its own skill file. Harmless and cheap. A future "reference-only" approach (tell the agent to read the skill rather than inject it) would remove this at the cost of a guaranteed round-trip and less determinism; deferred intentionally to keep behavior identical here.