### PR TITLE
feat(advocacy-tone): flag imperative words (RANDZ-608 Theme C)

### DIFF
--- a/evals_inspectai/e2e/advocacy_tone_v2/dataset.json
+++ b/evals_inspectai/e2e/advocacy_tone_v2/dataset.json
@@ -37,5 +37,76 @@
       "Subjective Tone Detected": 0
     },
     "target_answer": "The Findings sentence is purely factual and contains no trigger words, advocacy phrases, or value-laden language. The agent should report zero advocacy/tone issues."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nIt is urgent that policymakers act now to close these gaps before the next funding cycle.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Advocacy Language Detected": 1
+    },
+    "target_answer": "The Findings sentence uses the imperative/normative word 'urgent' to push urgency and a call to action ('act now') without citing evidence. The agent should report one 'Advocacy Language Detected' issue (severity medium) on that sentence."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nAgencies must prioritize funding for these programs above all else.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Advocacy Language Detected": 1
+    },
+    "target_answer": "The Findings sentence uses a standalone imperative 'must' to assert the authors' own obligation/recommendation ('Agencies must prioritize ... above all else') without citing evidence. This is normative advocacy, not a description of an existing rule. The agent should report one 'Advocacy Language Detected' issue (severity medium)."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nAddressing this problem requires a fundamental restructuring of the program.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Advocacy Language Detected": 1
+    },
+    "target_answer": "The Findings sentence uses 'requires' as a normative call for action ('requires a fundamental restructuring') without supporting evidence, asserting what ought to be done rather than reporting a finding. The agent should report one 'Advocacy Language Detected' issue (severity medium)."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nIt is essential to expand funding for the program.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Advocacy Language Detected": 1
+    },
+    "target_answer": "The Findings sentence uses the imperative 'essential' to assert an obligation ('It is essential to expand funding') without citing evidence, promoting a position rather than reporting a result. The agent should report one 'Advocacy Language Detected' issue (severity medium)."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nPolicymakers must act to ensure equitable access for all recipients.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Advocacy Language Detected": 1
+    },
+    "target_answer": "The Findings sentence uses imperative language ('must act to ensure equitable access') to push a recommendation without citing evidence. It is normative advocacy, not a methods description of how data quality was ensured. The agent should report one 'Advocacy Language Detected' issue (severity medium)."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nThe analysis focused on critical infrastructure sectors such as energy and water.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Trigger Words Detected": 0,
+      "Advocacy Language Detected": 0,
+      "Subjective Tone Detected": 0
+    },
+    "target_answer": "The Findings sentence contains the word 'critical' only as part of the term-of-art noun phrase 'critical infrastructure', a neutral technical descriptor rather than a normative push. Per the imperative-word do-NOT-flag guidance, this should not be flagged. The agent should report zero advocacy/tone issues."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nThe measurement procedure requires two trained operators.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Trigger Words Detected": 0,
+      "Advocacy Language Detected": 0,
+      "Subjective Tone Detected": 0
+    },
+    "target_answer": "The Findings sentence uses 'requires' to state a factual technical requirement of a procedure, not a normative call for action. Per the imperative-word do-NOT-flag guidance, factual/technical requirements should not be flagged. The agent should report zero advocacy/tone issues."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nTo ensure data quality, all responses were validated against source records.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Trigger Words Detected": 0,
+      "Advocacy Language Detected": 0,
+      "Subjective Tone Detected": 0
+    },
+    "target_answer": "The Findings sentence uses 'ensure' in a factual methods-language sense (describing how data quality was maintained), not as a normative push. Per the imperative-word do-NOT-flag guidance, methods-language uses of 'ensure' should not be flagged. The agent should report zero advocacy/tone issues."
+  },
+  {
+    "input": "# Operations Research Report\n\n## Background\n\nThe study examined operations across three sites between 2018 and 2023. Data were collected via instrumented sensors and quarterly audits.\n\n## Findings\n\nUnder the current statute, agencies must submit annual reports.\n\n## Methods\n\nA stratified sampling scheme was applied across the three sites.\n",
+    "target_title_counts": {
+      "Trigger Words Detected": 0,
+      "Advocacy Language Detected": 0,
+      "Subjective Tone Detected": 0
+    },
+    "target_answer": "The Findings sentence uses 'must' only to describe an existing legal obligation ('Under the current statute, agencies must submit ...'), a factual statement rather than the authors' own advocacy. Per the imperative-word do-NOT-flag guidance, factual descriptions of existing obligations should not be flagged. The agent should report zero advocacy/tone issues."
   }
 ]

--- a/skills/advocacy-tone/SKILL.md
+++ b/skills/advocacy-tone/SKILL.md
@@ -11,7 +11,7 @@ You are a specialist document reviewer. Check whether the document uses neutral,
 
 - **Trigger words** — certainty language without evidence. Words implying certainty or universal truth without supporting evidence; academic writing should hedge claims appropriately. The words to look for are: `obviously`, `clearly`, `undoubtedly`, `certainly`, `definitely`, `absolutely`, `always`, `never`.
 
-- **Advocacy language** — unsupported recommendations. Statements promoting positions without citing evidence; research should distinguish between findings and opinions. The phrases to look for are: `we believe`, `in our opinion`, `it is clear that`, `without doubt`, `everyone knows`.
+- **Advocacy language** — unsupported recommendations. Statements promoting positions without citing evidence; research should distinguish between findings and opinions. The phrases to look for are: `we believe`, `in our opinion`, `it is clear that`, `without doubt`, `everyone knows`. This also includes **imperative / normative words** that push a position, urgency, or obligation rather than report a finding: `urgent`, `requires`, `must`, `critical`, `essential`, `ensure`, `ensuring`. These flag only when the author is asserting a position or obligation — not when they describe a fact, a technical requirement, or an existing rule (see the do-not-flag guidance in the Procedure).
 
 - **Subjective tone** — subjective evaluations. Value judgments or emotional language that may indicate bias; research writing should maintain a neutral, evidence-based tone. There is no fixed word list — judge this by reading the prose.
 
@@ -23,6 +23,12 @@ You are a specialist document reviewer. Check whether the document uses neutral,
 
 3. **Judge each candidate in context.** A lexical match is only a candidate, not a confirmed issue. Confirm an issue only when the language genuinely undermines neutrality or makes an unsupported certainty/opinion claim.
    - **Do not flag simple, factual mentions of legal terms or policies in an objective context.** For example, "the policy clearly states X" describing what a document says is acceptable; "X is clearly the best approach" is not.
+   - **Imperative / normative words — do NOT flag** when the word is factual rather than advocacy:
+     - **Term-of-art noun phrases**, e.g. "critical infrastructure", "essential services", "essential nutrients", "critical path", "critical region", "critical value".
+     - **Factual or technical requirements** describing how something works, e.g. "the procedure requires two operators", "the sample must be refrigerated before analysis".
+     - **Methods-language uses of "ensure"**, e.g. "to ensure data quality, responses were validated against source records".
+     - **Factual descriptions or quotations of existing obligations**, e.g. "under the current statute, agencies must report incidents within 24 hours".
+     - Flag only when the word carries the author's own normative push — a recommendation, a sense of urgency, or an asserted obligation without cited evidence (e.g. "policymakers must act now", "it is urgent that funding be expanded").
    - **Skip ignored sections.** Do not flag matches inside sections whose heading contains `author`, `reference`, `bibliography`, `appendix`, or `acknowledgment`.
 
 ## Reporting


### PR DESCRIPTION
## Summary

Implements **Theme C** of RANDZ-608: the **Advocacy & Tone** check now flags a class of imperative/normative words that QAMs identified as problematic — *Urgent, Requires, Must, Critical, Essential, Ensure/ensuring* — reported under the existing `"Advocacy Language Detected"` title. In-context judging keeps common objective/technical uses from being false-flagged.

Themes A (overstated empirical claims) and B (survey vs. convenience-sample terminology) are **out of scope** for this PR.

Linear: [RANDZ-608](https://linear.app/ae-studio/issue/RANDZ-608/advocacy-and-tone-address-qam-feedback-overstated-claims-imperative)

## Motivation

QAM feedback (via Emily) noted that phrases such as *Urgent, Is/are essential, Requires, Must, Critical, Ensure/ensuring* are often problematic in objective research writing. The skill's advocacy list previously caught only multi-word phrase forms (`we must`, `must ensure`, `it is essential that`, `critical to`) and missed these standalone forms entirely, so imperative advocacy slipped through.

## What's Changed

### Backend
- **`skills/advocacy-tone/SKILL.md`** — Added the imperative/normative words to the advocacy-language list, and a new "do NOT flag" carve-out in the Procedure covering term-of-art phrases (e.g. **"critical infrastructure"**, "essential services"), factual/technical requirements, methods-language uses of "ensure", and factual/quoted existing obligations. Words flag only when they carry the author's own normative push. This is the file loaded at runtime by the deep agent.
- **`evals_inspectai/e2e/advocacy_tone_v2/dataset.json`** — Added 9 samples: 5 positive (one per new word) expecting one `Advocacy Language Detected` issue, and 4 negative guardrail cases (critical infrastructure, factual `requires`, methods `ensure`, quoted `must`) expecting zero.

> Note: the RAND production overlay `bonetti/skills-customizations/advocacy-tone/SKILL.md` received the same edits for parity, but that path is gitignored (personal staging area) and is not part of this diff. It is not wired into runtime in this repo.

### Frontend
- None.

## Verification

Ran the full v2 e2e suite (backend running) — **14/14 pass**: `structured_output_scorer` 1.000, `model_graded_check` 1.000. Parsing the workflow output confirmed the 5 positive cases each produced exactly one `Advocacy Language Detected` issue and the 4 negative cases produced none — including the ticket's headline false positive, "critical infrastructure" → 0.

```
uv run inspect eval evals_inspectai/e2e/advocacy_tone_v2/advocacy_tone_v2_e2e.py
```

## Risks and Mitigations

- **False positives on standalone words** (`must`, `critical`, `essential`, `ensure`) are inherently more likely than on multi-word phrases. Mitigated by explicit in-context carve-outs in the skill Procedure and by dedicated negative eval samples that lock in the expected non-flagging behavior.
- **Scope contained to the skill-driven v2 check**; the legacy procedural `advocacy_tone` (v1) workflow and its regex/config lists are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4CdMbjXsZqc6emmLCLewi