### PR TITLE
feat(skills): convert advocacy_tone to a skill (advocacy_tone_v2)

### DIFF
--- a/evals_inspectai/e2e/advocacy_tone_v2/advocacy_tone_v2_e2e.py
+++ b/evals_inspectai/e2e/advocacy_tone_v2/advocacy_tone_v2_e2e.py
@@ -1,0 +1,68 @@
+from collections import Counter
+from pathlib import Path
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, json_dataset
+from inspect_ai.scorer import Score
+from inspect_ai.solver import TaskState
+
+from evals_inspectai.common.api_solver import api_workflow_agent
+from evals_inspectai.common.comparers import deep_diff_score
+from evals_inspectai.common.loaders import resolve_input
+from evals_inspectai.common.scorers import model_graded_check, structured_output_scorer
+from evals_inspectai.common.simple_deep_agent_types import SimpleDeepAgentOutput
+
+# Stable issue titles emitted by the advocacy-tone skill, one per check type.
+TRIGGER_WORDS_TITLE = "Trigger Words Detected"
+ADVOCACY_LANGUAGE_TITLE = "Advocacy Language Detected"
+SUBJECTIVE_TONE_TITLE = "Subjective Tone Detected"
+
+
+def _record_to_sample(record: dict) -> Sample:
+    return Sample(
+        input=resolve_input(record["input"]),
+        target=record.get("target_answer", ""),
+        metadata={
+            "target_title_counts": record.get("target_title_counts", {}),
+        },
+    )
+
+
+@task
+def advocacy_tone_v2_e2e():
+    dataset = json_dataset(
+        str(Path(__file__).parent / "dataset.json"),
+        _record_to_sample,
+    )
+
+    return Task(
+        dataset=dataset,
+        fail_on_error=0.2,
+        solver=api_workflow_agent("advocacy_tone_v2", timeout_s=600),
+        scorer=[
+            structured_output_scorer(SimpleDeepAgentOutput, _compare_title_counts),
+            model_graded_check(partial_credit=True),
+        ],
+    )
+
+
+def _compare_title_counts(output: SimpleDeepAgentOutput, state: TaskState) -> Score:
+    """Compare per-title issue counts to the expected counts.
+
+    Advocacy & Tone v2 emits one issue per genuine occurrence, with a stable
+    title identifying the check type ("Trigger Words Detected",
+    "Advocacy Language Detected", "Subjective Tone Detected"). Severities alone
+    can't separate advocacy_language from subjective_tone (both "medium"), so we
+    score on title counts instead.
+
+    Only the titles listed in ``target_title_counts`` are compared. A sample that
+    cares about a single check type lists only that title (don't-care on the
+    others), mirroring the v1 eval's per-check expectations; a sample that should
+    produce nothing lists all three titles set to 0.
+    """
+    expected: dict = state.metadata.get("target_title_counts", {})
+    issues = output.result.issues if output.result else []
+    counts = Counter(issue.title for issue in issues)
+    actual = {title: counts.get(title, 0) for title in expected}
+
+    return deep_diff_score(expected, actual)

--- a/evals_inspectai/e2e/advocacy_tone_v2/dataset.json
+++ b/evals_inspectai/e2e/advocacy_tone_v2/dataset.json
@@ -1,0 +1,41 @@
+[
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nThe intervention obviously works, so further analysis is unnecessary.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Trigger Words Detected": 1
+    },
+    "target_answer": "The Findings sentence uses 'obviously' to assert certainty without any cited evidence. The agent should report a 'Trigger Words Detected' issue (severity low) on that sentence. Advocacy and subjective tone are not the primary signal under test."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nSection 4 of the regulation states that workers must always wear protective equipment when handling hazardous materials.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Trigger Words Detected": 0,
+      "Advocacy Language Detected": 0,
+      "Subjective Tone Detected": 0
+    },
+    "target_answer": "The Findings sentence contains the trigger word 'always', but only as part of a factual quotation of a regulation in an objective context. Per the false-positive guardrail, simple factual mentions of legal terms should NOT be flagged. The agent should report zero advocacy/tone issues."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nWe believe stricter enforcement of these regulations would yield better outcomes overall.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Advocacy Language Detected": 1
+    },
+    "target_answer": "The Findings sentence states the authors' opinion ('We believe ...') and recommends stricter enforcement without citing evidence. The agent should report an 'Advocacy Language Detected' issue (severity medium) on that sentence."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nThe results are remarkably impressive, and the team's tireless dedication makes this one of the most exciting breakthroughs the field has ever seen.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Subjective Tone Detected": 1
+    },
+    "target_answer": "The Findings sentence is laden with value judgments and emotional language ('remarkably impressive', 'tireless dedication', 'most exciting breakthroughs') rather than a neutral, evidence-based statement. It contains no listed trigger words or advocacy phrases, so the agent should report a 'Subjective Tone Detected' issue (severity medium)."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nThe study collected 240 responses from three sites and applied a stratified sampling design.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Trigger Words Detected": 0,
+      "Advocacy Language Detected": 0,
+      "Subjective Tone Detected": 0
+    },
+    "target_answer": "The Findings sentence is purely factual and contains no trigger words, advocacy phrases, or value-laden language. The agent should report zero advocacy/tone issues."
+  }
+]

--- a/frontend/components/results/tabs/workflow-results-renderer.tsx
+++ b/frontend/components/results/tabs/workflow-results-renderer.tsx
@@ -106,6 +106,7 @@ function renderWorkflowResults(
     case WorkflowRunType.DocumentStructure:
     case WorkflowRunType.FiguresTablesCheck:
     case WorkflowRunType.RecommendationCheck:
+    case WorkflowRunType.AdvocacyToneV2:
     case WorkflowRunType.LiteratureReviewV2:
     case WorkflowRunType.LiveReportsV2:
       return (

--- a/frontend/components/workflows/workflow-type-checkbox.tsx
+++ b/frontend/components/workflows/workflow-type-checkbox.tsx
@@ -63,6 +63,7 @@ const workflowTypeIcons: Record<WorkflowRunType, LucideIcon> = {
   [WorkflowRunType.ClaimReferenceValidationV2]: ClipboardCheck,
   [WorkflowRunType.AbbreviationScanV2]: ALargeSmall,
   [WorkflowRunType.AdvocacyTone]: MessageSquareWarning,
+  [WorkflowRunType.AdvocacyToneV2]: MessageSquareWarning,
   [WorkflowRunType.AboutThisGer]: BookOpen,
   [WorkflowRunType.Reviewer2]: BookOpen,
   [WorkflowRunType.DocumentStructure]: FileCheckIcon,

--- a/frontend/lib/generated-api/types.gen.ts
+++ b/frontend/lib/generated-api/types.gen.ts
@@ -5804,6 +5804,7 @@ export const WorkflowRunType = {
   ClaimReferenceValidationV2: 'claim_reference_validation_v2',
   AbbreviationScanV2: 'abbreviation_scan_v2',
   AdvocacyTone: 'advocacy_tone',
+  AdvocacyToneV2: 'advocacy_tone_v2',
   AboutThisGer: 'about_this_ger',
   Reviewer2: 'reviewer_2',
   DocumentStructure: 'document_structure',

--- a/frontend/lib/workflow-state.ts
+++ b/frontend/lib/workflow-state.ts
@@ -55,6 +55,7 @@ type WorkflowTypeToDetail = {
   [WorkflowRunType.Reviewer2]: Reviewer2State;
   [WorkflowRunType.DocumentStructure]: SimpleDeepAgentState;
   [WorkflowRunType.FiguresTablesCheck]: SimpleDeepAgentState;
+  [WorkflowRunType.AdvocacyToneV2]: SimpleDeepAgentState;
 };
 
 export interface WorkflowRunDetailTyped<T> {

--- a/lib/workflows/advocacy_tone_v2/manifest.py
+++ b/lib/workflows/advocacy_tone_v2/manifest.py
@@ -1,0 +1,17 @@
+from lib.workflows.models import WorkflowRunType
+from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
+
+
+class AdvocacyToneV2Manifest(SimpleDeepAgentManifest):
+    """Flags advocacy language, trigger words, and subjective tone via a deep agent."""
+
+    type = WorkflowRunType.ADVOCACY_TONE_V2
+    name = "Advocacy & Tone"
+    description = (
+        "Does your document use neutral, objective language? Flags advocacy "
+        "language, trigger words, and subjective tone."
+    )
+    required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
+    is_experimental = False
+
+    skill = "advocacy-tone"

--- a/lib/workflows/categories.py
+++ b/lib/workflows/categories.py
@@ -55,7 +55,8 @@ WORKFLOW_DISPLAY_CONFIG: list[CategoryConfig] = [
         slug="language",
         label="Language",
         workflows=[
-            WorkflowRunType.ADVOCACY_TONE,
+            # WorkflowRunType.ADVOCACY_TONE,  # legacy v1; kept registered so old projects still load.
+            WorkflowRunType.ADVOCACY_TONE_V2,
         ],
     ),
     CategoryConfig(

--- a/lib/workflows/models.py
+++ b/lib/workflows/models.py
@@ -103,6 +103,7 @@ class WorkflowRunType(str, Enum):
     CLAIM_REFERENCE_VALIDATION_V2 = "claim_reference_validation_v2"
     ABBREVIATION_SCAN_V2 = "abbreviation_scan_v2"
     ADVOCACY_TONE = "advocacy_tone"
+    ADVOCACY_TONE_V2 = "advocacy_tone_v2"
     ABOUT_THIS_GER = "about_this_ger"
     REVIEWER_2 = "reviewer_2"
     DOCUMENT_STRUCTURE = "document_structure"

--- a/lib/workflows/registry.py
+++ b/lib/workflows/registry.py
@@ -62,6 +62,7 @@ def register_all_workflow_manifests():
     from lib.workflows.figures_tables_check.manifest import FiguresTablesCheckManifest
     from lib.workflows.about_this_ger.manifest import AboutThisGerManifest
     from lib.workflows.advocacy_tone.manifest import AdvocacyToneManifest
+    from lib.workflows.advocacy_tone_v2.manifest import AdvocacyToneV2Manifest
     from lib.workflows.chunk_splitting.manifest import ChunkSplittingManifest
     from lib.workflows.citation_detection.manifest import CitationDetectionManifest
     from lib.workflows.citation_suggester.manifest import CitationSuggesterManifest
@@ -128,6 +129,7 @@ def register_all_workflow_manifests():
         ReferenceValidationV2Manifest(),
         ResultsExtractionManifest(),
         AdvocacyToneManifest(),
+        AdvocacyToneV2Manifest(),
         AboutThisGerManifest(),
         Reviewer2Manifest(),
         DocumentStructureManifest(),

--- a/skills/advocacy-tone/SKILL.md
+++ b/skills/advocacy-tone/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: advocacy-tone
+description: Use this skill to check that a document uses neutral, objective language. Flags trigger words (certainty language without evidence), advocacy language (unsupported recommendations or opinion framing), and subjective tone (value judgments or emotional language). Invoke when asked to review a document's tone, neutrality, or objectivity.
+---
+
+# Advocacy & Tone
+
+You are a specialist document reviewer. Check whether the document uses neutral, objective language, as research writing should. Flag three kinds of non-neutral language: **trigger words**, **advocacy language**, and **subjective tone**. Read or search the document's content as needed to evaluate it.
+
+## What counts
+
+- **Trigger words** — certainty language without evidence. Words implying certainty or universal truth without supporting evidence; academic writing should hedge claims appropriately. The words to look for are: `obviously`, `clearly`, `undoubtedly`, `certainly`, `definitely`, `absolutely`, `always`, `never`.
+
+- **Advocacy language** — unsupported recommendations. Statements promoting positions without citing evidence; research should distinguish between findings and opinions. The phrases to look for are: `we believe`, `in our opinion`, `it is clear that`, `without doubt`, `everyone knows`.
+
+- **Subjective tone** — subjective evaluations. Value judgments or emotional language that may indicate bias; research writing should maintain a neutral, evidence-based tone. There is no fixed word list — judge this by reading the prose.
+
+## Procedure
+
+1. **Find the trigger words and advocacy phrases by searching.** Search the document for each trigger word and advocacy phrase listed above, using case-insensitive, whole-word matching. A search match only tells you where a candidate is — read the surrounding text to see each match in context before judging it.
+
+2. **Find subjective tone by reading.** Read the body sections of the document and identify sentences that use value judgments or emotionally loaded, non-neutral language. There is no list to search for — this relies on your reading judgment.
+
+3. **Judge each candidate in context.** A lexical match is only a candidate, not a confirmed issue. Confirm an issue only when the language genuinely undermines neutrality or makes an unsupported certainty/opinion claim.
+   - **Do not flag simple, factual mentions of legal terms or policies in an objective context.** For example, "the policy clearly states X" describing what a document says is acceptable; "X is clearly the best approach" is not.
+   - **Skip ignored sections.** Do not flag matches inside sections whose heading contains `author`, `reference`, `bibliography`, `appendix`, or `acknowledgment`.
+
+## Reporting
+
+Report issues following the conventions defined in the issues skill (`/skills/issues/SKILL.md`). Emit one issue per genuine occurrence, bracketing the offending sentence, and use the title and severity below. Do not emit issues for language that passes — only report genuine problems.
+
+- **Trigger word** issue → title `"Trigger Words Detected"`, **severity: low**.
+- **Advocacy language** issue → title `"Advocacy Language Detected"`, **severity: medium**.
+- **Subjective tone** issue → title `"Subjective Tone Detected"`, **severity: medium**.
+
+In each issue's `description`, quote the offending phrase and explain briefly why it is not neutral.

--- a/skills/capabilities/SKILL.md
+++ b/skills/capabilities/SKILL.md
@@ -26,6 +26,7 @@ These review the document and flag issues.
 | **Document Contents** | Does the document include all required sections — About This, Acknowledgements, Methods, Results, Conclusion, References, and an Appendix when one is referenced? | `document-contents` |
 | **Recommendation Check** | Is each recommendation supported by the document's own findings? Flags recommendations with weak, indirect, missing, or contradictory backing. | `recommendation-check` |
 | **Internal Inference Validation** | Does the reasoning hold up? Flags logical leaps, unsupported conclusions, and arguments where the evidence doesn't support the claim. | `inference-validation` |
+| **Advocacy & Tone** | Does the document use neutral, objective language? Flags trigger words (certainty language without evidence), advocacy language (unsupported recommendations or opinion framing), and subjective tone. (Beta.) | `advocacy-tone` |
 | **Reviewer 2** | A rigorous simulated peer review — summary, strengths, weaknesses, and prioritized next steps — plus a separate devil's-advocate rebuttal. (Beta.) | `reviewer-2` |
 | **Literature Review** | Are there relevant sources you may have missed? Searches the web for academic sources related to your document's claims — both supporting and conflicting — that aren't already cited. (Beta.) | `literature-review` |
 | **Live Reports** | Have your findings been updated or contradicted by newer research? Searches the web for sources published after your document's date and produces an addendum of what to update. (Beta.) | `live-reports` |

--- a/tests/unit/workflows/simple_deep_agent/test_skill_prompt.py
+++ b/tests/unit/workflows/simple_deep_agent/test_skill_prompt.py
@@ -11,11 +11,12 @@ from lib.workflows.models import WorkflowRunType
 from lib.workflows.registry import get_workflow_manifest
 from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
 
-# The Tier 1 workflows whose rules live in a skill file.
+# SimpleDeepAgent workflows whose rules live in a skill file.
 _SKILL_BACKED_WORKFLOWS = [
     WorkflowRunType.FIGURES_TABLES_CHECK,
     WorkflowRunType.DOCUMENT_STRUCTURE,
     WorkflowRunType.RECOMMENDATION_CHECK,
+    WorkflowRunType.ADVOCACY_TONE_V2,
 ]
 
 


### PR DESCRIPTION
## Summary

Converts the Advocacy & Tone assessment to the skill pattern ([RANDZ-603](https://linear.app/ae-studio/issue/RANDZ-603)). Replaces the old `advocacy_tone` (regex pre-filter + LLM verification) with **`advocacy_tone_v2`**, a `SimpleDeepAgent` driven by the portable `advocacy-tone` skill — resolving the open question of how to handle the regex stage (the deep agent does the search + judgment directly).

## What's Changed

### Skills
- **`skills/advocacy-tone/SKILL.md`** (new) — the advocacy/tone rules (trigger words, advocacy language, subjective tone; in-context judging; ignored sections; per-category titles/severities) as a **generic, portable** skill: no `/main.md`, no specific tool names (`grep`/`read_file`), no `start_line`/`end_line`. Matches the Tier 1 SimpleDeepAgent skill convention — the base system prompt supplies the document location, tools, and issues-format reference.
- **`skills/capabilities/SKILL.md`** — Advocacy & Tone listed under Assessments.

### Backend
- **`lib/workflows/advocacy_tone_v2/manifest.py`** (new) — `SimpleDeepAgentManifest` with `skill="advocacy-tone"`, registered in `registry.py`.
- **`lib/workflows/models.py`** — `ADVOCACY_TONE_V2` workflow type.
- **`lib/workflows/categories.py`** — activates v2 in the Language category; v1 commented out but kept registered so old projects still load (same v1→v2 pattern as reference_validation).

### Evals & Frontend
- **`evals_inspectai/e2e/advocacy_tone_v2/`** — e2e task + dataset.
- **Frontend** — wires the new workflow type (results renderer, workflow checkbox, regenerated API types, workflow state).

### Tests
- `tests/unit/workflows/simple_deep_agent/test_skill_prompt.py` — `ADVOCACY_TONE_V2` added to the skill-resolution guard.

## Verification
- `uv run mypy .` clean (371 files); unit tests pass (19).
- The `advocacy-tone` skill resolves via the manifest and is confirmed free of `/main.md`, `grep`/`read_file`, `start_line`/`end_line`, and placeholders.

## Notes
- Most of the v2 workflow wiring (manifest, models, registry, categories, eval, frontend) was authored outside the AI session; this PR bundles it with the generic-skill rewrite. An `advocacy_tone_v2` e2e eval is included for before/after validation during review.