### PR TITLE
feat(abbreviation): add abbreviation-extraction & abbreviation-scan skills

### DIFF
--- a/lib/agents/abbreviation_checker.py
+++ b/lib/agents/abbreviation_checker.py
@@ -9,106 +9,42 @@ from langchain_core.runnables import RunnableConfig
 
 from lib.config.llm_models import gpt_5_4_model
 from lib.models.agent import LangChainAgent
+from lib.skills import load_skill_prompt
 from lib.workflows.abbreviation_scan_v2.state import AbbreviationCheckOutput
 from lib.workflows.context import ContextSchema
 
-_SYSTEM_PROMPT = """You are a meticulous document analyst specialising in identifying and cataloguing abbreviations and acronyms.
+# The extraction *method* lives in the portable `abbreviation-extraction` skill
+# (the single source of truth). This backend-only addendum carries the
+# Draft-Detective specifics the skill omits: where the document lives, the
+# document-access tools, and the exact structured-output field mapping the
+# downstream deterministic checks depend on.
+_ENV_GUIDANCE = """\
 
-## Your Task
+---
 
-Scan the entire `/main.md` document and produce a complete catalogue of every
-abbreviation/acronym occurrence. You are **not** checking compliance rules yourself — a
-downstream system will do that. Your job is to record accurate, complete data for every
-occurrence so that the downstream checks have everything they need.
+## Environment & output
 
-For each occurrence you must capture:
-- The abbreviation itself (e.g. "OUSW").
-- Whether an inline definition accompanies that specific occurrence — i.e. the pattern
-  "Full Name (ABBR)". Example: "The Office of the Under Secretary of War (OUSW) issued…"
-  has an inline definition, while a later bare "OUSW" does not.
-- Whether the abbreviation appears in a dedicated "Abbreviations", "Acronyms", "Glossary",
-  or equivalent section, and if so what definition is listed there.
+The document is available at `/main.md` — use the available search and read tools to read or
+search it (e.g. search for headings like `^#+\\s*(Abbreviation|Acronym|Glossary)` to locate the
+Abbreviations section).
 
-## How to Proceed
+Return the structured catalogue as the `abbreviations` list — one entry per occurrence — where
+each entry records:
+- `abbr`: the abbreviation in its singular base form (e.g. "LLM", not "LLMs");
+- `inline_definition`: the inline definition accompanying this exact occurrence, or an empty
+  string when none accompanies it;
+- `occurrence_number`: the 1-based count of how many times this abbreviation has appeared so far
+  (1 for the first occurrence);
+- `line_start` / `line_end`: the 1-indexed line range in `/main.md` (same line number for a
+  single-line occurrence);
+- `abbreviations_section_definition`: the definition listed in the Abbreviations section, or
+  `None` when the abbreviation is not listed there or no such section exists;
+- `ignored`: `true` for occurrences excluded from compliance checks (headings, References /
+  Bibliography, cover page, exempt classes), `false` otherwise;
+- `ignored_reason`: a brief explanation when `ignored` is `true`, otherwise `None`.
 
-1. Use available search and read tools to find the Abbreviations section (search for patterns like
-   "^#+\\s*(Abbreviation|Acronym|Glossary)") and build a map of every abbreviation defined there
-   together with its listed definition.
-
-2. Read the document from the beginning, section by section. On **every line**, identify
-   **all** abbreviations present — including ones you have already seen earlier in the document.
-   Do not skip an abbreviation just because it was recorded on a previous line. For each
-   abbreviation occurrence you find:
-   - Record its `abbr`, the `inline_definition` accompanying that exact occurrence (empty string
-     if the occurrence has no inline definition), and the `occurrence_number` (1 for the very
-     first time this abbreviation appears in the document, 2 for the second time, etc.).
-   - Record `line_start` and `line_end` as the 1-indexed line numbers of the line(s) where this
-     occurrence appears in the document. For a single-line occurrence set both to the same line number.
-   - Record the `abbreviations_section_definition` from the Abbreviations section map (None if
-     not listed there, or if no Abbreviations section was found).
-
-3. Read the ENTIRE document — do not stop early.
-
-## Ignored Abbreviations
-
-Some occurrences must be recorded but marked as excluded by setting `ignored=true` and
-providing a brief `ignored_reason` explaining the category.
-
-**Heading abbreviations** — Any abbreviation appearing inside a Markdown heading
-(any line starting with one or more `#` characters) should be marked `ignored=true`.
-
-**Abbreviations / Glossary section** — Do **not** record any occurrences that appear inside
-the dedicated "Abbreviations", "Acronyms", "Glossary", or equivalent section itself. That
-section is the reference list, not document body text, so its entries must not appear in the
-output at all — not even as ignored items.
-
-**References / Bibliography section** — Any abbreviation appearing inside a dedicated
-"References", "Bibliography", "Works Cited", or equivalent section should be marked
-`ignored=true`.
-
-**Front page / Cover page** — Any abbreviation appearing on the front page or cover page
-(typically the first page of the document, before the table of contents or any body section)
-should be marked `ignored=true`.
-
-**Exempt abbreviation classes** — Certain common abbreviation types should be marked
-`ignored=true`. The exempt classes are:
-
-| Class | Examples | Notes |
-|---|---|---|
-| Personal titles | Mr., Mrs., Ms., Dr., Rev., Hon. | |
-| Academic degrees | Ph.D., M.A., B.Sc., M.D., J.D. | |
-| Common units of measurement | cm, mm, km, mW, kHz, MHz, GHz, kg, mg | |
-| Citation elements | Vol., Ch., pp., para., ed., ibid., et al. | |
-| Military ranks | Col., Gen., Sgt., Lt., Cpl., Adm., Maj. | |
-| Military equipment designators | C-141, F-35, Su-35, M-1, Ka-32 | |
-| Corporation names (all-caps) | RAND, CNA, MITRE, IBM, SAIC | |
-| Biological genus abbreviations | E. coli, C. botulinum, S. aureus | |
-| Security markings | (U), (S), (C), (TS), (SCI) | Record `abbr` with parentheses, e.g. "(U)" not "U" |
-| United States abbreviation | U.S. | |
-
-If an abbreviation clearly belongs to one of these classes, set `ignored=true`.
-
-For all non-ignored occurrences, leave `ignored_reason` as null.
-
-## Plural Forms
-
-Treat plural forms of an abbreviation as the same abbreviation as the singular form.
-For example, "LLMs" is the plural of "LLM" — they are the same abbreviation. When recording
-occurrences, always use the singular base form (e.g. "LLM", not "LLMs") as the `abbr` value.
-Occurrence numbering, inline-definition recording, and Abbreviations-section lookups should
-all treat singular and plural forms as a single abbreviation. A definition on either form counts
-for both (e.g. "Large Language Models (LLMs)" satisfies the first-use definition for "LLM").
-
-## Output
-
-Return the `abbreviations` list with one entry per occurrence (not one per unique abbreviation).
-If the same abbreviation appears 10 times, there should be 10 entries with occurrence_number 1–10.
-A single line may contain multiple abbreviations — both different abbreviations and repeated
-uses of the same one. Every abbreviation on a line must be recorded as its own entry. For
-example, "The NATO task force and the OSCE delegation briefed NATO headquarters" should produce
-three entries (NATO, OSCE, NATO), all sharing the same `line_start`/`line_end`.
-Set `abbreviations_section_found` to true only if you found and read a dedicated Abbreviations
-(or equivalent) section. Provide a brief `reasoning` summary of your findings.
+Also set `abbreviations_section_found` to `true` only if you found and read a dedicated
+Abbreviations (or equivalent) section, and provide a brief `reasoning` summary of your findings.
 """
 
 
@@ -140,7 +76,10 @@ class AbbreviationCheckerAgent(LangChainAgent):
                     include_supporting_files=False
                 ),
                 "messages": [
-                    SystemMessage(content=_SYSTEM_PROMPT),
+                    SystemMessage(
+                        content=load_skill_prompt("abbreviation-extraction")
+                        + _ENV_GUIDANCE
+                    ),
                     HumanMessage(
                         content=(
                             "Please scan the entire document for abbreviations and acronyms. "

--- a/skills/abbreviation-extraction/SKILL.md
+++ b/skills/abbreviation-extraction/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: abbreviation-extraction
+description: Use this skill to find and catalogue every abbreviation and acronym occurrence in a document — recording, for each occurrence, any accompanying inline definition, how many times the abbreviation has appeared so far, where it appears, the definition listed in any Abbreviations section, and whether the occurrence is exempt from compliance checks. Invoke when asked to extract, list, or inventory the abbreviations/acronyms in a document (e.g. as input to an abbreviation compliance check).
+---
+
+# Abbreviation Extraction
+
+You are a meticulous document analyst specialising in identifying and cataloguing abbreviations and acronyms.
+
+## Your task
+
+Scan the **entire** document and produce a complete catalogue of every abbreviation / acronym occurrence. You are **not** checking compliance rules here — your job is to record accurate, complete data for every occurrence so that a downstream check has everything it needs.
+
+For each occurrence, capture:
+
+- **The abbreviation itself** (e.g. "OUSW").
+- **Any inline definition accompanying that specific occurrence** — i.e. the pattern "Full Name (ABBR)". For example, "The Office of the Under Secretary of War (OUSW) issued…" has an inline definition, while a later bare "OUSW" does not. Record an empty value when the occurrence has no inline definition immediately accompanying it.
+- **The occurrence count** — how many times this abbreviation has appeared so far in the document (1 for the very first appearance, 2 for the second, and so on). The first occurrence is the most important.
+- **Where the occurrence appears** — the line range in the document where it occurs (for a single-line occurrence, the start and end are the same line).
+- **The definition listed in any dedicated Abbreviations section** — if the document has an "Abbreviations", "Acronyms", "Glossary", or equivalent section and this abbreviation is listed there, record the definition as written there; otherwise record that it is absent.
+
+## How to proceed
+
+1. **Find the Abbreviations section first.** Look for a dedicated "Abbreviations", "Acronyms", "Glossary", or equivalent section and build a map of every abbreviation defined there together with its listed definition.
+
+2. **Read the document from the beginning, section by section.** On **every line**, identify **all** abbreviations present — including ones you have already seen earlier in the document. Do not skip an abbreviation just because it was recorded on a previous line. For each occurrence, record the abbreviation, the inline definition accompanying that exact occurrence (empty if none), the occurrence count, the line range, and the definition from the Abbreviations-section map (absent if not listed there or if no such section exists).
+
+3. **Read the entire document — do not stop early.**
+
+## One entry per occurrence
+
+Produce one entry per **occurrence**, not one per unique abbreviation. If the same abbreviation appears 10 times, there should be 10 entries with occurrence counts 1–10. A single line may contain multiple abbreviations — both different abbreviations and repeated uses of the same one — and **every** abbreviation on a line must be recorded as its own entry. For example, "The NATO task force and the OSCE delegation briefed NATO headquarters" produces three entries (NATO, OSCE, NATO), all sharing the same line range.
+
+## Plural forms
+
+Treat the plural form of an abbreviation as the same abbreviation as its singular form. For example, "LLMs" is the plural of "LLM" — they are the same abbreviation. Always record the singular base form (e.g. "LLM", not "LLMs"). Occurrence counting, inline-definition recording, and Abbreviations-section lookups all treat singular and plural as a single abbreviation, and a definition on either form counts for both (e.g. "Large Language Models (LLMs)" satisfies the first-use definition for "LLM").
+
+## Exempt and ignored occurrences
+
+Some occurrences must still be recorded but marked as **excluded from compliance checks**, with a brief reason explaining the category:
+
+- **Heading abbreviations** — any abbreviation appearing inside a Markdown heading (a line starting with one or more `#` characters).
+- **References / Bibliography section** — any abbreviation appearing inside a dedicated "References", "Bibliography", "Works Cited", or equivalent section.
+- **Front page / cover page** — any abbreviation appearing on the front or cover page (typically the first page, before the table of contents or any body section).
+- **Exempt abbreviation classes** — abbreviations that clearly belong to one of these common classes:
+
+  | Class | Examples | Notes |
+  |---|---|---|
+  | Personal titles | Mr., Mrs., Ms., Dr., Rev., Hon. | |
+  | Academic degrees | Ph.D., M.A., B.Sc., M.D., J.D. | |
+  | Common units of measurement | cm, mm, km, mW, kHz, MHz, GHz, kg, mg | |
+  | Citation elements | Vol., Ch., pp., para., ed., ibid., et al. | |
+  | Military ranks | Col., Gen., Sgt., Lt., Cpl., Adm., Maj. | |
+  | Military equipment designators | C-141, F-35, Su-35, M-1, Ka-32 | |
+  | Corporation names (all-caps) | RAND, CNA, MITRE, IBM, SAIC | |
+  | Biological genus abbreviations | E. coli, C. botulinum, S. aureus | |
+  | Security markings | (U), (S), (C), (TS), (SCI) | Record the marking with its parentheses, e.g. "(U)" not "U" |
+  | United States abbreviation | U.S. | |
+
+  For non-exempt occurrences, leave the exclusion reason empty.
+
+## The Abbreviations / Glossary section itself
+
+Do **not** record any occurrences that appear **inside** the dedicated "Abbreviations", "Acronyms", "Glossary", or equivalent section. That section is the reference list, not document body text, so its entries must not appear in the catalogue at all — not even as excluded items. (Its contents are still used to populate each recorded occurrence's "definition listed in the Abbreviations section".)
+
+## Output
+
+Return the full catalogue (one entry per occurrence, as described above), whether or not a dedicated Abbreviations (or equivalent) section was found, and a brief summary of what you found and how.

--- a/skills/abbreviation-scan/SKILL.md
+++ b/skills/abbreviation-scan/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: abbreviation-scan
+description: Use this skill to check that a document's abbreviations and acronyms follow publication style — each is defined inline at its first use, listed in a dedicated Abbreviations section, used consistently, and not given conflicting meanings. Invoke when asked to review or validate a document's abbreviations/acronyms for compliance (e.g. per a manual of style).
+---
+
+# Abbreviation Scan
+
+You are a document reviewer checking that abbreviations and acronyms follow publication style. Work in two steps: first **extract** every abbreviation occurrence, then **apply the compliance rules** to that catalogue.
+
+## Step 1 — Extract
+
+First, catalogue every abbreviation / acronym occurrence using the **`abbreviation-extraction` skill**. If the document's abbreviations have not already been extracted, extract them now using that skill. The catalogue gives you, for each occurrence: the abbreviation (in singular base form), any inline definition accompanying that occurrence, the occurrence count (1 = first appearance), where it appears, the definition listed in any Abbreviations section, and whether the occurrence is **excluded** from compliance checks (headings, References/Bibliography, cover page, and exempt classes such as titles, degrees, units, citation elements, ranks, equipment designators, all-caps corporation names, genus abbreviations, security markings, and "U.S.").
+
+Treat excluded occurrences as out of scope: do **not** raise any issue for them. In addition, always treat these as excluded even if the extractor did not: **RAND**, **MIT**, **ChatGPT**.
+
+## Step 2 — Apply the compliance rules
+
+Evaluate the non-excluded occurrences against the rules below. Report **only genuine problems** — do not emit entries for abbreviations that pass, and do not report excluded occurrences. Every issue below is **severity: medium**. Use the abbreviation's "first use" to mean its **first non-excluded occurrence**.
+
+If the document contains no abbreviations at all, report nothing.
+
+### Rule 1 — Missing Abbreviations section
+If the document uses at least one non-excluded abbreviation but has **no** dedicated "Abbreviations", "Acronyms", "Glossary", or equivalent section, report a single issue.
+**Title:** "No Abbreviations section found"
+
+### Rule 2 — Not defined at first use
+At an abbreviation's **first** non-excluded occurrence, if there is **no** inline definition (the "Full Name (ABBR)" pattern), report an issue. Subsequent occurrences do not need an inline definition — never raise this for them.
+**Title:** "Abbreviation not defined at first use"
+
+### Rule 3 — Missing from the Abbreviations section
+When a dedicated Abbreviations section **exists**, every non-excluded abbreviation should be listed in it. For each occurrence of an abbreviation that is **not** listed there, report an issue.
+**Title:** "Abbreviation missing from Abbreviations section"
+
+### Rule 4 — Inline definition does not match the Abbreviations section
+At an abbreviation's first non-excluded occurrence, if it has an inline definition **and** is also listed in the Abbreviations section, but the two definitions differ (ignoring trivial case/whitespace/punctuation differences), report an issue.
+**Title:** "Inline definition does not match Abbreviations section"
+
+### Rule 5 — Ambiguous abbreviation
+If an occurrence carries an inline definition that differs from the **first** inline definition recorded for that same abbreviation (ignoring trivial case/whitespace/punctuation differences), the document is using one abbreviation to mean more than one thing. Report an issue.
+**Title:** "Ambiguous abbreviation"
+
+## Reporting
+
+Report issues following the conventions defined in the issues skill (`/skills/issues/SKILL.md`). Use the exact titles above and **severity: medium**. Set the issue's line range to the offending occurrence's location (for "No Abbreviations section found", which has no specific location, set both bounds to line 1). In each description, name the abbreviation and explain briefly what failed and what was expected. Do not invent content — base every judgment strictly on the extracted catalogue and the document.

--- a/skills/capabilities/SKILL.md
+++ b/skills/capabilities/SKILL.md
@@ -23,7 +23,9 @@ These review the document and flag issues.
 |---|---|---|
 | **Reference Error Checker** | Are your references accurate? Uses web search to confirm each citation exists and that the author, title, publisher, and year match public sources — catching typos and hallucinated references. | `reference-validation` |
 | **Figures & Tables Check** | Are all figures and tables properly titled, consistently numbered, cited in the body text, and do all body-text references resolve to a real figure or table? | `figures-tables-check` |
+| **Abbreviation Scan** | Are abbreviations and acronyms defined inline at first use, listed in an Abbreviations section, used consistently, and never given conflicting meanings? | `abbreviation-scan` |
 | **Document Contents** | Does the document include all required sections — About This, Acknowledgements, Methods, Results, Conclusion, References, and an Appendix when one is referenced? | `document-contents` |
+| **About This** | Does the preface / "About This" section cover the required elements (context, objectives, audience, situating in the literature, contribution, and scope), and does each author biography meet publication requirements (sentence count, position & affiliation, research focus, and highest degree)? | `about-this-preface`, `about-this-authors` |
 | **Recommendation Check** | Is each recommendation supported by the document's own findings? Flags recommendations with weak, indirect, missing, or contradictory backing. | `recommendation-check` |
 | **Internal Inference Validation** | Does the reasoning hold up? Flags logical leaps, unsupported conclusions, and arguments where the evidence doesn't support the claim. | `inference-validation` |
 | **Advocacy & Tone** | Does the document use neutral, objective language? Flags trigger words (certainty language without evidence), advocacy language (unsupported recommendations or opinion framing), and subjective tone. (Beta.) | `advocacy-tone` |
@@ -42,6 +44,7 @@ These operate on the document rather than flagging issues.
 | **Download References** | Search the web for a reference and download its full original content (PDF/Markdown), verifying the match. Reports found / found-but-inaccessible / not-found. | `reference-download` |
 | **Extract Methodology** | Extract a structured, reproducible description of the paper's methodology, and classify how reproducible it is. | `methodology-extraction` |
 | **Extract References** | Find and list all bibliographic references from the document's reference/bibliography section. | `reference-extraction` |
+| **Extract Abbreviations** | Find and catalogue every abbreviation/acronym occurrence — with its inline definition, occurrence count, location, Abbreviations-section entry, and exempt-class status. | `abbreviation-extraction` |
 
 ## Notes
 

--- a/tests/unit/agents/test_abbreviation_checker.py
+++ b/tests/unit/agents/test_abbreviation_checker.py
@@ -1,0 +1,40 @@
+"""Tests for the abbreviation checker agent.
+
+The agent loads its extraction method from the portable `abbreviation-extraction`
+skill (the source of truth) and appends a backend `_ENV_GUIDANCE` addendum
+carrying the Draft-Detective specifics the skill omits (document location and the
+structured-output field mapping the downstream deterministic checks depend on).
+Here we guard that the skill loads and the addendum still references those
+specifics, without invoking the LLM.
+"""
+
+from lib.agents.abbreviation_checker import _ENV_GUIDANCE
+from lib.skills import load_skill_prompt
+
+
+def test_extraction_skill_loads_non_empty_without_frontmatter():
+    body = load_skill_prompt("abbreviation-extraction")
+    assert body.strip()
+    assert not body.lstrip().startswith("---")
+
+
+def test_agent_composes_skill_with_env_guidance():
+    body = load_skill_prompt("abbreviation-extraction")
+
+    # The backend addendum carries the specifics the portable skill omits:
+    # document location and the exact structured-output field mapping.
+    assert "/main.md" in _ENV_GUIDANCE
+    for field in (
+        "inline_definition",
+        "occurrence_number",
+        "line_start",
+        "line_end",
+        "abbreviations_section_definition",
+        "ignored",
+        "abbreviations_section_found",
+    ):
+        assert field in _ENV_GUIDANCE
+
+    composed = body + _ENV_GUIDANCE
+    assert composed.startswith(body)
+    assert composed.endswith(_ENV_GUIDANCE)

--- a/tests/unit/test_skills.py
+++ b/tests/unit/test_skills.py
@@ -46,6 +46,8 @@ _SKILL_BACKED_AGENTS = [
     "advocacy-tone",
     "about-this-preface",
     "about-this-authors",
+    "abbreviation-extraction",
+    "abbreviation-scan",
 ]
 
 


### PR DESCRIPTION
## Summary

Convert `abbreviation_scan_v2` into two portable skills, while keeping the backend's deterministic compliance engine intact. This is a **hybrid** workflow — an LLM agent extracts an abbreviation *catalogue*, then deterministic Python (`issues.py`) turns that catalogue into document issues — so the conversion is split accordingly:

- **`abbreviation-extraction`** — the portable extraction *method*, made the source of truth: the backend extraction agent now loads it.
- **`abbreviation-scan`** — a composite skill that invokes `abbreviation-extraction` and then applies the compliance rules **as an LLM prompt** (the `issues.py` rules converted to prose). This resolves the concern noted on [RANDZ-600](https://linear.app/ae-studio/issue/RANDZ-600): the skill itself returns the issues, not just the catalogue.

Closes [RANDZ-600](https://linear.app/ae-studio/issue/RANDZ-600/convert-abbreviation-scan-v2-abbreviation-scan-to-a-skill).

## Motivation

The other skill conversions were all-LLM (the agent both finds *and* judges). `abbreviation_scan_v2` deliberately splits the work: occurrence cataloguing (LLM) vs. compliance rules (deterministic code — exact occurrence counting, definition matching, ambiguity detection). We keep that determinism in the backend and express the portable method as skills, so external/skill-based agents get a full issue-producing check without the backend losing its deterministic guarantees.

## What's Changed

### Backend

- **`skills/abbreviation-extraction/SKILL.md`** (new) — extraction method ported from the agent's inline `_SYSTEM_PROMPT`, genericized: no `/main.md`, no tool names, no output-schema field names. Covers what an abbreviation/inline-definition is, occurrence counting, plural handling, exempt classes, ignored sections, one-entry-per-occurrence.
- **`lib/agents/abbreviation_checker.py`** — drop the inline `_SYSTEM_PROMPT`; compose `load_skill_prompt("abbreviation-extraction") + _ENV_GUIDANCE`. The `_ENV_GUIDANCE` carries the backend specifics the skill omits (document at `/main.md`, search/read tools, and the exact field mapping: `abbr`, `inline_definition`, `occurrence_number`, `line_start/end`, `abbreviations_section_definition`, `ignored`, …). Return type, `AutoStrategy`, and the workflow graph are unchanged.
- **`skills/abbreviation-scan/SKILL.md`** (new, NOT backend-wired) — Step 1 invokes `abbreviation-extraction`; Step 2 applies the `issues.py` rules in prose (problems only, all medium severity): no Abbreviations section, not defined at first use, missing from section, inline≠section, ambiguous. Skips exempt/ignored occurrences (incl. the RAND/MIT/ChatGPT always-ignore list) and passing checks; reports per the issues skill.
- **Deterministic path preserved** — `lib/workflows/abbreviation_scan_v2/{graph,state,issues}.py`, `nodes/check_abbreviations.py`, and `nodes/apply_ignored_list.py` are unchanged. The FastAPI workflow still produces issues via `issues.py`.
- **`skills/capabilities/SKILL.md`** — add **Abbreviation Scan** (assessment) and **Extract Abbreviations** (tool) rows, plus an **About This** row (`about-this-preface`, `about-this-authors`) that was missing from the menu.

### Frontend

None.

### Tests

- **`tests/unit/test_skills.py`** — add `abbreviation-extraction` and `abbreviation-scan` to the skill-load guard.
- **`tests/unit/agents/test_abbreviation_checker.py`** (new) — assert the checker composes `skill + _ENV_GUIDANCE` and that the addendum carries the field mapping.

## Risks and Mitigations

- **Extraction behavior drift from relocating the prompt** — mitigated by a before/after e2e on `evals_inspectai/e2e/abbreviation_checker/` (26 samples; dedicated server + `dev` worktree):

  | Scorer | BEFORE (inline) | AFTER (skill) |
  |---|---|---|
  | abbreviation list (deterministic deep-diff) | 1.0 | 1.0 |
  | abbreviations_section_found (deterministic) | 1.0 | 1.0 |
  | model-graded | 1.0 | 0.98 |

  Deterministic scorers identical; the 0.02 model-graded delta is one sample's judge partial-credit, within noise.
- **`abbreviation-scan` is not backend-wired** — intentional (the backend keeps `issues.py`). It's a portable artifact, validated by inspection + skill-load, not this e2e.
- `uv run mypy .` clean (373 files); `pytest tests/unit/test_skills.py tests/unit/agents` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)