### PR TITLE
chore(workflows): hide deprecated Citation Suggester from picker

### DIFF
--- a/lib/workflows/categories.py
+++ b/lib/workflows/categories.py
@@ -64,7 +64,7 @@ WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
         workflows=[
             # WorkflowRunType.LITERATURE_REVIEW,  # legacy v1; kept registered so old projects still load.
             WorkflowRunType.LITERATURE_REVIEW_V2,
-            WorkflowRunType.CITATION_SUGGESTER,
+            # WorkflowRunType.CITATION_SUGGESTER,  # deprecated; superseded by Literature Review. Kept registered so old projects still load.
             # WorkflowRunType.LIVE_REPORTS,  # legacy v1; kept registered so old projects still load.
             WorkflowRunType.LIVE_REPORTS_V2,
         ],


### PR DESCRIPTION
## Summary

Hides the **Citation Suggester** workflow from the workflow selection. It is deprecated — Literature Review now does essentially the same thing — so it should no longer be offered for new runs.

## Motivation

Citation Suggester and Literature Review overlap heavily in purpose (surfacing relevant sources to cite). To avoid presenting users two redundant options, Citation Suggester is being retired from the picker while preserving backward compatibility for existing projects.

## What's Changed

### Backend
- `lib/workflows/categories.py` — comment `WorkflowRunType.CITATION_SUGGESTER` out of the `research_writing_assistant` category, following the same convention used for retired v1 workflows.

The manifest stays registered in `registry.py`, so:
- existing Citation Suggester runs still load and render (via `CitationSuggesterResults`),
- the workflow is simply no longer selectable when picking new workflows to run.

## Risks and Mitigations
- **Old data**: unaffected — the manifest, state type, and result view are untouched; only the picker entry is removed. Verified the type still resolves from the registry and is no longer present in `WORKFLOW_DISPLAY_CONFIG`.
- **No enum/registry/frontend/migration changes** — single-line, low-risk change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)