### PR TITLE
feat(live-reports): add v2 workflow using simple deep agent

### DIFF
--- a/evals_inspectai/common/api_client.py
+++ b/evals_inspectai/common/api_client.py
@@ -67,6 +67,7 @@ async def upload_and_start_analysis(
     workflow_types: list[str],
     file_name: str = "document.md",
     supporting_files: list[tuple[str, str]] | None = None,
+    publication_date: str | None = None,
 ) -> str:
     """Upload a document and start analysis workflows.
 
@@ -77,6 +78,9 @@ async def upload_and_start_analysis(
         file_name: Display name for the main document.
         supporting_files: Optional list of (file_name, markdown_content) tuples
             uploaded alongside the main document as multipart `supporting_documents`.
+        publication_date: Optional document publication date (YYYY-MM-DD) passed
+            to the workflow config. Used by date-sensitive workflows such as
+            live reports, which search for sources published after this date.
 
     Returns the project_id.
     """
@@ -114,6 +118,9 @@ async def upload_and_start_analysis(
             data: dict[str, Any] = {}
             for wt in workflow_types:
                 data.setdefault("workflow_types", []).append(wt)
+
+            if publication_date:
+                data["publication_date"] = publication_date
 
             openai_api_key = os.environ.get("EVAL_API_OPENAI_API_KEY")
             if openai_api_key:

--- a/evals_inspectai/e2e/live_reports_v2/dataset.json
+++ b/evals_inspectai/e2e/live_reports_v2/dataset.json
@@ -1,0 +1,21 @@
+[
+  {
+    "input": "# State of the Art in Machine Translation (2017)\n\n## Overview\n\nThis brief summarizes the leading approaches to automated machine translation as of early 2017.\n\n## Claims\n\nPhrase-based statistical machine translation (SMT) is the most accurate and most widely deployed approach to automated translation. Neural approaches show early promise but remain experimental and are not yet competitive with SMT on standard benchmarks for most language pairs.\n\n## References\n\n1. Koehn, P. (2010). Statistical Machine Translation. Cambridge University Press.\n",
+    "publication_date": "2017-01-01",
+    "min_issues": 1,
+    "target_answer": "As of early 2017 the document claims phrase-based statistical machine translation (SMT) is the most accurate approach and that neural approaches are not yet competitive. Evidence published after 2017-01-01 shows neural machine translation (notably the Transformer architecture and subsequent neural MT systems) became the dominant, higher-accuracy approach, contradicting the claim. A good result surfaces at least one relevant, real, high-quality source published AFTER 2017-01-01 that updates or challenges this claim, recommends updating the claim or adding a citation, and includes the full citation for the source (authors, year, title, venue, DOI or URL). Fabricated sources, or sources published before the 2017 publication date, should count against the result."
+  },
+  {
+    "input": "# The HTTP Protocol: Current Version (2015)\n\n## Overview\n\nThis brief describes the current state of the Hypertext Transfer Protocol (HTTP) as of the start of 2015.\n\n## Claim\n\nHTTP/1.1 is the current and latest version of the HTTP protocol. It is the most recent standardized version and there is no newer standardized version of HTTP in use.\n\n## References\n\n1. Fielding, R., et al. (1999). RFC 2616: Hypertext Transfer Protocol -- HTTP/1.1. IETF.\n",
+    "publication_date": "2015-01-01",
+    "min_issues": 1,
+    "target_answer": "As of the start of 2015 the document claims HTTP/1.1 is the current and latest standardized version of HTTP, with no newer standardized version. Evidence published after 2015-01-01 contradicts this: HTTP/2 was standardized as RFC 7540 in May 2015, and HTTP/3 as RFC 9114 in 2022. A good result surfaces at least one relevant, real source published AFTER 2015-01-01 (e.g. the HTTP/2 or HTTP/3 RFC) that updates or challenges the claim, recommends updating the claim or adding a citation, and includes the full citation (title, year, publisher/standards body, and URL). Fabricated sources, or sources published before the 2015 publication date, should count against the result."
+  },
+  {
+    "input": "# Internal Note: Renaming the Export Button\n\n## Context\n\nThis internal note documents a minor UI copy change in our web application. The button currently labelled \"Download\" on the reports page will be renamed to \"Export\". This is a cosmetic wording change with no functional impact, and the note makes no empirical, scientific, or statistical claims.\n\n## Decision\n\nWe will rename the button in the next release. No user research or external literature informed or is relevant to this decision.\n\n## References\n\nNone.\n",
+    "publication_date": "2026-01-01",
+    "min_issues": 0,
+    "max_issues": 2,
+    "target_answer": "This is an internal product note with no substantive empirical or scientific claims and no bibliography. No newer evidence could meaningfully update or challenge it, so few or no recommendations are appropriate. A good result returns an empty or very short issue list and a brief report explaining that no updates from newer sources are warranted. Any recommended sources must be genuinely relevant; padding the output with tangential or fabricated citations should count against the result."
+  }
+]

--- a/evals_inspectai/e2e/live_reports_v2/live_reports_v2_e2e.py
+++ b/evals_inspectai/e2e/live_reports_v2/live_reports_v2_e2e.py
@@ -1,0 +1,168 @@
+"""E2E eval for the live_reports_v2 workflow.
+
+Live Reports searches the web for sources published *after* the document's
+publication date that update or challenge its claims, returning the
+simple-deep-agent output (`AgentCheckResult`: a list of `issues` plus a
+`report_markdown` addendum). Each sample sets an explicit (old) publication
+date so that newer post-date sources exist to be found.
+
+Because the recommended sources come from live web search, the output is
+non-deterministic — so we score on stable structural signals (issue-count band,
+valid line ranges, report contains citations) plus an LLM-graded rubric stored
+per-sample in the dataset.
+"""
+
+import json
+import re
+from pathlib import Path
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, json_dataset
+from inspect_ai.model import ModelOutput
+from inspect_ai.scorer import Score
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+
+from evals_inspectai.common.api_client import (
+    poll_until_complete,
+    upload_and_start_analysis,
+)
+from evals_inspectai.common.errors import WorkflowCompletionError
+from evals_inspectai.common.loaders import resolve_input
+from evals_inspectai.common.scorers import model_graded_check, structured_output_scorer
+from evals_inspectai.common.simple_deep_agent_types import SimpleDeepAgentOutput
+
+_TARGET_WORKFLOW = "live_reports_v2"
+
+# Matches a 4-digit year (19xx/20xx) or a DOI/URL token — used to heuristically
+# confirm the report includes full citations for recommended sources.
+_CITATION_HINT = re.compile(r"\b(?:19|20)\d{2}\b|https?://|doi\.org|10\.\d{4,}", re.I)
+
+
+def _record_to_sample(record: dict) -> Sample:
+    return Sample(
+        input=resolve_input(record["input"]),
+        target=record.get("target_answer", ""),
+        metadata={
+            "publication_date": record.get("publication_date"),
+            "min_issues": record.get("min_issues", 0),
+            "max_issues": record.get("max_issues"),
+            "target_answer": record.get("target_answer", ""),
+        },
+    )
+
+
+@solver
+def live_reports_v2_solver(
+    timeout_s: float = 1800,
+    poll_interval_s: float = 5,
+) -> Solver:
+    """Run live_reports_v2 via the API, passing the sample's publication date.
+
+    A custom solver (rather than the shared ``api_workflow_agent``) is needed
+    because Live Reports is date-sensitive: it only searches for sources
+    published after the document's publication date, so each sample supplies an
+    explicit (old) date via metadata.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        meta = state.metadata or {}
+
+        project_id = await upload_and_start_analysis(
+            file_content=state.input_text,
+            file_name="eval-document.md",
+            workflow_types=[_TARGET_WORKFLOW],
+            publication_date=meta.get("publication_date"),
+        )
+
+        try:
+            run_detail = await poll_until_complete(
+                project_id=project_id,
+                workflow_type=_TARGET_WORKFLOW,
+                timeout_s=timeout_s,
+                interval_s=poll_interval_s,
+            )
+        except TimeoutError as e:
+            raise WorkflowCompletionError(str(e)) from e
+
+        workflow_state = run_detail.get("state") or {}
+        workflow_state.pop("messages", [])
+
+        state.output = ModelOutput(
+            completion=json.dumps(workflow_state),
+            model="api",
+        )
+        return state
+
+    return solve
+
+
+@task
+def live_reports_v2_e2e():
+    dataset = json_dataset(
+        str(Path(__file__).parent / "dataset.json"),
+        _record_to_sample,
+    )
+
+    return Task(
+        dataset=dataset,
+        fail_on_error=0.2,
+        solver=live_reports_v2_solver(timeout_s=1800),
+        scorer=[
+            structured_output_scorer(SimpleDeepAgentOutput, _score_structure),
+            model_graded_check(
+                target_from_metadata="target_answer", partial_credit=True
+            ),
+        ],
+    )
+
+
+def _score_structure(output: SimpleDeepAgentOutput, state: TaskState) -> Score:
+    """Deterministic structural checks, averaged into a [0, 1] score.
+
+    Exact recommended sources are not asserted (web search is non-deterministic);
+    instead we check the output's shape: a result is present with a non-empty
+    report, the issue count falls within the sample's expected band, every issue
+    carries a sane line range, and — when updates are expected — the report
+    includes citation-like detail.
+    """
+    min_issues: int = state.metadata.get("min_issues", 0)
+    max_issues = state.metadata.get("max_issues")
+
+    if output.result is None:
+        return Score(value=0.0, explanation="No result in workflow state")
+
+    issues = output.result.issues
+    report = output.result.report_markdown or ""
+
+    checks: list[tuple[str, bool]] = []
+
+    checks.append(("report_markdown non-empty", bool(report.strip())))
+
+    count_ok = len(issues) >= min_issues
+    if max_issues is not None:
+        count_ok = count_ok and len(issues) <= max_issues
+    band = f">={min_issues}" + (f" and <={max_issues}" if max_issues is not None else "")
+    checks.append((f"issue count {len(issues)} in band ({band})", count_ok))
+
+    line_ranges_ok = all(
+        issue.start_line >= 1 and issue.end_line >= issue.start_line
+        for issue in issues
+    )
+    checks.append(("all issues have valid line ranges", line_ranges_ok))
+
+    # Only meaningful when updates are expected: the report should carry full
+    # citations (years / DOIs / URLs) for the recommended newer sources.
+    if min_issues > 0:
+        checks.append(
+            ("report includes citation detail", bool(_CITATION_HINT.search(report)))
+        )
+
+    passed = sum(1 for _, ok in checks if ok)
+    value = passed / len(checks)
+    failed = [name for name, ok in checks if not ok]
+    explanation = (
+        "All structural checks passed"
+        if not failed
+        else f"Failed: {'; '.join(failed)} ({passed}/{len(checks)} passed)"
+    )
+    return Score(value=value, explanation=explanation)

--- a/frontend/components/results/tabs/workflow-results-renderer.tsx
+++ b/frontend/components/results/tabs/workflow-results-renderer.tsx
@@ -107,6 +107,7 @@ function renderWorkflowResults(
     case WorkflowRunType.FiguresTablesCheck:
     case WorkflowRunType.RecommendationCheck:
     case WorkflowRunType.LiteratureReviewV2:
+    case WorkflowRunType.LiveReportsV2:
       return (
         <SimpleDeepAgentResults
           project={project}

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -53,6 +53,7 @@ const workflowTypeIcons: Record<WorkflowRunType, LucideIcon> = {
   [WorkflowRunType.LiteratureReview]: Library,
   [WorkflowRunType.LiteratureReviewV2]: Library,
   [WorkflowRunType.LiveReports]: Newspaper,
+  [WorkflowRunType.LiveReportsV2]: Newspaper,
   [WorkflowRunType.ReferenceValidation]: FileCheck,
   [WorkflowRunType.ReferenceValidationV2]: FileCheck,
   [WorkflowRunType.CitationSuggester]: Lightbulb,

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -5794,6 +5794,7 @@ export const WorkflowRunType = {
   LiteratureReview: 'literature_review',
   LiteratureReviewV2: 'literature_review_v2',
   LiveReports: 'live_reports',
+  LiveReportsV2: 'live_reports_v2',
   ReferenceValidation: 'reference_validation',
   ReferenceValidationV2: 'reference_validation_v2',
   CitationSuggester: 'citation_suggester',

--- a/lib/workflows/categories.py
+++ b/lib/workflows/categories.py
@@ -65,7 +65,8 @@ WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
             # WorkflowRunType.LITERATURE_REVIEW,  # legacy v1; kept registered so old projects still load.
             WorkflowRunType.LITERATURE_REVIEW_V2,
             WorkflowRunType.CITATION_SUGGESTER,
-            WorkflowRunType.LIVE_REPORTS,
+            # WorkflowRunType.LIVE_REPORTS,  # legacy v1; kept registered so old projects still load.
+            WorkflowRunType.LIVE_REPORTS_V2,
         ],
     ),
 ]

--- a/lib/workflows/live_reports_v2/manifest.py
+++ b/lib/workflows/live_reports_v2/manifest.py
@@ -1,0 +1,41 @@
+from langgraph.graph import START, StateGraph
+from langgraph.graph.state import END
+
+from lib.workflows.context import ContextSchema
+from lib.workflows.live_reports_v2.nodes.live_reports import live_reports
+from lib.workflows.models import WorkflowRunType
+from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
+from lib.workflows.simple_deep_agent.state import SimpleDeepAgentState
+
+
+class LiveReportsV2Manifest(SimpleDeepAgentManifest):
+    """Live Reports implemented with the simple deep-agent pattern.
+
+    Same goal as v1 (surface newer sources published after the document's
+    publication date that update or challenge its claims, and produce an
+    addendum), but returns the standard simple-deep-agent output
+    (`AgentCheckResult`: issues + report_markdown).
+
+    Reuses ``SimpleDeepAgentState``/``SimpleDeepAgentConfig`` and the base
+    ``create_initial_state`` / ``convert_state_to_issues``; only the graph is
+    customised so the agent can use web search and receive the document's
+    extracted bibliography + publication date in its prompt.
+    """
+
+    type = WorkflowRunType.LIVE_REPORTS_V2
+    name = "Live Reports"
+    description = "Have any of your findings been updated or contradicted by newer research? Searches the web for sources published after your document's publish date that may update or challenge your claims. Generates an addendum containing any new evidence."
+    needs_web_search = True
+    is_experimental = True
+    required_dependencies = [
+        WorkflowRunType.REFERENCE_EXTRACTION,
+    ]
+
+    def build_graph(self) -> StateGraph:
+        graph = StateGraph(SimpleDeepAgentState, context_schema=ContextSchema)
+
+        graph.add_node("live_reports", live_reports)
+        graph.add_edge(START, "live_reports")
+        graph.add_edge("live_reports", END)
+
+        return graph  # type: ignore[return-value]

--- a/lib/workflows/live_reports_v2/nodes/live_reports.py
+++ b/lib/workflows/live_reports_v2/nodes/live_reports.py
@@ -1,0 +1,123 @@
+"""Live reports v2 node — runs a simple deep agent with web search.
+
+Mirrors the v1 Live Reports goal (find sources published *after* the document's
+publication date that update or challenge its claims, and produce an addendum)
+but is implemented with the simple deep-agent pattern: the agent reads the
+document from `/main.md` via its tools and returns the standard
+`AgentCheckResult` output (a list of `issues` plus a single `report_markdown`).
+"""
+
+import logging
+from datetime import date
+
+from langchain_core.prompts import PromptTemplate
+from langgraph.runtime import Runtime
+
+from lib.agents.formatting_utils import format_bibliography
+from lib.workflows.context import ContextSchema
+from lib.workflows.decorators import register_node
+from lib.workflows.simple_deep_agent.agent import SimpleDeepAgent
+from lib.workflows.simple_deep_agent.state import SimpleDeepAgentState
+
+logger = logging.getLogger(__name__)
+
+
+class LiveReportsV2Agent(SimpleDeepAgent):
+    """Simple deep agent with a longer timeout for the web-search-heavy
+    live reports pass."""
+
+    timeout = 600
+
+
+_SYSTEM_PROMPT = """\
+You are an expert research analyst producing a "live report" addendum for a document.
+
+## Document
+
+The document is available at `/main.md`. Use your tools to read or search its \
+content as needed. Use web search to find newer literature that may update or \
+challenge the document's claims.
+
+## Reporting
+
+Follow the issue-reporting conventions in the issues skill \
+(`/skills/issues/SKILL.md`). Report each claim that newer evidence would update \
+or strengthen as one issue, and include an overall `report_markdown` addendum.\
+"""
+
+
+_USER_PROMPT = PromptTemplate.from_template(
+    """
+# Role
+You are an expert literature review researcher specializing in finding newer evidence that could update or contextualize existing claims in academic and policy documents.
+
+# Goal
+Read the document at `/main.md` and identify its central claims. For those claims, use web search to find high-quality literature published AFTER the document's publication date that supports, conflicts with, updates, or adds important context to the claim. Then produce an addendum report describing what the authors should update and why.
+
+# Instructions
+1. Identify the document's central claims by reading `/main.md`.
+2. For each central claim, search the web for relevant, high-quality sources published AFTER the document publication date ({document_publication_date}). Classify each source's direction relative to the claim: supporting, conflicting, mixed, or contextual.
+3. Prioritize peer-reviewed academic sources, government/NGO reports, and reputable institutions. Prefer meta-analyses, systematic reviews, and large-scale studies. Focus on the highest-quality and most relevant sources.
+4. Do NOT include sources published before the document publication date, and do NOT re-list sources already present in the document's bibliography below.
+
+# Output Format
+Return your findings as a list of `issues` plus an overall `report_markdown` addendum.
+
+Create **one issue per claim that newer evidence would update or strengthen**, with:
+- **title**: A short title naming the affected claim and the recommended action (e.g. "Update claim: X" or "Add citation: Smith et al. 2024").
+- **description**: What the newer evidence shows and its direction relative to the claim (supporting, conflicting, mixed, contextual).
+- **long_description**: The full details in markdown, including the new source's **full citation** (authors, year, title, venue/publisher, and a URL or DOI link when available), the relevant excerpt or finding, and how it relates to the claim.
+- **suggested_action**: What the authors should do — update the claim (and how), or add a citation — and how to implement it.
+- **severity**: Use "medium" for an actionable update or added citation; use "low" for purely contextual additions.
+- **start_line** / **end_line**: The 1-indexed line range in `/main.md` of the claim/passage this update relates to.
+
+Also provide an overall **report_markdown** addendum that summarizes the most important updates (what to change, how, and why it matters) and includes the **full citation / bibliography entry** for every recommended source (authors, year, title, venue, DOI or URL), so the reader can see at a glance how to find each source.
+
+Remember:
+- Only consider sources published AFTER the document publication date ({document_publication_date}).
+- Do not fabricate any references. If no newer evidence warrants a change for a claim, omit it (do not create an issue for it). If nothing warrants an update, return an empty issue list and a short report saying so.
+
+# NOTE:
+When generating responses, remove or replace all internal citation tokens such as turn1search0, turn2search3, or similar. Do not display raw reference IDs or metadata markers in the final text. Return clean, human-readable output only.
+
+## Document publication date
+{document_publication_date}
+
+## Current bibliography from the document (already cited — do not re-list these)
+```
+{bibliography}
+```
+"""
+)
+
+
+@register_node("Generate live report")
+async def live_reports(
+    state: SimpleDeepAgentState, runtime: Runtime[ContextSchema]
+) -> dict:
+    file_artifacts_service = runtime.context.file_artifacts_service
+
+    references = await file_artifacts_service.get_extracted_references()
+    bibliography = format_bibliography(references)
+    document_publication_date = (
+        state.config.publication_date
+        if state.config.publication_date
+        else date.today().isoformat()
+    )
+
+    user_prompt = _USER_PROMPT.invoke(
+        {
+            "bibliography": bibliography,
+            "document_publication_date": document_publication_date,
+        }
+    ).to_string()
+
+    agent = LiveReportsV2Agent(
+        context=runtime.context,
+        system_prompt=_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        tools=[{"type": "web_search"}],
+    )
+    result, messages = await agent.ainvoke({})
+
+    return {"result": result, "messages": messages}

--- a/lib/workflows/live_reports_v2/nodes/live_reports.py
+++ b/lib/workflows/live_reports_v2/nodes/live_reports.py
@@ -75,6 +75,7 @@ Also provide an overall **report_markdown** addendum that summarizes the most im
 
 Remember:
 - Only consider sources published AFTER the document publication date ({document_publication_date}).
+- Only analyze substantive empirical, scientific, or factual claims that newer research could realistically update. If the document makes no such claims (for example an internal note, administrative memo, or opinion piece), do not invent updates — return an empty issue list and a short report stating that no newer evidence is warranted.
 - Do not fabricate any references. If no newer evidence warrants a change for a claim, omit it (do not create an issue for it). If nothing warrants an update, return an empty issue list and a short report saying so.
 
 # NOTE:

--- a/lib/workflows/models.py
+++ b/lib/workflows/models.py
@@ -93,6 +93,7 @@ class WorkflowRunType(str, Enum):
     LITERATURE_REVIEW = "literature_review"
     LITERATURE_REVIEW_V2 = "literature_review_v2"
     LIVE_REPORTS = "live_reports"
+    LIVE_REPORTS_V2 = "live_reports_v2"
     REFERENCE_VALIDATION = "reference_validation"
     REFERENCE_VALIDATION_V2 = "reference_validation_v2"
     CITATION_SUGGESTER = "citation_suggester"

--- a/lib/workflows/registry.py
+++ b/lib/workflows/registry.py
@@ -84,6 +84,7 @@ def register_all_workflow_manifests():
     from lib.workflows.literature_review.manifest import LiteratureReviewManifest
     from lib.workflows.literature_review_v2.manifest import LiteratureReviewV2Manifest
     from lib.workflows.live_reports.manifest import LiveReportsManifest
+    from lib.workflows.live_reports_v2.manifest import LiveReportsV2Manifest
     from lib.workflows.methodological_alignment.manifest import (
         MethodologicalAlignmentManifest,
     )
@@ -120,6 +121,7 @@ def register_all_workflow_manifests():
         LiteratureReviewManifest(),
         LiteratureReviewV2Manifest(),
         LiveReportsManifest(),
+        LiveReportsV2Manifest(),
         MethodologicalAlignmentManifest(),
         ReferenceDownloaderManifest(),
         ReferenceValidationManifest(),


### PR DESCRIPTION
## Summary

Adds a **v2** of the Live Reports workflow implemented with the project's **simple deep agent** pattern, mirroring `literature_review_v2`. Same goal as v1 — surface newer sources (published *after* the document's publication date) that update or challenge its claims, and produce an addendum — but it returns the standard simple-deep-agent output type (`AgentCheckResult`): a single `report_markdown` plus a list of `issues` (which become inline `DocumentIssue`s in the Document Explorer). The report includes the full citation/bibliography for each recommended source.

v2 becomes the version offered to users in the workflow picker. v1 stays registered so existing project data still loads and old runs still render, but is removed from the picker. v2 keeps `is_experimental = True` (matching v1).

## Motivation

v1 Live Reports is a two-node, multi-agent workflow (`LiveLiteratureReviewAgent` + `EvidenceWeighterAgent` per claim, then `AddendumReportGeneratorAgent`) producing a bespoke `ReportOutput`. Re-implementing it on the simple deep-agent pattern unifies it with the other deep-agent checks (`document_structure`, `figures_tables_check`, `recommendation_check`, `literature_review_v2`): standard `report_markdown` + issues output, shared state, shared frontend renderer, and issues surfaced inline.

## What's Changed

### Backend
- `lib/workflows/models.py` — add `LIVE_REPORTS_V2` to `WorkflowRunType`.
- `lib/workflows/live_reports_v2/manifest.py` — new `LiveReportsV2Manifest(SimpleDeepAgentManifest)`; reuses base state/config/issue-conversion, builds its single-node graph inline, `needs_web_search=True`, `is_experimental=True`, depends on `REFERENCE_EXTRACTION`.
- `lib/workflows/live_reports_v2/nodes/live_reports.py` — node that injects the extracted bibliography + publication date into the prompt (adapted from v1's live-reports framing: find high-quality sources published after the publication date that update/challenge central claims; emit one issue per claim needing an update or added citation, each with the new source's full citation, plus a `report_markdown` addendum) and runs `LiveReportsV2Agent` (a `SimpleDeepAgent` subclass with a 600s timeout) with web search. The prompt declines to invent updates for documents with no substantive empirical/scientific claims (e.g. internal notes).
- `lib/workflows/registry.py` — register v2; **keep v1 registered** so old runs resolve.
- `lib/workflows/categories.py` — show v2 in the "Research & Writing Assistant" picker category; comment out v1 (kept registered).

### Frontend
- `components/results/tabs/workflow-results-renderer.tsx` — route v2 to `SimpleDeepAgentResults`; v1 still renders via `LiveReportsResults`.
- `components/workflows/workflow-type-checkbox.tsx` — add v2 to the workflow-type icon map.
- `lib/generated-api/*` — regenerated via `pnpm run openapi-generate` (new `live_reports_v2` enum value).

### Evals
- `evals_inspectai/e2e/live_reports_v2/` — new end-to-end Inspect AI eval (task + 3-sample inline dataset). Output is non-deterministic (live web search), so scoring combines a **structural scorer** (result present, `report_markdown` non-empty, issue count within a per-sample band, valid line ranges, citation detail when updates are expected) with a per-sample **LLM-graded rubric**. Live Reports is date-sensitive, so a **custom solver** passes each sample's `publication_date`; samples use old publication dates (a 2017 machine-translation doc and a 2015 HTTP doc that newer evidence supersedes, plus a 2026 internal note that warrants no updates). Solver timeout 1800s.
- `evals_inspectai/common/api_client.py` — `upload_and_start_analysis` gains a non-breaking optional `publication_date` argument, forwarded to `/api/start-analysis`.

## Testing
- `uv run mypy .` clean; `npx tsc --noEmit` clean.
- Registry sanity: both `LIVE_REPORTS_V2` and `LIVE_REPORTS` resolve from the registry; v2 graph builds; v2 in the picker category, v1 not.
- E2E eval run against a local server: all 3 samples score **1.0 on the structural scorer and "Correct" on the LLM rubric** — the two outdated-doc samples produce cited update recommendations, and the internal note correctly produces no updates.

## Risks and Mitigations
- **Old data**: v1 stays registered with its state class, manifest, and `LiveReportsResults` view, so existing runs continue to load and render. Verified v1 is no longer in the picker but still resolvable from the registry.
- **No DB migration**: workflow state is JSON keyed by the `WorkflowRunType` string; the new enum value just round-trips.
- **Reuses `SimpleDeepAgentState`**: no new state class and no `workflow_types.py` union change.
- **Shared `api_client` change**: the new `publication_date` argument defaults to `None`, so existing eval callers are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)