### PR TITLE
feat(skills): convert results_extraction (Reproducibility Check) to a skill

### DIFF
--- a/lib/workflows/results_extraction/agents/results_extractor.py
+++ b/lib/workflows/results_extraction/agents/results_extractor.py
@@ -1,18 +1,15 @@
 # %%
 from enum import Enum
+from typing import List, Optional, cast
 
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.messages import HumanMessage
 from langchain_core.runnables.config import RunnableConfig
 from pydantic import BaseModel, Field
 
-from lib.config.env import config
-from lib.config.llm_models import gpt_5_mini_model
-from typing import List, Optional, cast
-
 from lib.agents.models import ReproducibilityCategory
+from lib.config.llm_models import gpt_5_mini_model
 from lib.models.agent import LangChainAgent
-from lib.services.file_artifacts_service.mock import MockFileArtifactsService
-from lib.workflows.context import ContextSchema
+from lib.skills import load_skill_prompt
 
 
 class ResultType(Enum):
@@ -48,76 +45,6 @@ class ResultsListResponse(BaseModel):
     )
 
 
-_results_extractor_agent_prompt = ChatPromptTemplate.from_template(
-    """
-# Task
-You are an expert scientific reader and results analyst. You will be given a research document (or a long excerpt of one), and must extract the main results of the document AND determine whether these each of these main results is reproducible given the information provided in the paper.
-
-"Results" are defined as any qualitative, mathematical, or quantitative end-points of an analysis. Things that aren't included in results are assumptions or initial conditions.
-
-The document may be long (e.g., 10,000+ words) and may NOT be cleanly structured into sections labeled as "Results."
-
-## Your goals
-
-1. Read the document holistically. Do not rely solely on section headers.
-2. Identify the main results of the paper. "Results" are defined as any qualitative, mathematical, or quantitative end-points of an analysis. Things that aren't included in results are assumptions or initial conditions.
-3. Determine the "Result Type"
-    - Figure: The result is a figure within the text
-    - Table: The result is a table within the text
-    - Equation: The result is a final equation
-    - Text: The result is a section of text (e.g., numerical statements within text)
-    - Algorithm: The result is an algorithm stated in pseudo-code in text
-    - Other: The result doesn't fit in any of the given categories
-4. Determine the reproducibility class of the result based on the following criteria:
-   - If the result is fully reproducible, return the class value "fully_reproducible".
-   - If the result is reproducible if an AI agent is given access to web search, return the class value "reproducible_with_web_search".
-   - If the result is reproducible provided the user uploads data, return the class value "reproducible_with_external_uploads".
-   - If the result is not reproducible, return the class value "not_reproducible".
-   Provide a rationale for this categorization and explain what would be needed to make the result fully reproducible
-5. Describe the result in no more than five sentences
-6. Provide the location of the result.  This should be a description of the page number, figure number, table number, equation number, etc
-7. Provide a descriptive title for the result
-
-
-## Results extraction guidelines
-
-Results are sometimes represented as equations, figures, tables, or specific numerical quantities stated within the text. In general, they are defined as the end-points of some quantitative or qualitative analysis. For the results extraction, we want to extract results and put them within the same section according to their natural grouping within the paper. For example, a table could countain dozens of values, but it should represent a single result. Similarly with figures. Each of these particular results should have a reproducibility category.
-
-## Reproducibility Criteria
-
-- Fully Reproducible (Definition): Methodologies where the logic is fully explained and the necessary data (parameters, equations, prompts, or rubrics) is provided directly within the text or appendices. A coding agent or researcher could replicate these results immediately without external data additions. These studies primarily consist of mathematical models, simulations, and algorithmic pipelines where the "data" consists of algebraic formulas or specific parameters explicitly recorded in the report.
-
-- Reproducible with Web Search (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data can be easily retrieved with web search.
-
-- Reproducible with External Uploads (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data consists of public laws, historical documents, or open public datasets that a researcher can easily retrieve with data additions. These studies are largely legal reviews, historical analyses, or quantitative models using large public datasets (like ISO interconnection queues).
-
-- Not Reproducible (Definition): Methodologies where the logic is not fully explained and/or the necessary data (parameters, equations, prompts, or rubrics) or the data cannot be easily obtained. Methodologies that cannot be reproduced even with web search capabilities because they rely on confidential, proprietary, or paid-access data that is not released..
-
-## Reproducibility Requirements
-
-If the result is fully reproducible, it should be detailed enough that a technically literate researcher could reproduce the work. This means:
-
-- **Step-by-step procedures**: Document the exact sequence of steps taken, in order
-- **Specific values**: Include exact parameters, hyperparameters, and configurations when available
-- **Software specifications**: Note software versions, library versions, and tool specifications when mentioned in the document
-- **Data details**: Include specific information about data preprocessing, transformations, and handling
-- **Implementation details**: Document any randomization seeds, initialization procedures, or stochastic elements
-- **Evaluation specifics**: Include exact definitions of metrics, evaluation procedures, and statistical tests
-
-When important details are truly missing from the provided text (e.g., sample size, exact hyperparameters, full experimental conditions, software versions), explicitly indicate this with phrases like:
-- "The exact sample size is not specified in the provided text."
-- "Details of the optimization procedure are not specified in the provided text."
-- "The software version used is not specified in the provided text."
-
-Do **not** invent or guess specific values or procedures that are not clearly supported by the document.
-
-## The document to analyze
-
-{document}
-"""
-)
-
-
 class ResultsExtractorAgent(LangChainAgent):
     name = "Results Extractor"
     description = "Read a research document and extract a detailed list of the results"
@@ -130,89 +57,12 @@ class ResultsExtractorAgent(LangChainAgent):
         prompt_kwargs: dict,
         config: Optional[RunnableConfig] = None,
     ) -> ResultsListResponse:
-        messages = _results_extractor_agent_prompt.format_messages(**prompt_kwargs)
+        content = (
+            load_skill_prompt("reproducibility-check")
+            + "\n\n## The document to analyze\n\n"
+            + prompt_kwargs["document"]
+        )
         return cast(
             ResultsListResponse,
-            await self.llm.ainvoke(messages, config=config),
+            await self.llm.ainvoke([HumanMessage(content=content)], config=config),
         )
-
-
-# Test script - can be run directly or imported
-if __name__ == "__main__":
-    import asyncio
-    import os
-    import sys
-    from pathlib import Path
-
-    from lib.services.converters.base import convert_to_markdown
-
-    # Set the file path here, or pass it as a command line argument
-    # FILE_PATH = "tests/data/RAND_RRA3307-1.pdf"  # e.g., "tests/data/sample_document.md"
-    # FILE_PATH = "tests/data/case_1/main_document.md"
-    # FILE_PATH = "rand-personal/sample_papers_rand/RAND_RRA3034-1.pdf"
-    FILE_PATH = "rand-personal/smaldino_reproduction/Smaldino_McElreath_(2016).pdf"
-
-    async def test_results_extractor(file_path: str):
-        """Test the results extractor agent with a given file."""
-        # Resolve the file path (handle relative paths from project root)
-        if not os.path.isabs(file_path):
-            # Assume relative to project root
-            project_root = Path(__file__).parent.parent.parent.parent.parent
-            file_path = str(project_root / file_path)
-
-        if not os.path.exists(file_path):
-            print(f"Error: File not found: {file_path}")
-            return
-
-        print(f"Reading file: {file_path}")
-        print("-" * 80)
-
-        # Convert file to markdown
-        markdown_content = await convert_to_markdown(file_path)
-
-        print(f"Document length: {len(markdown_content)} characters")
-        print("Running results extractor agent...")
-        print("-" * 80)
-
-        # Initialize context
-        context = ContextSchema(
-            openai_api_key=config.OPENAI_API_KEY,
-            vector_store=None,
-            project_id="dev",
-            file_artifacts_service=MockFileArtifactsService(),
-        )
-
-        # Run the agent
-        results_extractor_agent = ResultsExtractorAgent(context)
-        response = await results_extractor_agent.ainvoke({"document": markdown_content})
-
-        results_list = response.result_sections
-        for result in results_list:
-
-            # Print the methodology results
-            print("\n" + "=" * 80)
-            print("EXTRACTED RESULT")
-            print("Title:", result.title)
-            print("Type:", result.result_type)
-            print("Location:", result.location)
-            print("Description:", result.description)
-            print("\n" + "-" * 80)
-
-            # Print the reproducibility results
-            print("REPRODUCIBILITY ASSESSMENT")
-            print(f"Category: {result.reproducibility.value}")
-            print(f"\nRationale:\n{result.reproducibility_rationale}")
-            print("\n" + "=" * 80)
-
-    # Get file path from command line or use the FILE_PATH variable
-    if len(sys.argv) > 1:
-        file_path = sys.argv[1]
-    elif FILE_PATH:
-        file_path = FILE_PATH
-    else:
-        print("Usage: python methodology_extractor_agent.py <file_path>")
-        print("   or: Set FILE_PATH variable in the script")
-        sys.exit(1)
-
-    # Run the test
-    asyncio.run(test_results_extractor(file_path))

--- a/skills/capabilities/SKILL.md
+++ b/skills/capabilities/SKILL.md
@@ -30,6 +30,7 @@ These review the document and flag issues.
 | **Literature Review** | Are there relevant sources you may have missed? Searches the web for academic sources related to your document's claims — both supporting and conflicting — that aren't already cited. (Beta.) | `literature-review` |
 | **Live Reports** | Have your findings been updated or contradicted by newer research? Searches the web for sources published after your document's date and produces an addendum of what to update. (Beta.) | `live-reports` |
 | **Methodological Alignment** | Does your methodology match standard practice in the field? Uses web search to characterize the field baseline, then compares your approach — similarities, differences, missing components, rigor, and suggested improvements. | `methodology-comparison` |
+| **Reproducibility Check** | Could someone reproduce your results from the document alone? Extracts the main results and classifies each by how reproducible it is. (Beta.) | `reproducibility-check` |
 
 ## Tools
 

--- a/skills/reproducibility-check/SKILL.md
+++ b/skills/reproducibility-check/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: reproducibility-check
+description: Use this skill to extract a research document's main results and classify how reproducible each one is (fully reproducible, reproducible with web search, reproducible with external uploads, or not reproducible) from the information in the paper. Invoke when the user asks whether their results could be reproduced from the document alone, or to assess the reproducibility of a paper's findings.
+---
+
+# Task
+You are an expert scientific reader and results analyst. You will be given a research document (or a long excerpt of one), and must extract the main results of the document AND determine whether these each of these main results is reproducible given the information provided in the paper.
+
+"Results" are defined as any qualitative, mathematical, or quantitative end-points of an analysis. Things that aren't included in results are assumptions or initial conditions.
+
+The document may be long (e.g., 10,000+ words) and may NOT be cleanly structured into sections labeled as "Results."
+
+## Your goals
+
+1. Read the document holistically. Do not rely solely on section headers.
+2. Identify the main results of the paper. "Results" are defined as any qualitative, mathematical, or quantitative end-points of an analysis. Things that aren't included in results are assumptions or initial conditions.
+3. Determine the "Result Type"
+    - Figure: The result is a figure within the text
+    - Table: The result is a table within the text
+    - Equation: The result is a final equation
+    - Text: The result is a section of text (e.g., numerical statements within text)
+    - Algorithm: The result is an algorithm stated in pseudo-code in text
+    - Other: The result doesn't fit in any of the given categories
+4. Determine the reproducibility class of the result based on the following criteria:
+   - If the result is fully reproducible, return the class value "fully_reproducible".
+   - If the result is reproducible if an AI agent is given access to web search, return the class value "reproducible_with_web_search".
+   - If the result is reproducible provided the user uploads data, return the class value "reproducible_with_external_uploads".
+   - If the result is not reproducible, return the class value "not_reproducible".
+   Provide a rationale for this categorization and explain what would be needed to make the result fully reproducible
+5. Describe the result in no more than five sentences
+6. Provide the location of the result.  This should be a description of the page number, figure number, table number, equation number, etc
+7. Provide a descriptive title for the result
+
+
+## Results extraction guidelines
+
+Results are sometimes represented as equations, figures, tables, or specific numerical quantities stated within the text. In general, they are defined as the end-points of some quantitative or qualitative analysis. For the results extraction, we want to extract results and put them within the same section according to their natural grouping within the paper. For example, a table could countain dozens of values, but it should represent a single result. Similarly with figures. Each of these particular results should have a reproducibility category.
+
+## Reproducibility Criteria
+
+- Fully Reproducible (Definition): Methodologies where the logic is fully explained and the necessary data (parameters, equations, prompts, or rubrics) is provided directly within the text or appendices. A coding agent or researcher could replicate these results immediately without external data additions. These studies primarily consist of mathematical models, simulations, and algorithmic pipelines where the "data" consists of algebraic formulas or specific parameters explicitly recorded in the report.
+
+- Reproducible with Web Search (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data can be easily retrieved with web search.
+
+- Reproducible with External Uploads (Definition): Methodologies where the logic is fully explained but the necessary data (parameters, equations, prompts, or rubrics) is not provided directly within the text or appendices. However, the data consists of public laws, historical documents, or open public datasets that a researcher can easily retrieve with data additions. These studies are largely legal reviews, historical analyses, or quantitative models using large public datasets (like ISO interconnection queues).
+
+- Not Reproducible (Definition): Methodologies where the logic is not fully explained and/or the necessary data (parameters, equations, prompts, or rubrics) or the data cannot be easily obtained. Methodologies that cannot be reproduced even with web search capabilities because they rely on confidential, proprietary, or paid-access data that is not released..
+
+## Reproducibility Requirements
+
+If the result is fully reproducible, it should be detailed enough that a technically literate researcher could reproduce the work. This means:
+
+- **Step-by-step procedures**: Document the exact sequence of steps taken, in order
+- **Specific values**: Include exact parameters, hyperparameters, and configurations when available
+- **Software specifications**: Note software versions, library versions, and tool specifications when mentioned in the document
+- **Data details**: Include specific information about data preprocessing, transformations, and handling
+- **Implementation details**: Document any randomization seeds, initialization procedures, or stochastic elements
+- **Evaluation specifics**: Include exact definitions of metrics, evaluation procedures, and statistical tests
+
+When important details are truly missing from the provided text (e.g., sample size, exact hyperparameters, full experimental conditions, software versions), explicitly indicate this with phrases like:
+- "The exact sample size is not specified in the provided text."
+- "Details of the optimization procedure are not specified in the provided text."
+- "The software version used is not specified in the provided text."
+
+Do **not** invent or guess specific values or procedures that are not clearly supported by the document.

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -41,6 +41,7 @@ _SKILL_BACKED_AGENTS = [
     "live-reports",
     "methodology-extraction",
     "methodology-comparison",
+    "reproducibility-check",
 ]
 
 


### PR DESCRIPTION
## Summary

Converts the `results_extraction` ("Reproducibility Check") workflow's prompt into a portable source-of-truth skill ([RANDZ-599](https://linear.app/ae-studio/issue/RANDZ-599)). Same faithful-relocation pattern as `methodology-extraction` / `literature-review`.

## What's Changed

### Skills
- **`skills/reproducibility-check/SKILL.md`** (new) — extract a document's main results and classify each by how reproducible it is. Generic: no `/main.md`, no `{document}` placeholder, no output-schema field names.
- **`skills/capabilities/SKILL.md`** — added **Reproducibility Check** under the Assessments group (Beta).

### Backend
- **`lib/workflows/results_extraction/agents/results_extractor.py`** — `ResultsExtractorAgent` now loads its prompt via `load_skill_prompt("reproducibility-check")` and appends the document as a plain `HumanMessage` (dropped the inline `ChatPromptTemplate`). Output schema (`ResultsListResponse`), node, and manifest unchanged — the workflow is still report-only (`convert_state_to_issues` returns `[]`).

### Tests
- `tests/unit/test_skills.py` — `reproducibility-check` added to the skill-load guard.

## Verification
- `uv run mypy .` clean (369 files); unit tests pass (12).
- **Prompt-equivalence**: the skill body is exactly equal to the original inline prompt minus the trailing `{document}` block (confirmed by AST diff) — a faithful relocation, no behavioral change.
- **No e2e eval exists** for this workflow, so there's no before/after eval; the equivalence check + mypy + tests cover correctness.

## Risks and Mitigations
- Skill file is load-bearing for the agent; a missing/renamed skill fails fast at runtime (guarded by the unit test).
- Byte-identical prompt (placeholder backend-injected), so no behavioral change expected.