### PR TITLE
feat(skills): convert reference_extraction to a portable skill

### DIFF
--- a/lib/agents/reference_text_extractor_v2.py
+++ b/lib/agents/reference_text_extractor_v2.py
@@ -11,6 +11,7 @@ from lib.agents.tools.read_main_document import read_document
 from lib.agents.tools.search_main_document import search_document
 from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
+from lib.skills import load_skill_prompt
 from lib.workflows.context import ContextSchema
 
 
@@ -41,63 +42,28 @@ class ReferenceExtractorV2Output(BaseModel):
     )
 
 
-_SYSTEM_PROMPT = """\
-You are a reference extraction specialist. Your task is to find and extract all bibliographic references from the Reference List section of an academic document.
+# The reference-extraction *procedure* is the portable `reference-extraction`
+# skill (the single source of truth). This backend-only addendum carries the
+# Draft-Detective specifics the skill omits: the document-access tools and the
+# line-range output contract that downstream consumers depend on.
+_ENV_GUIDANCE = """\
 
-## Available Tools
+---
 
-1. **search_document(pattern)**: Search the document for lines matching a regex pattern (case-insensitive). Returns matching lines with line numbers and context. Use this to locate reference sections.
+## Tools and output in this environment
 
-2. **read_document(start_line, end_line)**: Read a specific range of lines from the document. Use this after finding a reference section to read its full content. The output format is "LINE_NUMBER|content" for each line.
+You have these tools to read the document:
+- `search_document(pattern)`: search for lines matching a regex pattern (case-insensitive); returns matching lines with their line numbers and context. Use it to locate the reference section.
+- `read_document(start_line, end_line)`: read a specific range of lines; output is `LINE_NUMBER|content` per line. Use it to read the full section once located.
 
-## Instructions
+Begin your output with brief `reasoning` describing what you searched for and found.
 
-1. Use search_document to locate reference/bibliography sections. Try searching for common section headers like "References", "Bibliography", "Works Cited", "Literature Cited", "Sources" etc. Section titles might be in markdown format using # (e.g., "# References" or "## Bibliography"). It's possible that the reference section is not labeled, so you may need to search for common patterns in the document.
-
-2. Once you find a reference section (note the line numbers), use read_document to read the full content of that section.
-
-3. Extract each individual reference as a complete bibliographic entry. Keep each reference as a single string, preserving the original formatting.
-
-4. Common reference patterns to look for:
-   - APA, MLA, Chicago, or other Reference List formats
-
-5. Be thorough - the reference section may span many lines. Use read_document to read larger sections when needed.
-
-## Output Format
-
-After searching and reading, provide:
-- Your reasoning explaining what you searched for and found
-- A list of all extracted references, each with:
-  - **text**: The complete reference text
-  - **start_line**: The 1-indexed line number where this reference starts (from read_document output)
-  - **end_line**: The 1-indexed line number where this reference ends
-
-For example, if read_document shows:
+For each extracted reference, also report the 1-indexed `start_line` and `end_line` where it appears in the document (from the `read_document` line numbers). If a reference spans multiple lines, use the first line as `start_line` and the last as `end_line`. For example, if `read_document` shows:
 ```
 152|Smith, J. (2020). Title of Paper. Journal, 5(2), 123-145.
 153|Doe, A. (2019). Another Paper Title. Publisher.
 ```
-
-You would output:
-- Reference 1: text="Smith, J. (2020). Title of Paper. Journal, 5(2), 123-145.", start_line=152, end_line=152
-- Reference 2: text="Doe, A. (2019). Another Paper Title. Publisher.", start_line=153, end_line=153
-
-If a reference spans multiple lines, use the first line as start_line and last line as end_line.
-
-## Document Format
-
-The document you are searching is in markdown format, converted from DOC or PDF files. Due to the conversion process, the document may contain formatting errors, extra whitespace, or other artifacts. Be flexible when matching patterns and account for potential conversion issues.
-
-## Important Notes
-
-- Each reference should be a complete bibliographic entry
-- Do not include in-text citations - only extract the full reference entries from the bibliography section
-- If no reference section is found, return an empty list
-- Footnotes might appear in the end of document with the format "160. Text content here #footnote-ref-160"; they should be ignored as they are not part of the reference list
-- Preserve the original text of each reference exactly as it appears, except for the following:
-    - Remove entry numbers (e.g., [1], 1., (1)) from the beginning of the reference text
-    - If you see a placeholder for repeated authors at the start of a reference (commonly `---.` but also `———.`, `___`, or similar patterns), replace it with the author from the previous reference
-    - If a single reference item is split across multiple lines, merge them into a single line (remove line breaks)
+you would output text="Smith, J. (2020). Title of Paper. Journal, 5(2), 123-145." with start_line=152, end_line=152, and text="Doe, A. (2019). Another Paper Title. Publisher." with start_line=153, end_line=153.
 """
 
 _USER_MESSAGE = "Please extract all bibliographic references from the document."
@@ -127,7 +93,10 @@ class ReferenceExtractorV2Agent(LangChainAgent):
         result = await agent.ainvoke(
             {
                 "messages": [
-                    SystemMessage(content=_SYSTEM_PROMPT),
+                    SystemMessage(
+                        content=load_skill_prompt("reference-extraction")
+                        + _ENV_GUIDANCE
+                    ),
                     HumanMessage(content=_USER_MESSAGE),
                 ]
             },

--- a/skills/capabilities/SKILL.md
+++ b/skills/capabilities/SKILL.md
@@ -40,6 +40,7 @@ These operate on the document rather than flagging issues.
 |---|---|---|
 | **Download References** | Search the web for a reference and download its full original content (PDF/Markdown), verifying the match. Reports found / found-but-inaccessible / not-found. | `reference-download` |
 | **Extract Methodology** | Extract a structured, reproducible description of the paper's methodology, and classify how reproducible it is. | `methodology-extraction` |
+| **Extract References** | Find and list all bibliographic references from the document's reference/bibliography section. | `reference-extraction` |
 
 ## Notes
 

--- a/skills/reference-extraction/SKILL.md
+++ b/skills/reference-extraction/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: reference-extraction
+description: Use this skill to find and extract all bibliographic references from a document's reference/bibliography section, returning the complete text of each entry. Invoke when the user asks to extract, list, or pull out all the references, citations, or the bibliography from a document.
+---
+
+# Reference Extraction
+
+You are a reference extraction specialist. Your task is to find and extract all bibliographic references from the Reference List section of a document.
+
+## Instructions
+
+1. Locate the reference/bibliography section. Look for common section headers like "References", "Bibliography", "Works Cited", "Literature Cited", "Sources", etc. The heading may be a markdown heading (e.g. "# References" or "## Bibliography"). The section is sometimes unlabeled, so you may need to search for the common pattern of bibliographic entries directly.
+2. Read the full content of that section — it may span many pages, so be thorough.
+3. Extract each individual reference as a complete bibliographic entry. Keep each reference as a single string, preserving the original formatting.
+4. Common reference patterns to look for: APA, MLA, Chicago, or other Reference List formats.
+
+## Document Format
+
+The document may be in markdown converted from a DOC or PDF file. Due to the conversion process it can contain formatting errors, extra whitespace, or other artifacts. Be flexible when matching patterns and account for potential conversion issues.
+
+## Important Notes
+
+- Each reference should be a complete bibliographic entry.
+- Do not include in-text citations — only extract the full reference entries from the bibliography section.
+- If no reference section is found, return an empty list.
+- Footnotes might appear at the end of the document in a format like "160. Text content here #footnote-ref-160"; ignore them, as they are not part of the reference list.
+- Preserve the original text of each reference exactly as it appears, except for the following:
+    - Remove entry numbers (e.g., `[1]`, `1.`, `(1)`) from the beginning of the reference text.
+    - If you see a placeholder for repeated authors at the start of a reference (commonly `---.` but also `———.`, `___`, or similar patterns), replace it with the author from the previous reference.
+    - If a single reference item is split across multiple lines, merge them into a single line (remove line breaks).
+
+## Output
+
+Return the complete text of each extracted reference. For example, given a reference section containing:
+
+```
+Smith, J. (2020). Title of Paper. Journal, 5(2), 123-145.
+Doe, A. (2019). Another Paper Title. Publisher.
+```
+
+you would extract two references:
+- "Smith, J. (2020). Title of Paper. Journal, 5(2), 123-145."
+- "Doe, A. (2019). Another Paper Title. Publisher."

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -42,6 +42,7 @@ _SKILL_BACKED_AGENTS = [
     "methodology-extraction",
     "methodology-comparison",
     "reproducibility-check",
+    "reference-extraction",
 ]
 
 


### PR DESCRIPTION
## Summary

Converts `reference_extraction` into a **portable** source-of-truth skill ([RANDZ-601](https://linear.app/ae-studio/issue/RANDZ-601)). This redoes the earlier conversion that was reverted for baking Draft-Detective internals into the skill — now the skill is tool-agnostic and the DD specifics live in the agent.

## What's Changed

### Skills
- **`skills/reference-extraction/SKILL.md`** (new) — the reference-extraction procedure (locate the bibliography section; extract each complete entry; exclude in-text citations; ignore footnotes; normalization: strip entry numbers, expand repeated-author placeholders, merge multi-line). **No** tool names, **no** `start_line`/`end_line`, **no** placeholders — usable by any agent with its own read tools.
- **`skills/capabilities/SKILL.md`** — added **Extract References** under the Tools group.

### Backend
- **`lib/agents/reference_text_extractor_v2.py`** — `ReferenceExtractorV2Agent` now uses `load_skill_prompt("reference-extraction")` as its system prompt plus a backend-only `_ENV_GUIDANCE` block that carries what the skill omits: the `search_document`/`read_document` tools and the `start_line`/`end_line` output contract (with the line-numbered example). The `create_agent([search_document, read_document], response_format=ReferenceExtractorV2Output)` call, `_USER_MESSAGE`, node, manifest, and schema are unchanged.

### Tests
- `tests/unit/test_skills.py` — `reference-extraction` added to the skill-load guard.

## Verification
- `uv run mypy .` clean (369 files); unit tests pass (13).
- Skill confirmed free of `search_document`/`read_document`/`start_line`/`end_line`/placeholders; the composed system prompt (skill + `_ENV_GUIDANCE`) carries them.
- **Before/after e2e** (`reference_text_extractor`, 7 samples): 5/7 identical; the two partial-score samples moved in opposite directions (sample 6 −, sample 7 +). Epoching the regressed sample 6 three times on AFTER gave **0.746 / 0.741 / 0.746** — identical to BEFORE's **0.741** — so the lone low run was an outlier (tool-calling variance on a hard sample), **not** a regression.

## Risks and Mitigations
- The `start_line`/`end_line` output is load-bearing downstream; the `_ENV_GUIDANCE` preserves that contract and the eval confirms the line ranges still populate correctly.
- Skill file is load-bearing for the agent; a missing/renamed skill fails fast at runtime (guarded by the unit test).