### PR TITLE
feat(skills): convert methodological_alignment to two composed skills

### DIFF
--- a/lib/agents/methodology_comparator.py
+++ b/lib/agents/methodology_comparator.py
@@ -2,7 +2,6 @@ from typing import List, Optional
 
 from langchain.agents import create_agent
 from langchain_core.messages import HumanMessage
-from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables.config import RunnableConfig
 from pydantic import BaseModel, Field
 
@@ -10,6 +9,7 @@ from lib.agents.literature_review import ReferenceType
 from lib.agents.methodology_extractor import ReproducibilityCategoryResponse
 from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
+from lib.skills import load_skill_prompt
 from lib.workflows.context import ContextSchema
 
 
@@ -61,137 +61,6 @@ class MethodologyComparisonResponse(BaseModel):
     )
 
 
-_methodology_comparison_agent_prompt = PromptTemplate.from_template(
-    """
-# Task
-You are an expert methodological reviewer in the relevant scientific field. You are given:
-
-1. A description of a **paper's methodology** (what this paper actually did to obtain its results).
-
-Your job is to compare the paper's methodology to the broader field's methods and produce a clear, structured narrative. You must use web search to find information about typical methods used in the broader field.
-
-## Web Search Instructions
-
-Use web search to:
-- Find typical or canonical methods used in the broader field for similar problems
-- Identify standard practices, data sources, experimental setups, and analytical techniques
-- Locate authoritative sources (peer-reviewed articles, methodological reviews, field standards)
-- Gather information about evaluation practices and rigor standards in the field
-
-When using web search:
-- Focus on high-quality sources (peer-reviewed publications, methodological reviews, field standards)
-- Search for terms related to the paper's methodology and the broader field
-- Look for systematic reviews, meta-analyses, or methodological guidelines when available
-- Consider different disciplinary perspectives if relevant
-
-## Inputs
-
-### Paper methodology
-
-This is the methodology as extracted from the focal paper:
-
-{extracted_methodology}
-
-## Your goals
-
-1. **Characterize the field baseline.**
-   - Use web search to identify and briefly restate what appears to be *standard practice* in the field.
-   - Focus on typical data sources, experimental/observational setups, modeling or analytical techniques, and evaluation practices.
-
-2. **Compare the focal paper to the field baseline.**
-   - Identify key **similarities** between the paper's methodology and standard field practice.
-   - Identify key **differences** or **innovations** in the paper's methodology.
-   - Identify any **missing standard components** (things that are common in the field but absent or very weak in the paper).
-   - Comment on the **rigor and robustness** of the paper's methodology relative to the field norm (e.g., more rigorous, similar, weaker).
-
-3. **Highlight implications and risks.**
-   - Explain how the similarities and differences might affect the **credibility**, **generalizability**, or **interpretability** of the paper's results.
-   - Point out any methodological **risks or limitations** that follow from the paper's deviations from standard practice, or from omissions of common checks.
-
-## Output requirements
-
-For the markdown output of the sections, you must:
-- Approximately **500–900 words** for the overview, alignment, and rigor and risks sections.
-- Approximately **200–400 words** for the suggestions for improvements section.
-- Structured using markdown formatting as shown in the template below.
-- **Mathematical notation**: Any equations, formulas, or mathematical expressions must be written in LaTeX format using `$...$` for inline math and `$$...$$` for display equations.
-
-### Suggested Markdown Format
-
-Format your response using the following markdown structure:
-
-```markdown
-## Extracted Methodology
-
-[Include the full extracted methodology from the paper here. This should be a complete restatement or copy of the methodology provided in the input. Present it clearly and comprehensively so readers understand exactly what methodology was used in the paper before seeing the comparison.]
-
-## Field Methods Overview
-
-[Brief overview of standard practices in the field, based on web search findings. Describe typical data sources, experimental setups, analytical techniques, and evaluation practices used in the broader field.]
-
-## Alignment with Field Practice
-
-### Similarities
-
-[Identify and describe key similarities between the paper's methodology and standard field practice. Use bullet points or paragraphs as appropriate.]
-
-### Differences and Innovations
-
-[Identify and describe key differences or innovations in the paper's methodology compared to standard practice. Highlight what makes the approach novel or different.]
-
-### Missing or Weak Standard Components
-
-[Identify any standard components that are common in the field but absent or weak in the paper. Explain what is typically expected and what is missing.]
-
-## Methodological Rigor and Risks
-
-[Assess the rigor and robustness of the paper's methodology relative to field norms. Explain implications for credibility, generalizability, and interpretability. Highlight any methodological risks or limitations that follow from deviations from standard practice.]
-
-## Suggestions for Improvements
-
-[Based on previous analyses provide a bulleted list of at most three suggestions to change the language of the paper, the data sources used, methodological approaches, etc. to improve the robustness, rigor, or generalizability of the findings.]
-
-
-### Citations
-
-[When referencing sources found through web search, cite them appropriately using markdown links or inline citations, for example: "According to [Source Name](URL)..." or "Smith et al. (2023) found that..."]
-```
-
-**Formatting Guidelines:**
-- Use `##` for main sections (level 2 headings)
-- Use `###` for subsections (level 3 headings)
-- Use `**bold**` for emphasis on key terms
-- Use bullet points (`-`) or numbered lists when listing multiple items
-- Use code blocks (`` ` ``) for technical terms or specific values
-- Include citations with markdown links when referencing web search sources
-- Keep paragraphs focused and well-structured
-- **Mathematical equations**: All equations must be formatted in LaTeX notation:
-- For inline equations, use single dollar signs: `$E = mc^2$`
-- For block/display equations, use double dollar signs on separate lines:
-```latex
-$$E = mc^2$$
-```
-- Always use proper LaTeX syntax for mathematical notation (e.g., `\\alpha`, `\\beta`, `\\sum`, `\\prod`, `\\frac{{a}}{{b}}`, `\\sqrt{{x}}`, etc.)
-- When describing equations from the paper, convert them to LaTeX format rather than using plain text or Unicode characters
-
-Additional guidance:
-
-- **Start with the extracted methodology**: The first section must be "## Extracted Methodology" and should contain the full methodology from the paper. This allows readers to understand what was done before seeing how it compares to the field.
-- **CRITICAL**: You MUST include citations for all claims about field practices that come from web search.
-- Format citations as markdown links: [Source Title](URL) immediately after the claim.
-- Base your reasoning on the provided paper methodology and information found through web search.
-- When something seems important but is not specified in the paper methodology, explicitly note that it is **not specified** rather than guessing.
-- You may generalize about the field when it is clearly supported by web search results, but avoid fabricating very specific claims or citations.
-- When using web search results, cite the sources appropriately in your comparison narrative.
-
-# NOTE:
-When generating responses,REMOVE OR REPLACE ALL INTERNAL CITATION TOKENS SUCH AS turn1search0, turn2search3, or similar. DO NOT DISPLAY RAW REFERENCE IDS OR METADATA MARKERS IN THE FINAL TEXT. RETURN CLEAN, HUMAN-READABLE OUTPUT ONLY.
-
-Now write the comparison as described above.
-"""
-)
-
-
 class MethodologyComparisonAgent(LangChainAgent):
     name = "Methodology Comparison Agent"
     description = (
@@ -214,7 +83,12 @@ class MethodologyComparisonAgent(LangChainAgent):
                 "extracted_methodology": str,  # output of MethodologyExtractorAgent
             }
         """
-        prompt = _methodology_comparison_agent_prompt.invoke(prompt_kwargs)
+        content = (
+            load_skill_prompt("methodology-comparison")
+            + "\n\n## Inputs for this run\n\n"
+            + "### Paper methodology (extracted per the methodology-extraction skill)\n\n"
+            + prompt_kwargs["extracted_methodology"]
+        )
 
         agent = create_agent(
             self.llm,
@@ -224,7 +98,7 @@ class MethodologyComparisonAgent(LangChainAgent):
         )
 
         result = await agent.ainvoke(  # type: ignore[call-overload]
-            {"messages": [HumanMessage(content=prompt.to_string())]},
+            {"messages": [HumanMessage(content=content)]},
             config=config,
             context=self.context,
         )

--- a/lib/agents/methodology_extractor.py
+++ b/lib/agents/methodology_extractor.py
@@ -2,7 +2,7 @@
 from enum import Enum
 from typing import Optional, cast
 
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.messages import HumanMessage
 from langchain_core.runnables.config import RunnableConfig
 from pydantic import BaseModel, Field
 
@@ -10,6 +10,7 @@ from lib.config.env import config
 from lib.config.llm_models import gpt_5_mini_model
 from lib.agents.models import ReproducibilityCategory
 from lib.models.agent import LangChainAgent
+from lib.skills import load_skill_prompt
 from lib.workflows.context import ContextSchema
 
 
@@ -38,119 +39,6 @@ class MethodologyExtractionResponse(BaseModel):
     )
 
 
-_methodology_extractor_agent_prompt = ChatPromptTemplate.from_template(
-    """
-# Task
-You are an expert scientific reader and methodology analyst. You are given a research document (or a long excerpt of one) and must extract the methodology used to obtain the results AND to determine the reproducibility class of the methodology.
-
-The document may be long (e.g., 10,000+ words) and may NOT be cleanly structured into sections like "Methods" or "Methodology". You must infer the methodological content from the text itself.
-
-## Your goals
-
-1. Read the document holistically. Do not rely solely on section headers.
-2. Identify and describe the **procedures and processes** used to obtain the results in sufficient detail for reproduction, including as relevant:
-   - Data sources, datasets, and sampling strategy (with specific details about data collection, selection criteria, sample sizes)
-   - Experimental or observational setup (equipment specifications, conditions, interventions, groups, control variables)
-   - Computational or analytical methods (algorithms, models, estimators, simulations with specific parameters)
-   - Training, fitting, or calibration procedures (learning rates, optimization algorithms, convergence criteria, number of epochs/iterations)
-   - Evaluation or validation procedures (metrics with exact definitions, baselines, statistical tests with significance levels)
-   - Software versions, library versions, and tool specifications when mentioned
-   - Randomization seeds, initialization procedures, and any stochastic elements
-   - Data preprocessing steps in detail (normalization, filtering, transformation procedures)
-   - Any key implementation choices that materially affect the results
-4. Determine the reproducibility class of the methodology based on the following criteria:
-   - If the methodology is fully reproducible, return the class value "fully_reproducible".
-   - If the methodology is reproducible if an AI agent is given access to web search, return the class value "reproducible_with_web_search".
-   - If the methodology is reproducible provided the user uploads data, return the class value "reproducible_with_external_uploads".
-   - If the methodology is not reproducible, return the class value "not_reproducible".
-3. Exclude:
-   - High-level motivation and background theory that do not directly describe what was done
-   - Extended literature review or related work
-   - Interpretations of results, discussion, implications, or conclusions
-
-## Reproducibility Criteria
-
-- Fully Reproducible (Definition): Methodologies where the logic is fully explained and the necessary data (parameters, equations, prompts, or rubrics) is provided directly within the text or appendices. A coding agent or researcher could replicate these results immediately without external data additions. These studies primarily consist of mathematical models, simulations, and algorithmic pipelines where the "data" consists of algebraic formulas or specific parameters explicitly recorded in the report.
-
-- Reproducible with Web Search (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data can be easily retrieved with web search.
-
-- Reproducible with External Uploads (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data consists of public laws, historical documents, or open public datasets that a researcher can easily retrieve with data additions. These studies are largely legal reviews, historical analyses, or quantitative models using large public datasets (like ISO interconnection queues).
-
-- Not Reproducible (Definition): Methodologies where the logic is not fully explained and/or the necessary data (parameters, equations, prompts, or rubrics) or the data cannot be easily obtained. Methodologies that cannot be reproduced even with web search capabilities because they rely on confidential, proprietary, or paid-access data that is not released..
-
-## Reproducibility Requirements
-
-If the methodology is fully reproducible, it should be detailed enough that a technically literate researcher could reproduce the work. This means:
-
-- **Step-by-step procedures**: Document the exact sequence of steps taken, in order
-- **Specific values**: Include exact parameters, hyperparameters, and configurations when available
-- **Software specifications**: Note software versions, library versions, and tool specifications when mentioned in the document
-- **Data details**: Include specific information about data preprocessing, transformations, and handling
-- **Implementation details**: Document any randomization seeds, initialization procedures, or stochastic elements
-- **Evaluation specifics**: Include exact definitions of metrics, evaluation procedures, and statistical tests
-
-You may use markdown formatting to structure the methodology (e.g., sections, lists) if it improves clarity and reproducibility.
-
-## Output requirements
-
-You must return a single field called **methodology** which is:
-
-
-## Extracted Methodology
-
-[Include the full extracted methodology from the paper here. This should be a complete restatement or copy of the methodology provided in the input. Present it clearly and comprehensively so readers understand exactly what methodology was used in the paper before seeing the comparison.]
-
-Organize the methodology using the following subsections as appropriate with proper markdown formatting for headings (use only those that are relevant to the paper):
-
-### Research Design
-
-[Describe the overall research design, study type (e.g., experimental, observational, simulation, meta-analysis), and the general approach taken.]
-
-### Data Sources and Collection
-
-[Describe the data sources used, how data was collected, sampling methods, data acquisition procedures, and any data preprocessing steps.]
-
-### Experimental Setup
-
-[For experimental studies: describe the experimental conditions, controls, variables manipulated, and experimental procedures. For observational studies: describe the observational framework, measurement instruments, and data collection protocols.]
-
-### Analytical Methods
-
-[Describe the statistical methods, modeling approaches, algorithms, computational techniques, or other analytical methods used to analyze the data or test hypotheses.]
-
-### Evaluation Metrics and Validation
-
-[Describe how results were evaluated, what metrics were used, validation procedures, robustness checks, and any quality assurance measures.]
-
-### Limitations and Constraints
-
-[Note any limitations, constraints, or assumptions explicitly mentioned in the methodology, including sample size limitations, data quality issues, or methodological constraints.]
-
-**Note:** If the extracted methodology does not clearly separate into these categories, present it in a logical flow that best represents the paper's methodological approach. The goal is clarity and comprehensiveness, not rigid adherence to this structure.
-
-## Guidelines
-
-- Output must be:
-    - a **coherent, stand-alone narrative** that is detailed enough for reproduction (approximately **500–1000 words**, or longer if needed for completeness).
-    - Written in clear prose that could be read by a technically literate researcher unfamiliar with the paper.
-    - Focused on **what was actually done** to generate the results, with sufficient detail to enable reproduction.
-    - Structured clearly, potentially using markdown formatting (sections, lists) to organize complex procedures.
-    - Emphasizes completeness and reproducibility over conciseness.
-
-When important details are truly missing from the provided text (e.g., sample size, exact hyperparameters, full experimental conditions, software versions), explicitly indicate this with phrases like:
-- "The exact sample size is not specified in the provided text."
-- "Details of the optimization procedure are not specified in the provided text."
-- "The software version used is not specified in the provided text."
-
-Do **not** invent or guess specific values or procedures that are not clearly supported by the document.
-
-## The document to analyze
-
-{document}
-"""
-)
-
-
 class MethodologyExtractorAgent(LangChainAgent):
     name = "Methodology Extractor"
     description = (
@@ -167,10 +55,14 @@ class MethodologyExtractorAgent(LangChainAgent):
         prompt_kwargs: dict,
         config: Optional[RunnableConfig] = None,
     ) -> MethodologyExtractionResponse:
-        messages = _methodology_extractor_agent_prompt.format_messages(**prompt_kwargs)
+        content = (
+            load_skill_prompt("methodology-extraction")
+            + "\n\n## The document to analyze\n\n"
+            + prompt_kwargs["document"]
+        )
         return cast(
             MethodologyExtractionResponse,
-            await self.llm.ainvoke(messages, config=config),
+            await self.llm.ainvoke([HumanMessage(content=content)], config=config),
         )
 
 

--- a/skills/capabilities/SKILL.md
+++ b/skills/capabilities/SKILL.md
@@ -29,14 +29,16 @@ These review the document and flag issues.
 | **Reviewer 2** | A rigorous simulated peer review — summary, strengths, weaknesses, and prioritized next steps — plus a separate devil's-advocate rebuttal. (Beta.) | `reviewer-2` |
 | **Literature Review** | Are there relevant sources you may have missed? Searches the web for academic sources related to your document's claims — both supporting and conflicting — that aren't already cited. (Beta.) | `literature-review` |
 | **Live Reports** | Have your findings been updated or contradicted by newer research? Searches the web for sources published after your document's date and produces an addendum of what to update. (Beta.) | `live-reports` |
+| **Methodological Alignment** | Does your methodology match standard practice in the field? Uses web search to characterize the field baseline, then compares your approach — similarities, differences, missing components, rigor, and suggested improvements. | `methodology-comparison` |
 
-## Reference tools
+## Tools
 
-These operate on the document's references rather than flagging issues.
+These operate on the document rather than flagging issues.
 
 | Tool | What it does | Skill |
 |---|---|---|
 | **Download References** | Search the web for a reference and download its full original content (PDF/Markdown), verifying the match. Reports found / found-but-inaccessible / not-found. | `reference-download` |
+| **Extract Methodology** | Extract a structured, reproducible description of the paper's methodology, and classify how reproducible it is. | `methodology-extraction` |
 
 ## Notes
 

--- a/skills/methodology-comparison/SKILL.md
+++ b/skills/methodology-comparison/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: methodology-comparison
+description: Use this skill to compare a paper's methodology against standard practice in its scientific field (methodological alignment) — using web search to characterize the field baseline, then assessing similarities, differences, missing components, rigor/risks, and improvements. Invoke when the user asks whether a document's methodology matches standard/typical methods in the field, or for a methodological-alignment review.
+---
+
+# Task
+You are an expert methodological reviewer in the relevant scientific field. Your input is a description of a **paper's methodology** — what the paper actually did to obtain its results — as produced by the **`methodology-extraction` skill**. If the paper's methodology has not already been extracted, extract it first using that skill.
+
+Your job is to compare the paper's methodology to the broader field's methods and produce a clear, structured narrative. You must use web search to find information about typical methods used in the broader field.
+
+## Web Search Instructions
+
+Use web search to:
+- Find typical or canonical methods used in the broader field for similar problems
+- Identify standard practices, data sources, experimental setups, and analytical techniques
+- Locate authoritative sources (peer-reviewed articles, methodological reviews, field standards)
+- Gather information about evaluation practices and rigor standards in the field
+
+When using web search:
+- Focus on high-quality sources (peer-reviewed publications, methodological reviews, field standards)
+- Search for terms related to the paper's methodology and the broader field
+- Look for systematic reviews, meta-analyses, or methodological guidelines when available
+- Consider different disciplinary perspectives if relevant
+
+## Your goals
+
+1. **Characterize the field baseline.**
+   - Use web search to identify and briefly restate what appears to be *standard practice* in the field.
+   - Focus on typical data sources, experimental/observational setups, modeling or analytical techniques, and evaluation practices.
+
+2. **Compare the focal paper to the field baseline.**
+   - Identify key **similarities** between the paper's methodology and standard field practice.
+   - Identify key **differences** or **innovations** in the paper's methodology.
+   - Identify any **missing standard components** (things that are common in the field but absent or very weak in the paper).
+   - Comment on the **rigor and robustness** of the paper's methodology relative to the field norm (e.g., more rigorous, similar, weaker).
+
+3. **Highlight implications and risks.**
+   - Explain how the similarities and differences might affect the **credibility**, **generalizability**, or **interpretability** of the paper's results.
+   - Point out any methodological **risks or limitations** that follow from the paper's deviations from standard practice, or from omissions of common checks.
+
+## Output requirements
+
+For the markdown output of the sections, you must:
+- Approximately **500–900 words** for the overview, alignment, and rigor and risks sections.
+- Approximately **200–400 words** for the suggestions for improvements section.
+- Structured using markdown formatting as shown in the template below.
+- **Mathematical notation**: Any equations, formulas, or mathematical expressions must be written in LaTeX format using `$...$` for inline math and `$$...$$` for display equations.
+
+### Suggested Markdown Format
+
+Format your response using the following markdown structure:
+
+```markdown
+## Extracted Methodology
+
+[Include the full extracted methodology from the paper here. This should be a complete restatement or copy of the methodology provided in the input. Present it clearly and comprehensively so readers understand exactly what methodology was used in the paper before seeing the comparison.]
+
+## Field Methods Overview
+
+[Brief overview of standard practices in the field, based on web search findings. Describe typical data sources, experimental setups, analytical techniques, and evaluation practices used in the broader field.]
+
+## Alignment with Field Practice
+
+### Similarities
+
+[Identify and describe key similarities between the paper's methodology and standard field practice. Use bullet points or paragraphs as appropriate.]
+
+### Differences and Innovations
+
+[Identify and describe key differences or innovations in the paper's methodology compared to standard practice. Highlight what makes the approach novel or different.]
+
+### Missing or Weak Standard Components
+
+[Identify any standard components that are common in the field but absent or weak in the paper. Explain what is typically expected and what is missing.]
+
+## Methodological Rigor and Risks
+
+[Assess the rigor and robustness of the paper's methodology relative to field norms. Explain implications for credibility, generalizability, and interpretability. Highlight any methodological risks or limitations that follow from deviations from standard practice.]
+
+## Suggestions for Improvements
+
+[Based on previous analyses provide a bulleted list of at most three suggestions to change the language of the paper, the data sources used, methodological approaches, etc. to improve the robustness, rigor, or generalizability of the findings.]
+
+
+### Citations
+
+[When referencing sources found through web search, cite them appropriately using markdown links or inline citations, for example: "According to [Source Name](URL)..." or "Smith et al. (2023) found that..."]
+```
+
+**Formatting Guidelines:**
+- Use `##` for main sections (level 2 headings)
+- Use `###` for subsections (level 3 headings)
+- Use `**bold**` for emphasis on key terms
+- Use bullet points (`-`) or numbered lists when listing multiple items
+- Use code blocks (`` ` ``) for technical terms or specific values
+- Include citations with markdown links when referencing web search sources
+- Keep paragraphs focused and well-structured
+- **Mathematical equations**: All equations must be formatted in LaTeX notation:
+- For inline equations, use single dollar signs: `$E = mc^2$`
+- For block/display equations, use double dollar signs on separate lines:
+```latex
+$$E = mc^2$$
+```
+- Always use proper LaTeX syntax for mathematical notation (e.g., `\alpha`, `\beta`, `\sum`, `\prod`, `\frac{a}{b}`, `\sqrt{x}`, etc.)
+- When describing equations from the paper, convert them to LaTeX format rather than using plain text or Unicode characters
+
+Additional guidance:
+
+- **Start with the extracted methodology**: The first section must be "## Extracted Methodology" and should contain the full methodology from the paper. This allows readers to understand what was done before seeing how it compares to the field.
+- **CRITICAL**: You MUST include citations for all claims about field practices that come from web search.
+- Format citations as markdown links: [Source Title](URL) immediately after the claim.
+- Base your reasoning on the provided paper methodology and information found through web search.
+- When something seems important but is not specified in the paper methodology, explicitly note that it is **not specified** rather than guessing.
+- You may generalize about the field when it is clearly supported by web search results, but avoid fabricating very specific claims or citations.
+- When using web search results, cite the sources appropriately in your comparison narrative.
+
+# NOTE:
+When generating responses, REMOVE OR REPLACE ALL INTERNAL CITATION TOKENS SUCH AS turn1search0, turn2search3, or similar. DO NOT DISPLAY RAW REFERENCE IDS OR METADATA MARKERS IN THE FINAL TEXT. RETURN CLEAN, HUMAN-READABLE OUTPUT ONLY.
+
+Now write the comparison as described above.

--- a/skills/methodology-extraction/SKILL.md
+++ b/skills/methodology-extraction/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: methodology-extraction
+description: Use this skill to extract a detailed, reproducible description of the methodology a research document used to obtain its results, and to classify how reproducible that methodology is. Invoke when the user asks to extract, summarize, or describe a paper's methods/methodology, or to assess whether a study's methodology is reproducible.
+---
+
+# Task
+
+You are an expert scientific reader and methodology analyst. You are given a research document (or a long excerpt of one) and must extract the methodology used to obtain the results AND to determine the reproducibility class of the methodology.
+
+The document may be long (e.g., 10,000+ words) and may NOT be cleanly structured into sections like "Methods" or "Methodology". You must infer the methodological content from the text itself.
+
+## Your goals
+
+1. Read the document holistically. Do not rely solely on section headers.
+2. Identify and describe the **procedures and processes** used to obtain the results in sufficient detail for reproduction, including as relevant:
+   - Data sources, datasets, and sampling strategy (with specific details about data collection, selection criteria, sample sizes)
+   - Experimental or observational setup (equipment specifications, conditions, interventions, groups, control variables)
+   - Computational or analytical methods (algorithms, models, estimators, simulations with specific parameters)
+   - Training, fitting, or calibration procedures (learning rates, optimization algorithms, convergence criteria, number of epochs/iterations)
+   - Evaluation or validation procedures (metrics with exact definitions, baselines, statistical tests with significance levels)
+   - Software versions, library versions, and tool specifications when mentioned
+   - Randomization seeds, initialization procedures, and any stochastic elements
+   - Data preprocessing steps in detail (normalization, filtering, transformation procedures)
+   - Any key implementation choices that materially affect the results
+3. Determine the reproducibility class of the methodology based on the following criteria:
+   - If the methodology is fully reproducible, return the class value "fully_reproducible".
+   - If the methodology is reproducible if an AI agent is given access to web search, return the class value "reproducible_with_web_search".
+   - If the methodology is reproducible provided the user uploads data, return the class value "reproducible_with_external_uploads".
+   - If the methodology is not reproducible, return the class value "not_reproducible".
+4. Exclude:
+   - High-level motivation and background theory that do not directly describe what was done
+   - Extended literature review or related work
+   - Interpretations of results, discussion, implications, or conclusions
+
+## Reproducibility Criteria
+
+- Fully Reproducible (Definition): Methodologies where the logic is fully explained and the necessary data (parameters, equations, prompts, or rubrics) is provided directly within the text or appendices. A coding agent or researcher could replicate these results immediately without external data additions. These studies primarily consist of mathematical models, simulations, and algorithmic pipelines where the "data" consists of algebraic formulas or specific parameters explicitly recorded in the report.
+
+- Reproducible with Web Search (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data can be easily retrieved with web search.
+
+- Reproducible with External Uploads (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data consists of public laws, historical documents, or open public datasets that a researcher can easily retrieve with data additions. These studies are largely legal reviews, historical analyses, or quantitative models using large public datasets (like ISO interconnection queues).
+
+- Not Reproducible (Definition): Methodologies where the logic is not fully explained and/or the necessary data (parameters, equations, prompts, or rubrics) or the data cannot be easily obtained. Methodologies that cannot be reproduced even with web search capabilities because they rely on confidential, proprietary, or paid-access data that is not released..
+
+## Reproducibility Requirements
+
+If the methodology is fully reproducible, it should be detailed enough that a technically literate researcher could reproduce the work. This means:
+
+- **Step-by-step procedures**: Document the exact sequence of steps taken, in order
+- **Specific values**: Include exact parameters, hyperparameters, and configurations when available
+- **Software specifications**: Note software versions, library versions, and tool specifications when mentioned in the document
+- **Data details**: Include specific information about data preprocessing, transformations, and handling
+- **Implementation details**: Document any randomization seeds, initialization procedures, or stochastic elements
+- **Evaluation specifics**: Include exact definitions of metrics, evaluation procedures, and statistical tests
+
+You may use markdown formatting to structure the methodology (e.g., sections, lists) if it improves clarity and reproducibility.
+
+## Output requirements
+
+Produce the extracted methodology as follows:
+
+```markdown
+## Extracted Methodology
+
+[Include the full extracted methodology from the paper here. This should be a complete restatement or copy of the methodology provided in the input. Present it clearly and comprehensively so readers understand exactly what methodology was used in the paper before seeing the comparison.]
+
+Organize the methodology using the following subsections as appropriate with proper markdown formatting for headings (use only those that are relevant to the paper):
+
+### Research Design
+
+[Describe the overall research design, study type (e.g., experimental, observational, simulation, meta-analysis), and the general approach taken.]
+
+### Data Sources and Collection
+
+[Describe the data sources used, how data was collected, sampling methods, data acquisition procedures, and any data preprocessing steps.]
+
+### Experimental Setup
+
+[For experimental studies: describe the experimental conditions, controls, variables manipulated, and experimental procedures. For observational studies: describe the observational framework, measurement instruments, and data collection protocols.]
+
+### Analytical Methods
+
+[Describe the statistical methods, modeling approaches, algorithms, computational techniques, or other analytical methods used to analyze the data or test hypotheses.]
+
+### Evaluation Metrics and Validation
+
+[Describe how results were evaluated, what metrics were used, validation procedures, robustness checks, and any quality assurance measures.]
+
+### Limitations and Constraints
+
+[Note any limitations, constraints, or assumptions explicitly mentioned in the methodology, including sample size limitations, data quality issues, or methodological constraints.]
+```
+
+**Note:** If the extracted methodology does not clearly separate into these categories, present it in a logical flow that best represents the paper's methodological approach. The goal is clarity and comprehensiveness, not rigid adherence to this structure.
+
+## Guidelines
+
+- Output must be:
+  - a **coherent, stand-alone narrative** that is detailed enough for reproduction (approximately **500–1000 words**, or longer if needed for completeness).
+  - Written in clear prose that could be read by a technically literate researcher unfamiliar with the paper.
+  - Focused on **what was actually done** to generate the results, with sufficient detail to enable reproduction.
+  - Structured clearly, potentially using markdown formatting (sections, lists) to organize complex procedures.
+  - Emphasizes completeness and reproducibility over conciseness.
+
+When important details are truly missing from the provided text (e.g., sample size, exact hyperparameters, full experimental conditions, software versions), explicitly indicate this with phrases like:
+
+- "The exact sample size is not specified in the provided text."
+- "Details of the optimization procedure are not specified in the provided text."
+- "The software version used is not specified in the provided text."
+
+Do **not** invent or guess specific values or procedures that are not clearly supported by the document.

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -39,6 +39,8 @@ _SKILL_BACKED_AGENTS = [
     "reference-download",
     "literature-review",
     "live-reports",
+    "methodology-extraction",
+    "methodology-comparison",
 ]
 
 


### PR DESCRIPTION
## Summary

Converts the `methodological_alignment` workflow's two agent prompts into portable, user-invocable skills, where the **comparison skill uses the extraction skill**. Part of Tier 3 ([RANDZ-587](https://linear.app/ae-studio/issue/RANDZ-587)).

## Motivation

`methodological_alignment` runs two sequential LLM agents — an **extractor** (describe the paper's methodology + classify reproducibility) and a **comparator** (web-search the field baseline and compare). Making each a standalone skill (source-of-truth pattern) keeps the procedures reusable while the agents retain the Draft-Detective-specific mechanics (document/methodology injection, structured output schema). The comparison composes on the extraction, mirroring how `reference_validator_v2` references the `reference-validation` skill.

## What's Changed

### Skills
- **`skills/methodology-extraction/SKILL.md`** (new) — extract a structured, reproducible description of a paper's methodology and classify its reproducibility. Generic (no `{document}`; backend appends the document).
- **`skills/methodology-comparison/SKILL.md`** (new) — compare the paper's methodology against field practice via web search (field baseline, similarities/differences, missing components, rigor/risks, improvements). **References the `methodology-extraction` skill** as the source of its input; generic (no `{extracted_methodology}`).
- **`skills/capabilities/SKILL.md`** — added **Methodological Alignment** (`methodology-comparison`) under Assessments; added **Extract Methodology** (`methodology-extraction`) under a renamed general **Tools** group (previously "Reference tools").

### Backend
- **`lib/agents/methodology_extractor.py`** / **`lib/agents/methodology_comparator.py`** — each loads its skill via `load_skill_prompt(...)` and appends the per-run input (document / extracted methodology) as a plain `HumanMessage` (no `ChatPromptTemplate`, avoiding brace-parsing of skill markdown). Output schemas (`MethodologyExtractionResponse`, `MethodologyComparisonResponse`), the node, and the manifest are unchanged. The workflow still emits no issues (report-only).

### Tests
- `tests/unit/test_skills.py` — both new skills added to the skill-load guard.

## Verification
- `uv run mypy .` clean (369 files); unit tests pass (11).
- **Prompt-equivalence checks**: confirmed the originals' `{document}` / `{extracted_methodology}` placeholders are dropped from the skills (now backend-appended), and the substance is preserved (reproducibility criteria, output sections, citation hygiene, LaTeX `\frac{a}{b}` rendered correctly). The change is a faithful relocation.
- **No e2e eval exists** for `methodological_alignment`, so there's no before/after eval. The equivalence checks + mypy + unit tests cover correctness; the delivered prompts are semantically identical to before.

## Risks and Mitigations
- Skill files are load-bearing for both agents; a missing/renamed skill fails fast at runtime (guarded by unit tests).
- Faithful relocation (placeholders backend-injected, substance preserved), so no behavioral change is expected; absence of an eval is mitigated by the equivalence checks.