### PR TITLE
feat(skills): convert literature_review_v2 and live_reports_v2 to source-of-truth skills

### DIFF
--- a/lib/workflows/literature_review_v2/nodes/literature_review.py
+++ b/lib/workflows/literature_review_v2/nodes/literature_review.py
@@ -10,10 +10,10 @@ via its tools and returns the standard `AgentCheckResult` output (a list of
 import logging
 from datetime import date
 
-from langchain_core.prompts import PromptTemplate
 from langgraph.runtime import Runtime
 
 from lib.agents.formatting_utils import format_bibliography
+from lib.skills import load_skill_prompt
 from lib.workflows.context import ContextSchema
 from lib.workflows.decorators import register_node
 from lib.workflows.simple_deep_agent.agent import SimpleDeepAgent
@@ -29,6 +29,10 @@ class LiteratureReviewV2Agent(SimpleDeepAgent):
     timeout = 600
 
 
+# The literature-review *procedure* is the portable `literature-review` skill
+# (the single source of truth). This system prompt carries only the
+# Draft-Detective-specific framing: where the document lives and how to map the
+# skill's recommendations onto the standard issues output contract.
 _SYSTEM_PROMPT = """\
 You are an expert literature review researcher reviewing a document.
 
@@ -40,54 +44,42 @@ content as needed. Use web search to find high-quality academic sources.
 ## Reporting
 
 Follow the issue-reporting conventions in the issues skill \
-(`/skills/issues/SKILL.md`). Report each recommended source as one issue and \
-include an overall `report_markdown` summary.\
+(`/skills/issues/SKILL.md`). Report **one issue per recommended source**, mapping \
+your recommendation onto the issue fields:
+- **title**: name the suggested source and the action (e.g. "Add citation: Smith et al. 2021").
+- **description**: why it should be cited or discussed, including its quality \
+(high/medium/low) and direction relative to the document (supporting, \
+conflicting, mixed, contextual).
+- **long_description**: full details in markdown — authors, year, full citation \
+text, URL/DOI, the relevant excerpt from the source, and the related excerpt \
+from the document.
+- **suggested_action**: the action to take (add a new citation, cite an existing \
+reference in a new place, replace one, or discuss it) and how to implement it.
+- **severity**: "low" by default; "medium" only when a missing or conflicting \
+source is clearly significant.
+- **start_line** / **end_line**: the 1-indexed line range in `/main.md` of the \
+passage the source relates to.
+
+Also include an overall `report_markdown` summarizing the review by topic, with \
+the full citation for every recommended source.\
 """
 
 
-_USER_PROMPT = PromptTemplate.from_template(
-    """
-# Role
-You are an expert literature review researcher tasked with ensuring an article cites the highest quality and most current sources available. However, if the document publication date is provided, you are only to look for references that come BEFORE the document publication date.
+# Backend-injected, per-run inputs appended to the portable skill prompt.
+_INPUTS_TEMPLATE = """\
 
-# Goal
-Given the full article (available at `/main.md`) and its extracted bibliography, identify references that should be cited or discussed to improve the article. These may be:
-- Existing references already listed in the bibliography but not cited in some of the places they should be cited in.
-- New, high-quality references found via web research.
+---
 
-# Instructions
-1. Read the full document (`/main.md`) and bibliography carefully to understand the existing arguments and cited sources for each.
-2. Research relevant high quality references about each topic of discussion and how they could fit in the document as citations.
+## Inputs for this run
 
-# Output Format
-Return your findings as a list of `issues` plus an overall `report_markdown`.
-
-Create **one issue per recommended reference**, with:
-- **title**: A short title naming the suggested source and the recommended action (e.g. "Add citation: Smith et al. 2021").
-- **description**: Why this reference should be cited or discussed, including its quality (high, medium, low) and direction relative to the document (supporting, conflicting, mixed, contextual).
-- **long_description**: The full details of the recommendation in markdown, including: the authors, publication year, full bibliography citation text, URL or DOI link (if available), the relevant excerpt from the reference, and the relevant excerpt from the main document that relates to it.
-- **suggested_action**: What action to take (add a new citation, cite an existing reference in a new place, replace an existing reference, or discuss the reference) and how to implement it.
-- **severity**: Use "low" for these recommendations unless a missing or conflicting source is clearly significant, in which case use "medium".
-- **start_line** / **end_line**: The 1-indexed line range in `/main.md` of the passage that this reference relates to.
-
-Also provide an overall **report_markdown** summarizing your literature review recommendations (topics of discussion and the references proposed for each). For every new source you recommend, include its **full citation / bibliography entry** in the report (authors, year, title, venue/publisher, and a URL or DOI link when available), so the reader can see at a glance how to find each source. A compact way to do this is a "Recommended sources" section listing each source's full bibliography entry as a numbered or bulleted reference.
-
-Remember:
-- If the document publication date is provided, you are only to look for references that come BEFORE the document publication date.
-- Do not fabricate any references. If relevance to the claims cannot be found, omit the recommendation (do not create an issue for it).
-
-# NOTE:
-When generating responses, remove or replace all internal citation tokens such as turn1search0, turn2search3, or similar. Do not display raw reference IDs or metadata markers in the final text. Return clean, human-readable output only.
-
-## Document publication date
+### Document publication date
 {document_publication_date}
 
-## Extracted bibliography
+### Extracted bibliography
 ```
 {bibliography}
 ```
 """
-)
 
 
 @register_node("Review literature")
@@ -104,12 +96,10 @@ async def literature_review(
         else date.today().isoformat()
     )
 
-    user_prompt = _USER_PROMPT.invoke(
-        {
-            "bibliography": bibliography,
-            "document_publication_date": document_publication_date,
-        }
-    ).to_string()
+    user_prompt = load_skill_prompt("literature-review") + _INPUTS_TEMPLATE.format(
+        document_publication_date=document_publication_date,
+        bibliography=bibliography,
+    )
 
     agent = LiteratureReviewV2Agent(
         context=runtime.context,

--- a/lib/workflows/live_reports_v2/nodes/live_reports.py
+++ b/lib/workflows/live_reports_v2/nodes/live_reports.py
@@ -10,10 +10,10 @@ document from `/main.md` via its tools and returns the standard
 import logging
 from datetime import date
 
-from langchain_core.prompts import PromptTemplate
 from langgraph.runtime import Runtime
 
 from lib.agents.formatting_utils import format_bibliography
+from lib.skills import load_skill_prompt
 from lib.workflows.context import ContextSchema
 from lib.workflows.decorators import register_node
 from lib.workflows.simple_deep_agent.agent import SimpleDeepAgent
@@ -29,6 +29,10 @@ class LiveReportsV2Agent(SimpleDeepAgent):
     timeout = 600
 
 
+# The live-report *procedure* is the portable `live-reports` skill (the single
+# source of truth). This system prompt carries only the Draft-Detective-specific
+# framing: where the document lives and how to map the skill's recommendations
+# onto the standard issues output contract.
 _SYSTEM_PROMPT = """\
 You are an expert research analyst producing a "live report" addendum for a document.
 
@@ -41,55 +45,42 @@ challenge the document's claims.
 ## Reporting
 
 Follow the issue-reporting conventions in the issues skill \
-(`/skills/issues/SKILL.md`). Report each claim that newer evidence would update \
-or strengthen as one issue, and include an overall `report_markdown` addendum.\
+(`/skills/issues/SKILL.md`). Report **one issue per claim that newer evidence \
+would update or strengthen**, mapping your recommendation onto the issue fields:
+- **title**: name the affected claim and the action (e.g. "Update claim: X" or "Add citation: Smith et al. 2024").
+- **description**: what the newer evidence shows and its direction relative to \
+the claim (supporting, conflicting, mixed, contextual).
+- **long_description**: full details in markdown — the new source's full citation \
+(authors, year, title, venue/publisher, URL/DOI), the relevant excerpt/finding, \
+and how it relates to the claim.
+- **suggested_action**: what the authors should do (update the claim and how, or \
+add a citation) and how to implement it.
+- **severity**: "medium" for an actionable update or added citation; "low" for \
+purely contextual additions.
+- **start_line** / **end_line**: the 1-indexed line range in `/main.md` of the \
+claim/passage the update relates to.
+
+Also include an overall `report_markdown` addendum summarizing the most important \
+updates, with the full citation for every recommended source. If nothing warrants \
+an update, return an empty issue list and a short report saying so.\
 """
 
 
-_USER_PROMPT = PromptTemplate.from_template(
-    """
-# Role
-You are an expert literature review researcher specializing in finding newer evidence that could update or contextualize existing claims in academic and policy documents.
+# Backend-injected, per-run inputs appended to the portable skill prompt.
+_INPUTS_TEMPLATE = """\
 
-# Goal
-Read the document at `/main.md` and identify its central claims. For those claims, use web search to find high-quality literature published AFTER the document's publication date that supports, conflicts with, updates, or adds important context to the claim. Then produce an addendum report describing what the authors should update and why.
+---
 
-# Instructions
-1. Identify the document's central claims by reading `/main.md`.
-2. For each central claim, search the web for relevant, high-quality sources published AFTER the document publication date ({document_publication_date}). Classify each source's direction relative to the claim: supporting, conflicting, mixed, or contextual.
-3. Prioritize peer-reviewed academic sources, government/NGO reports, and reputable institutions. Prefer meta-analyses, systematic reviews, and large-scale studies. Focus on the highest-quality and most relevant sources.
-4. Do NOT include sources published before the document publication date, and do NOT re-list sources already present in the document's bibliography below.
+## Inputs for this run
 
-# Output Format
-Return your findings as a list of `issues` plus an overall `report_markdown` addendum.
-
-Create **one issue per claim that newer evidence would update or strengthen**, with:
-- **title**: A short title naming the affected claim and the recommended action (e.g. "Update claim: X" or "Add citation: Smith et al. 2024").
-- **description**: What the newer evidence shows and its direction relative to the claim (supporting, conflicting, mixed, contextual).
-- **long_description**: The full details in markdown, including the new source's **full citation** (authors, year, title, venue/publisher, and a URL or DOI link when available), the relevant excerpt or finding, and how it relates to the claim.
-- **suggested_action**: What the authors should do — update the claim (and how), or add a citation — and how to implement it.
-- **severity**: Use "medium" for an actionable update or added citation; use "low" for purely contextual additions.
-- **start_line** / **end_line**: The 1-indexed line range in `/main.md` of the claim/passage this update relates to.
-
-Also provide an overall **report_markdown** addendum that summarizes the most important updates (what to change, how, and why it matters) and includes the **full citation / bibliography entry** for every recommended source (authors, year, title, venue, DOI or URL), so the reader can see at a glance how to find each source.
-
-Remember:
-- Only consider sources published AFTER the document publication date ({document_publication_date}).
-- Only analyze substantive empirical, scientific, or factual claims that newer research could realistically update. If the document makes no such claims (for example an internal note, administrative memo, or opinion piece), do not invent updates — return an empty issue list and a short report stating that no newer evidence is warranted.
-- Do not fabricate any references. If no newer evidence warrants a change for a claim, omit it (do not create an issue for it). If nothing warrants an update, return an empty issue list and a short report saying so.
-
-# NOTE:
-When generating responses, remove or replace all internal citation tokens such as turn1search0, turn2search3, or similar. Do not display raw reference IDs or metadata markers in the final text. Return clean, human-readable output only.
-
-## Document publication date
+### Document publication date
 {document_publication_date}
 
-## Current bibliography from the document (already cited — do not re-list these)
+### Current bibliography from the document (already cited — do not re-list these)
 ```
 {bibliography}
 ```
 """
-)
 
 
 @register_node("Generate live report")
@@ -106,12 +97,10 @@ async def live_reports(
         else date.today().isoformat()
     )
 
-    user_prompt = _USER_PROMPT.invoke(
-        {
-            "bibliography": bibliography,
-            "document_publication_date": document_publication_date,
-        }
-    ).to_string()
+    user_prompt = load_skill_prompt("live-reports") + _INPUTS_TEMPLATE.format(
+        document_publication_date=document_publication_date,
+        bibliography=bibliography,
+    )
 
     agent = LiveReportsV2Agent(
         context=runtime.context,

--- a/skills/capabilities/SKILL.md
+++ b/skills/capabilities/SKILL.md
@@ -27,6 +27,7 @@ These review the document and flag issues.
 | **Recommendation Check** | Is each recommendation supported by the document's own findings? Flags recommendations with weak, indirect, missing, or contradictory backing. | `recommendation-check` |
 | **Internal Inference Validation** | Does the reasoning hold up? Flags logical leaps, unsupported conclusions, and arguments where the evidence doesn't support the claim. | `inference-validation` |
 | **Reviewer 2** | A rigorous simulated peer review — summary, strengths, weaknesses, and prioritized next steps — plus a separate devil's-advocate rebuttal. (Beta.) | `reviewer-2` |
+| **Literature Review** | Are there relevant sources you may have missed? Searches the web for academic sources related to your document's claims — both supporting and conflicting — that aren't already cited. (Beta.) | `literature-review` |
 
 ## Reference tools
 

--- a/skills/capabilities/SKILL.md
+++ b/skills/capabilities/SKILL.md
@@ -28,6 +28,7 @@ These review the document and flag issues.
 | **Internal Inference Validation** | Does the reasoning hold up? Flags logical leaps, unsupported conclusions, and arguments where the evidence doesn't support the claim. | `inference-validation` |
 | **Reviewer 2** | A rigorous simulated peer review — summary, strengths, weaknesses, and prioritized next steps — plus a separate devil's-advocate rebuttal. (Beta.) | `reviewer-2` |
 | **Literature Review** | Are there relevant sources you may have missed? Searches the web for academic sources related to your document's claims — both supporting and conflicting — that aren't already cited. (Beta.) | `literature-review` |
+| **Live Reports** | Have your findings been updated or contradicted by newer research? Searches the web for sources published after your document's date and produces an addendum of what to update. (Beta.) | `live-reports` |
 
 ## Reference tools
 

--- a/skills/literature-review/SKILL.md
+++ b/skills/literature-review/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: literature-review
+description: Use this skill to perform a literature review of a document — surface high-quality academic sources the document should cite or discuss but doesn't, both supporting and conflicting, using web search. Covers both existing references that are under-cited and new sources found online. Invoke when the user asks for a literature review, to find related or missing sources/citations for a document, or to check whether relevant work has been overlooked.
+---
+
+# Literature Review
+
+You are an expert literature review researcher. Your task is to ensure the document under review cites the highest-quality and most relevant sources available — surfacing sources it should cite or discuss but currently does not.
+
+## Goal
+
+Identify references that would improve the document. These fall into two kinds:
+
+- **Existing-but-under-cited**: references already in the document's bibliography that should also be cited (or discussed) in places they currently are not.
+- **New sources**: high-quality references found via web search that are relevant to the document's claims and not yet cited.
+
+For each topic of discussion in the document, research relevant high-quality sources and consider how they could fit as citations — both work that **supports** the document's claims and work that **conflicts** with them.
+
+## Constraints
+
+- **Publication date**: if the document's publication date is known, only recommend sources that were available *before* that date. (Recommending work the authors could not have cited is unhelpful.)
+- **No fabrication**: never invent references. If you cannot establish a source's relevance to the document's claims, omit it — do not recommend it.
+
+## What to capture for each recommended source
+
+- The full citation: authors, publication year, title, venue/publisher, and a URL or DOI when available.
+- Why it should be cited or discussed.
+- Its **quality**: high, medium, or low.
+- Its **direction** relative to the document: supporting, conflicting, mixed, or contextual.
+- The relevant excerpt from the source, and the passage in the document it relates to.
+- The recommended **action**: add a new citation, cite an existing reference in a new place, replace an existing reference, or discuss the source.
+
+## Output
+
+Report each recommended source as a separate, actionable recommendation, and provide an overall summary of the review — organized by topic of discussion — that lists the **full citation** for every source you recommend (so the reader can locate each one at a glance).
+
+Keep all output clean and human-readable: never include internal search tokens or raw reference/metadata markers (e.g. `turn1search0`) in any field.

--- a/skills/live-reports/SKILL.md
+++ b/skills/live-reports/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: live-reports
+description: Use this skill to produce a "live report" addendum for a document — find high-quality literature published AFTER the document's publication date that updates, challenges, supports, or adds context to its claims, using web search, and recommend what the authors should update. Invoke when the user asks whether a document's findings have been updated or contradicted by newer research, or wants an addendum of newer evidence.
+---
+
+# Live Reports
+
+You are an expert research analyst producing a "live report" addendum for the document under review. Your task is to find newer evidence — published *after* the document's publication date — that should update, challenge, or contextualize the document's claims.
+
+## Goal
+
+Identify the document's central claims, then use web search to find high-quality literature published **after the document's publication date** that supports, conflicts with, updates, or adds important context to those claims. Produce an addendum describing what the authors should update and why.
+
+## Instructions
+
+1. Read the document under review and identify its central claims.
+2. For each central claim, search the web for relevant, high-quality sources published **after** the document's publication date. Classify each source's direction relative to the claim: supporting, conflicting, mixed, or contextual.
+3. Prioritize peer-reviewed academic sources, government/NGO reports, and reputable institutions. Prefer meta-analyses, systematic reviews, and large-scale studies. Focus on the highest-quality and most relevant sources.
+4. Do **not** include sources published before the document's publication date, and do **not** re-list sources already cited in the document.
+
+## Constraints
+
+- **Only newer sources**: every recommended source must postdate the document's publication date.
+- **Substantive claims only**: only analyze empirical, scientific, or factual claims that newer research could realistically update. If the document makes no such claims (e.g. an internal note, administrative memo, or opinion piece), do not invent updates — report that no newer evidence is warranted.
+- **No fabrication**: never invent references. If no newer evidence warrants a change for a claim, omit it. If nothing warrants an update, say so plainly.
+
+## What to capture for each update
+
+- The affected claim and the recommended action (update the claim — and how — or add a citation).
+- What the newer evidence shows and its **direction** relative to the claim (supporting, conflicting, mixed, contextual).
+- The new source's full citation: authors, publication year, title, venue/publisher, and a URL or DOI when available.
+- The relevant excerpt or finding from the source, and how it relates to the claim.
+
+## Output
+
+Report each claim that newer evidence would update or strengthen as a separate, actionable recommendation, and provide an overall addendum summarizing the most important updates (what to change, how, and why it matters) with the **full citation** for every recommended source.
+
+Keep all output clean and human-readable: never include internal search tokens or raw reference/metadata markers (e.g. `turn1search0`) in any field.

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -38,6 +38,7 @@ _SKILL_BACKED_AGENTS = [
     "inference-validation",
     "reference-download",
     "literature-review",
+    "live-reports",
 ]
 
 

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -37,6 +37,7 @@ _SKILL_BACKED_AGENTS = [
     "reviewer-2",
     "inference-validation",
     "reference-download",
+    "literature-review",
 ]
 
 


### PR DESCRIPTION
## Summary

Converts two web-search assessment workflows — `literature_review_v2` and `live_reports_v2` — into portable, user-invocable skills (source-of-truth pattern), and lists both in the `capabilities` router. Part of Tier 3 ([RANDZ-587](https://linear.app/ae-studio/issue/RANDZ-587)). The v1 `literature_review` / `live_reports` (bespoke schemas) are untouched.

## Motivation

Make each procedure a standalone skill ("find related/missing sources for this document"; "find newer evidence that updates this document's claims") while keeping the Draft-Detective-specific mechanics in the agent — matching the `reference-download` precedent (generic skill + backend owns the document path, the per-run inputs, and the issues output contract).

## What's Changed

### Skills
- **`skills/literature-review/SKILL.md`** (new) — surface high-quality sources the document should cite/discuss (under-cited existing refs + new web sources; supporting/conflicting), with quality + direction, respecting publication date, no fabrication, summary with full citations.
- **`skills/live-reports/SKILL.md`** (new) — identify central claims, find high-quality sources published *after* the document's publication date that update/challenge/contextualize them, recommend updates; substantive-claims-only, no fabrication, addendum summary.
- Both are fully generic: no `/main.md`, no template placeholders, no issue-schema field names.
- **`skills/capabilities/SKILL.md`** — added **Literature Review** and **Live Reports** under the Assessments group.

### Backend
- **`lib/workflows/literature_review_v2/nodes/literature_review.py`** and **`lib/workflows/live_reports_v2/nodes/live_reports.py`** — each node now loads its skill (`load_skill_prompt(...)`) and appends a per-run **Inputs** block (extracted bibliography + publication date). Each `_SYSTEM_PROMPT` now owns the backend output contract (issue-field mapping, severity, `start_line`/`end_line` in `/main.md`, `report_markdown`). Node flow, agents, manifests, and state are otherwise unchanged.

### Tests
- `tests/unit/test_skills.py` — `literature-review` and `live-reports` added to the skill-load guard.

## Verification
- `uv run mypy .` clean (369 files); unit tests pass.
- Both skills confirmed free of `/main.md`, `{placeholders}`, and issue field names; the composed node prompts still inject bibliography + date, and the system prompts carry the issues/`report_markdown` contract.
- **AFTER e2e:**
  - `literature_review_v2` (3 samples): **1.000** on both scorers.
  - `live_reports_v2`: **2/3 samples 1.0/C**; the 3rd wedged on a transient OpenAI API retry (infra flake, not a content failure) and was stopped rather than waiting out the 30-min solver timeout.
- Both are at/near ceiling, so no regression vs the original is indicated. These are small, web-search-based samples — the scores reflect *no regression*, not a precision guarantee.

## Risks and Mitigations
- Skill files are load-bearing for the nodes; a missing/renamed skill fails fast at runtime (guarded by unit tests).
- Prompts are reworded (not byte-identical) and the workflows hit the live web; the maxed/near-maxed AFTER scores indicate no regression on the evals' samples.