### PR TITLE
feat(advocacy-tone): make advocacy_tone_v2 deployment-configurable via app settings

### DIFF
--- a/lib/services/app_configs.py
+++ b/lib/services/app_configs.py
@@ -108,9 +108,10 @@ async def ensure_defaults(defaults: List[DefaultConfig]) -> None:
 def _collect_all_defaults() -> List[DefaultConfig]:
     """Gather every DefaultConfig list registered across the codebase."""
     from lib.workflows.about_this_ger.config_keys import ABOUT_THIS_GER_DEFAULTS
+    from lib.workflows.advocacy_tone_v2.config_keys import ADVOCACY_TONE_V2_DEFAULTS
     from lib.config_keys.about_page import ABOUT_PAGE_DEFAULTS
 
-    return [*ABOUT_THIS_GER_DEFAULTS, *ABOUT_PAGE_DEFAULTS]
+    return [*ABOUT_THIS_GER_DEFAULTS, *ADVOCACY_TONE_V2_DEFAULTS, *ABOUT_PAGE_DEFAULTS]
 
 
 async def seed_all_defaults() -> None:

--- a/lib/workflows/advocacy_tone_v2/config_keys.py
+++ b/lib/workflows/advocacy_tone_v2/config_keys.py
@@ -1,0 +1,47 @@
+"""Runtime config key for the Advocacy & Tone (v2) workflow.
+
+A single admin-overridable text setting (looked up via the AppConfig table)
+holds the deployment-tunable configuration for the advocacy/tone review: the
+trigger words, advocacy phrases, sections to skip, and what each issue type
+means. The `advocacy-tone` skill remains the portable *method*; this setting is
+the deployment's *data*, injected into the prompt at runtime and superseding the
+skill's built-in defaults.
+
+The default below mirrors the skill's built-in defaults, so out-of-the-box
+behavior matches the skill. Admins edit this one text field in the app-config UI.
+"""
+
+from lib.services.app_configs import DefaultConfig
+
+ADVOCACY_TONE_V2_CONFIG_KEY = "advocacy_tone_v2.config"
+
+_DEFAULT_CONFIG = """\
+Trigger words (certainty language without evidence):
+obviously, clearly, undoubtedly, certainly, definitely, absolutely, always, never
+
+Advocacy phrases (unsupported recommendations):
+we believe, in our opinion, it is clear that, without doubt, everyone knows
+
+Skip sections whose heading contains:
+author, reference, bibliography, appendix, acknowledgment
+
+What each issue type means:
+- Trigger words — certainty language without evidence. Words implying certainty or universal truth without supporting evidence; academic writing should hedge claims appropriately.
+- Advocacy language — unsupported recommendations. Statements promoting positions without citing evidence; research should distinguish between findings and opinions.
+- Subjective tone — subjective evaluations. Value judgments or emotional language that may indicate bias; research writing should maintain a neutral, evidence-based tone.
+"""
+
+ADVOCACY_TONE_V2_DEFAULTS = [
+    DefaultConfig(
+        key=ADVOCACY_TONE_V2_CONFIG_KEY,
+        default_value=_DEFAULT_CONFIG,
+        description=(
+            "Deployment configuration for the Advocacy & Tone (v2) workflow. "
+            "Plain text, edited here in the UI: the trigger words, advocacy "
+            "phrases, sections to skip, and the definition of each issue type. "
+            "It is injected into the review prompt and supersedes the skill's "
+            "built-in defaults — so you can tune what the check looks for "
+            "without changing code or the skill."
+        ),
+    ),
+]

--- a/lib/workflows/advocacy_tone_v2/manifest.py
+++ b/lib/workflows/advocacy_tone_v2/manifest.py
@@ -1,9 +1,20 @@
+from langgraph.graph import StateGraph
+
+from lib.workflows.advocacy_tone_v2.nodes.advocacy_tone import (
+    build_advocacy_tone_v2_graph,
+)
 from lib.workflows.models import WorkflowRunType
 from lib.workflows.simple_deep_agent.manifest_base import SimpleDeepAgentManifest
 
 
 class AdvocacyToneV2Manifest(SimpleDeepAgentManifest):
-    """Flags advocacy language, trigger words, and subjective tone via a deep agent."""
+    """Flags advocacy language, trigger words, and subjective tone via a deep agent.
+
+    Reuses the SimpleDeepAgent state/config and issue conversion, but customises
+    the graph so the node can inject the deployment's tunable configuration
+    (the ``advocacy_tone_v2.config`` app setting) into the `advocacy-tone` skill
+    prompt at runtime.
+    """
 
     type = WorkflowRunType.ADVOCACY_TONE_V2
     name = "Advocacy & Tone"
@@ -14,4 +25,5 @@ class AdvocacyToneV2Manifest(SimpleDeepAgentManifest):
     required_dependencies = [WorkflowRunType.DOCUMENT_PROCESSING]
     is_experimental = False
 
-    skill = "advocacy-tone"
+    def build_graph(self) -> StateGraph:
+        return build_advocacy_tone_v2_graph()

--- a/lib/workflows/advocacy_tone_v2/nodes/advocacy_tone.py
+++ b/lib/workflows/advocacy_tone_v2/nodes/advocacy_tone.py
@@ -1,0 +1,69 @@
+"""Advocacy & Tone v2 node — a SimpleDeepAgent driven by the `advocacy-tone`
+skill, with the deployment's tunable configuration injected at runtime.
+
+The skill is the portable *method*; the `advocacy_tone_v2.config` app setting is
+the deployment's *data* (trigger words, advocacy phrases, ignored sections,
+issue-type definitions). The node loads the skill and appends the configuration
+so admins can tune the check via the app-config UI without touching code.
+"""
+
+import logging
+from typing import Optional
+
+from langgraph.graph import START, StateGraph
+from langgraph.graph.state import END
+from langgraph.runtime import Runtime
+
+from lib.services.app_configs import get_config
+from lib.skills import load_skill_prompt
+from lib.workflows.advocacy_tone_v2.config_keys import ADVOCACY_TONE_V2_CONFIG_KEY
+from lib.workflows.context import ContextSchema
+from lib.workflows.decorators import register_node
+from lib.workflows.simple_deep_agent.agent import SimpleDeepAgent
+from lib.workflows.simple_deep_agent.state import SimpleDeepAgentState
+
+logger = logging.getLogger(__name__)
+
+_CONFIG_HEADER = """\
+
+---
+
+## Configuration for this deployment
+
+Use the trigger words, advocacy phrases, sections to skip, and issue-type \
+definitions below for this review. They supersede the example lists and \
+definitions in the sections above.
+
+"""
+
+
+def build_user_prompt(config_text: Optional[str]) -> str:
+    """Compose the agent user prompt: the portable skill + the deployment config.
+
+    Falls back to the skill alone (its built-in defaults) when no config is set.
+    """
+    prompt = load_skill_prompt("advocacy-tone")
+    if config_text and config_text.strip():
+        prompt += _CONFIG_HEADER + config_text.strip() + "\n"
+    return prompt
+
+
+@register_node("Detect advocacy & tone")
+async def detect_advocacy_tone(
+    state: SimpleDeepAgentState, runtime: Runtime[ContextSchema]
+) -> dict:
+    config_text = await get_config(ADVOCACY_TONE_V2_CONFIG_KEY)
+    agent = SimpleDeepAgent(
+        context=runtime.context,
+        user_prompt=build_user_prompt(config_text),
+    )
+    result, messages = await agent.ainvoke({})
+    return {"result": result, "messages": messages}
+
+
+def build_advocacy_tone_v2_graph() -> StateGraph:
+    graph = StateGraph(SimpleDeepAgentState, context_schema=ContextSchema)
+    graph.add_node("detect_advocacy_tone", detect_advocacy_tone)
+    graph.add_edge(START, "detect_advocacy_tone")
+    graph.add_edge("detect_advocacy_tone", END)
+    return graph  # type: ignore[return-value]

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -43,6 +43,7 @@ _SKILL_BACKED_AGENTS = [
     "methodology-comparison",
     "reproducibility-check",
     "reference-extraction",
+    "advocacy-tone",
 ]
 
 

--- a/tests/unit/workflows/advocacy_tone_v2/test_advocacy_tone_node.py
+++ b/tests/unit/workflows/advocacy_tone_v2/test_advocacy_tone_node.py
@@ -1,0 +1,35 @@
+"""Tests for advocacy_tone_v2 prompt composition and config registration."""
+
+from lib.services.app_configs import _collect_all_defaults
+from lib.skills import load_skill_prompt
+from lib.workflows.advocacy_tone_v2.config_keys import (
+    ADVOCACY_TONE_V2_CONFIG_KEY,
+    ADVOCACY_TONE_V2_DEFAULTS,
+)
+from lib.workflows.advocacy_tone_v2.nodes.advocacy_tone import build_user_prompt
+
+
+def test_build_user_prompt_without_config_is_just_the_skill():
+    skill = load_skill_prompt("advocacy-tone")
+    assert build_user_prompt(None) == skill
+    assert build_user_prompt("   ") == skill  # blank config ignored
+
+
+def test_build_user_prompt_appends_config_block():
+    cfg = "Trigger words:\nfoo, bar, baz"
+    prompt = build_user_prompt(cfg)
+    assert prompt.startswith(load_skill_prompt("advocacy-tone"))
+    assert "## Configuration for this deployment" in prompt
+    assert cfg in prompt
+    # the injected config supersedes the skill defaults
+    assert "supersede" in prompt.lower()
+
+
+def test_default_config_is_registered_for_seeding():
+    keys = {d.key for d in _collect_all_defaults()}
+    assert ADVOCACY_TONE_V2_CONFIG_KEY in keys
+    # the bundled defaults entry carries a non-empty default value
+    (entry,) = [
+        d for d in ADVOCACY_TONE_V2_DEFAULTS if d.key == ADVOCACY_TONE_V2_CONFIG_KEY
+    ]
+    assert entry.default_value.strip()

--- a/tests/unit/workflows/simple_deep_agent/test_skill_prompt.py
+++ b/tests/unit/workflows/simple_deep_agent/test_skill_prompt.py
@@ -16,7 +16,6 @@ _SKILL_BACKED_WORKFLOWS = [
     WorkflowRunType.FIGURES_TABLES_CHECK,
     WorkflowRunType.DOCUMENT_STRUCTURE,
     WorkflowRunType.RECOMMENDATION_CHECK,
-    WorkflowRunType.ADVOCACY_TONE_V2,
 ]
 
 


### PR DESCRIPTION
## Summary

The old `advocacy_tone` workflow was customizable via `workflow_config.yaml` (prod overrode it in `bonetti/prod_workflow_config.yaml`). The new `advocacy_tone_v2` (SimpleDeepAgent on the `advocacy-tone` skill) had no customization path. This adds one — keeping the skill as the portable **method** while a single admin-editable text setting supplies the deployment's **data**.

## Approach

A single `app_configs` text key, **`advocacy_tone_v2.config`**, holds the tunable content (trigger words, advocacy phrases, sections to skip, issue-type definitions) as plain, prompt-like text editable in the existing Application Settings UI — the same mechanism `about_this_ger` uses, but for just the configurable data, not the whole prompt. A small custom node injects it into the skill prompt at runtime, superseding the skill's built-in defaults.

## What's Changed

- **`lib/workflows/advocacy_tone_v2/config_keys.py`** (new) — the `advocacy_tone_v2.config` key + `DefaultConfig` (seeded with the skill's built-in defaults), registered in `app_configs._collect_all_defaults`.
- **`lib/workflows/advocacy_tone_v2/nodes/advocacy_tone.py`** (new) — custom node (the `literature_review_v2` pattern): loads the `advocacy-tone` skill, appends a `## Configuration for this deployment` block from the app setting (or skill-only when unset). `build_user_prompt()` is a pure, unit-tested composer.
- **`manifest.py`** — overrides `build_graph` with the node (drops the bare `skill=`).
- **`skills/advocacy-tone/SKILL.md`** — unchanged (portable method + default lists).
- **Tests** — composition + default-seeding tests; `advocacy-tone` added to the skill-load guard; `ADVOCACY_TONE_V2` moved off the `skill=`-resolution guard (now a custom-graph workflow).

The legacy `subjectivity_threshold` / `context_k` fields are intentionally dropped — the deep agent has no regex/TextBlob pre-filter or RAG window.

## Verification
- `uv run mypy .` clean (374 files); unit tests pass (22). The graph builds as a single `detect_advocacy_tone` node; the config default is registered for seeding; prompt composition (skill-only vs skill+config) is covered by tests.

## Follow-up (production)
The production value for `advocacy_tone_v2.config` (derived from `prod_workflow_config.yaml` — regex→phrases, moot fields dropped) is tracked in a separate Linear ticket for an admin to set in the app-config UI after deploy. Out of the box, the seeded default reproduces the skill's behavior.