### PR TITLE
feat(files): show all main-document revisions in the Files tab

### DIFF
--- a/frontend/components/analysis-form/file-list-item.tsx
+++ b/frontend/components/analysis-form/file-list-item.tsx
@@ -30,8 +30,10 @@ export const FileListItem = ({ file, type, onRemove }: FileListItemProps) => {
       <div className="flex items-center gap-2 min-w-0 flex-1">
         <FileText className={`w-4 h-4 flex-shrink-0 ${iconClass}`} />
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <p className="text-sm font-medium truncate">{file.name}</p>
+          <div className="flex items-center gap-2 min-w-0">
+            <p className="text-sm font-medium truncate min-w-0" title={file.name}>
+              {file.name}
+            </p>
             {isOversized && <AlertTriangle className="w-3.5 h-3.5 text-destructive flex-shrink-0" />}
           </div>
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -46,7 +48,7 @@ export const FileListItem = ({ file, type, onRemove }: FileListItemProps) => {
         variant="ghost"
         size="icon"
         onClick={onRemove}
-        className="h-6 w-6 text-muted-foreground hover:text-destructive"
+        className="h-6 w-6 flex-shrink-0 text-muted-foreground hover:text-destructive"
       >
         <X className="w-3 h-3" />
       </Button>

--- a/frontend/components/results/components/replace-main-document-dialog.tsx
+++ b/frontend/components/results/components/replace-main-document-dialog.tsx
@@ -160,7 +160,7 @@ export function ReplaceMainDocumentDialog({ isOpen, projectId, onClose }: Replac
             <span className="text-sm text-muted-foreground">{stageMessage}</span>
           </div>
         ) : (
-          <div className="space-y-4">
+          <div className="space-y-4 min-w-0">
             <div className="space-y-2">
               <Label>New document</Label>
               <FileUpload

--- a/frontend/components/results/tabs/files-tab.tsx
+++ b/frontend/components/results/tabs/files-tab.tsx
@@ -91,15 +91,31 @@ function FileNameLink({ file }: { file: FileListItem }) {
   );
 }
 
+function RoleBadge({ label, variant }: { label: string; variant: 'main' | 'muted' | 'support' }) {
+  const variantClass =
+    variant === 'main'
+      ? 'bg-primary/10 text-primary'
+      : variant === 'muted'
+        ? 'bg-muted text-muted-foreground'
+        : 'bg-secondary';
+  return (
+    <span className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${variantClass}`}>
+      {label}
+    </span>
+  );
+}
+
 interface FileTableRowProps {
   file: FileListItem;
   projectId: string;
+  currentRevision: number;
   matchedReference?: ComposedReference;
   onReplaceMain?: () => void;
 }
 
-function FileTableRow({ file, projectId, matchedReference, onReplaceMain }: FileTableRowProps) {
+function FileTableRow({ file, projectId, currentRevision, matchedReference, onReplaceMain }: FileTableRowProps) {
   const isMain = file.role === FileRole.Main;
+  const isCurrentMain = isMain && file.revision === currentRevision;
   const removeFileMutation = useRemoveFileMutation(projectId, file.id);
   const isRemoving = removeFileMutation.isPending;
 
@@ -109,13 +125,14 @@ function FileTableRow({ file, projectId, matchedReference, onReplaceMain }: File
         <FileNameLink file={file} />
       </TableCell>
       <TableCell className="">
-        <span
-          className={`inline-flex items-center rounded-full px-2 py-1 text-xs font-medium ${
-            isMain ? 'bg-primary/10 text-primary' : 'bg-secondary'
-          }`}
-        >
-          {isMain ? 'Main' : 'Supporting'}
-        </span>
+        {isMain ? (
+          <RoleBadge
+            label={isCurrentMain ? 'Main · Current' : `Main · Revision ${file.revision ?? '?'}`}
+            variant={isCurrentMain ? 'main' : 'muted'}
+          />
+        ) : (
+          <RoleBadge label="Supporting" variant="support" />
+        )}
       </TableCell>
       <TableCell className="text-xs whitespace-normal">
         {file.description ? (
@@ -133,44 +150,46 @@ function FileTableRow({ file, projectId, matchedReference, onReplaceMain }: File
       </TableCell>
       <TableCell className="text-xs text-right">{formatFileSize(file.file_size)}</TableCell>
       <TableCell>
-        <AlertDialog>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="size-8" disabled={isRemoving}>
-                {isRemoving ? <Loader2 className="size-4 animate-spin" /> : <MoreVerticalIcon className="size-4" />}
-                <span className="sr-only">Open menu</span>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {isMain && onReplaceMain ? (
-                <DropdownMenuItem onClick={onReplaceMain}>
-                  <RefreshCw className="size-4" />
-                  Replace document
-                </DropdownMenuItem>
-              ) : (
-                <AlertDialogTrigger asChild>
-                  <DropdownMenuItem disabled={isMain} variant="destructive">
-                    <Trash2 className="size-4" />
-                    Remove file
+        {isMain && !isCurrentMain ? null : (
+          <AlertDialog>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="size-8" disabled={isRemoving}>
+                  {isRemoving ? <Loader2 className="size-4 animate-spin" /> : <MoreVerticalIcon className="size-4" />}
+                  <span className="sr-only">Open menu</span>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {isCurrentMain && onReplaceMain ? (
+                  <DropdownMenuItem onClick={onReplaceMain}>
+                    <RefreshCw className="size-4" />
+                    Replace document
                   </DropdownMenuItem>
-                </AlertDialogTrigger>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>Remove file?</AlertDialogTitle>
-              <AlertDialogDescription className="break-all">
-                Are you sure you want to remove &quot;{file.file_name}&quot; from this project? This action cannot be
-                undone. The associated reference (if any) will become unmatched.
-              </AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>Cancel</AlertDialogCancel>
-              <AlertDialogAction onClick={() => removeFileMutation.mutate()}>Remove</AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+                ) : (
+                  <AlertDialogTrigger asChild>
+                    <DropdownMenuItem disabled={isMain} variant="destructive">
+                      <Trash2 className="size-4" />
+                      Remove file
+                    </DropdownMenuItem>
+                  </AlertDialogTrigger>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Remove file?</AlertDialogTitle>
+                <AlertDialogDescription className="break-all">
+                  Are you sure you want to remove &quot;{file.file_name}&quot; from this project? This action cannot be
+                  undone. The associated reference (if any) will become unmatched.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={() => removeFileMutation.mutate()}>Remove</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
       </TableCell>
     </TableRow>
   );
@@ -178,6 +197,7 @@ function FileTableRow({ file, projectId, matchedReference, onReplaceMain }: File
 
 export function FilesTab({ projectDetail, readOnly = false }: FilesTabProps) {
   const projectId = projectDetail.project.id;
+  const currentRevision = projectDetail.project.current_revision ?? 1;
   const files = useMemo(() => projectDetail.files ?? [], [projectDetail.files]);
   const workflowDetails = useMemo(() => projectDetail.workflow_runs ?? [], [projectDetail.workflow_runs]);
   const [searchQuery, setSearchQuery] = useState('');
@@ -198,12 +218,16 @@ export function FilesTab({ projectDetail, readOnly = false }: FilesTabProps) {
   // Build a map of file_id to matched references once
   const matchedReferencesMap = useMemo(() => buildReferenceByFileIdMap(composedReferences), [composedReferences]);
 
-  // Sort files: main file first, then other files sorted alphabetically by name
+  // Sort files: main documents first (current revision, then older revisions
+  // newest-first), then supporting files alphabetically by name.
   const sortedFiles = useMemo(
     () =>
       [...(files || [])].sort((a, b) => {
-        if (a.role === FileRole.Main) return -1;
-        if (b.role === FileRole.Main) return 1;
+        const aMain = a.role === FileRole.Main;
+        const bMain = b.role === FileRole.Main;
+        if (aMain && bMain) return (b.revision ?? 0) - (a.revision ?? 0);
+        if (aMain) return -1;
+        if (bMain) return 1;
         return (a.file_name || '').localeCompare(b.file_name || '');
       }),
     [files],
@@ -299,6 +323,7 @@ export function FilesTab({ projectDetail, readOnly = false }: FilesTabProps) {
                 key={file.id}
                 file={file}
                 projectId={projectId}
+                currentRevision={currentRevision}
                 matchedReference={file.id ? matchedReferencesMap.get(file.id) : undefined}
                 onReplaceMain={readOnly ? undefined : () => setIsReplaceDialogOpen(true)}
               />

--- a/lib/api/mcp/tools/files.py
+++ b/lib/api/mcp/tools/files.py
@@ -87,8 +87,11 @@ async def list_project_files(
     Returns a JSON array where each entry contains:
       file_id, file_name, file_size, file_type, role, revision, reference_id (null if unmatched).
 
-    revision: optional revision number. Defaults to the latest revision.
-    Returns the revision's MAIN file plus all shared supporting files.
+    Returns all files for the project: every MAIN document revision plus the shared
+    supporting files. The current main document is the MAIN file whose `revision`
+    equals the project's latest revision; MAIN files with a lower `revision` are
+    previous versions. Reference associations are scoped to the `revision`
+    argument (defaults to the latest revision).
 
     Use get_project to retrieve available reference IDs from the workflow state
     (look inside workflow_runs for type "reference_extraction" → state.extracted_references).
@@ -99,7 +102,7 @@ async def list_project_files(
     )
 
     resolved_revision = revision if revision is not None else project.current_revision
-    files = await get_project_files_list_items(project.id, revision=resolved_revision)
+    files = await get_project_files_list_items(project.id)
     matches = await get_file_reference_matches(project_id, revision=resolved_revision)
     file_to_reference = {m.file_id: m.reference_id for m in matches}
 

--- a/lib/api/routers/projects.py
+++ b/lib/api/routers/projects.py
@@ -12,6 +12,7 @@ from lib.models.file import File, FileRole
 from lib.models.project import AccessLevel, Project
 from lib.models.user import User
 from lib.services.docx_workflow_service import DocxManipulatorType, generate_docx
+from lib.services.files import get_files_by_project_id
 from lib.services.project_zip import create_project_files_zip
 from lib.services.projects import (
     ProjectDetailed,
@@ -341,8 +342,6 @@ async def list_revisions_endpoint(
     ),
 ):
     """List all revisions for a project with their main file info."""
-    from lib.services.files import get_files_by_project_id
-
     project, _ = await get_project_access(project_id, current_user, share_token)
 
     # Get all MAIN files to build revision list

--- a/lib/services/files.py
+++ b/lib/services/files.py
@@ -181,13 +181,15 @@ async def get_files_by_project_id(
 
 async def get_project_files_list_items(
     project_id: uuid.UUID | str,
-    revision: int | None = None,
 ) -> List[FileListItem]:
     """
     Get files for a project as lightweight list items (excludes markdown and summary).
 
-    When revision is set, returns files belonging to that revision plus
-    shared files (revision IS NULL, e.g. supporting documents).
+    Returns all files across every revision: each main-document revision plus the
+    shared supporting files (revision IS NULL). The latest revision — i.e. the one
+    matching Project.current_revision — is the current main document; older MAIN
+    files are previous revisions. Callers distinguish them by comparing each
+    File.revision to Project.current_revision.
     Excludes SUPPORTING_CANDIDATE files (temporary during reference downloading).
     """
     project_id = ensure_uuid(project_id, "project ID")
@@ -196,10 +198,6 @@ async def get_project_files_list_items(
             col(File.project_id) == project_id,
             col(File.role) != FileRole.SUPPORTING_CANDIDATE,
         )
-        if revision is not None:
-            stmt = stmt.where(
-                or_(col(File.revision) == revision, col(File.revision).is_(None))
-            )
         result = await session.execute(stmt)
         files = result.scalars().all()
         return [FileListItem.model_validate(f, from_attributes=True) for f in files]

--- a/lib/services/projects.py
+++ b/lib/services/projects.py
@@ -178,6 +178,11 @@ async def get_project_detailed_from_project(
     """
     Get detailed project information with workflow runs.
 
+    The files list always includes every revision (each main-document revision
+    plus shared supporting files); the current main is the one whose revision
+    matches project.current_revision. Issues, workflow runs, and markdown stay
+    scoped to the resolved revision.
+
     Args:
         project: The project to get details for
         access_level: The access level of the current user
@@ -243,9 +248,7 @@ async def get_project_detailed_from_project(
         access_level=access_level,
         workflow_runs=workflow_runs,
         issues=list(issues),
-        files=await get_project_files_list_items(
-            project.id, revision=resolved_revision
-        ),
+        files=await get_project_files_list_items(project.id),
         feedbacks=feedbacks,
         revision=resolved_revision,
         main_document_markdown=main_document_markdown,

--- a/tests/integration/test_get_project_files_list_items.py
+++ b/tests/integration/test_get_project_files_list_items.py
@@ -1,0 +1,87 @@
+"""Integration tests for get_project_files_list_items (returns all revisions)."""
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlmodel import col
+
+from lib.config.database import get_async_db_session
+from lib.models.file import File, FileRole
+from lib.models.project import Project
+from lib.models.user import User, UserRole
+from lib.services.files import get_project_files_list_items
+
+
+@pytest_asyncio.fixture
+async def project_with_revisions():
+    """A project at revision 2 with a main file per revision plus a shared support file."""
+    user = User(
+        id=uuid.uuid4(),
+        email=f"files-{uuid.uuid4()}@example.com",
+        name="Files Tester",
+        role=UserRole.USER,
+        show_experimental_features=False,
+    )
+    project = Project(id=uuid.uuid4(), title="Revisions", user_id=user.id, current_revision=2)
+
+    def _file(name: str, role: FileRole, revision: int | None) -> File:
+        return File(
+            id=uuid.uuid4(),
+            project_id=project.id,
+            file_name=name,
+            file_path=f"path/{name}",
+            file_type="application/pdf",
+            file_size=1234,
+            content_hash=str(uuid.uuid4()),
+            role=role,
+            uploaded_by=user.id,
+            revision=revision,
+        )
+
+    files = [
+        _file("main_v1.pdf", FileRole.MAIN, 1),
+        _file("main_v2.pdf", FileRole.MAIN, 2),
+        _file("support.pdf", FileRole.SUPPORT, None),
+    ]
+
+    # Commit in dependency order (users → projects → files) to satisfy FKs.
+    async with get_async_db_session() as session:
+        session.add(user)
+        await session.commit()
+    async with get_async_db_session() as session:
+        session.add(project)
+        await session.commit()
+    async with get_async_db_session() as session:
+        for f in files:
+            session.add(f)
+        await session.commit()
+
+    yield project
+
+    async with get_async_db_session() as session:
+        for f in files:
+            obj = (await session.execute(select(File).where(col(File.id) == f.id))).scalar_one_or_none()
+            if obj:
+                await session.delete(obj)
+        proj = (await session.execute(select(Project).where(col(Project.id) == project.id))).scalar_one_or_none()
+        if proj:
+            await session.delete(proj)
+        usr = (await session.execute(select(User).where(col(User.id) == user.id))).scalar_one_or_none()
+        if usr:
+            await session.delete(usr)
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_returns_every_main_revision_and_supports(project_with_revisions):
+    """All files are returned: every main-document revision plus shared support files."""
+    items = await get_project_files_list_items(project_with_revisions.id)
+    names = {i.file_name for i in items}
+    assert names == {"main_v1.pdf", "main_v2.pdf", "support.pdf"}
+
+    # The current main is the one matching the project's latest revision; the
+    # other MAIN file is a previous revision.
+    mains = {i.file_name: i.revision for i in items if i.role == FileRole.MAIN}
+    assert mains == {"main_v1.pdf": 1, "main_v2.pdf": 2}


### PR DESCRIPTION
## Summary

The Files tab now lists **every** revision of the main document instead of only the current one. The latest revision is clearly marked **Main · Current**, and older revisions are labeled **Main · Revision N** and are download-only. Also fixes a card overflow in the Replace main document dialog where a long filename spilled past the card and stretched the dialog.

## Motivation

When a user replaces the main document (creating a new revision), the previous main files still exist in the database but were hidden from the UI — there was no way to see or download earlier versions. Revisions are modeled on the `File` row itself (`File.revision`; `NULL` = shared supporting docs), with the latest tracked by `Project.current_revision`. The old behavior filtered the file list down to a single resolved revision, so history was invisible.

## What's Changed

### Backend

- **`lib/services/files.py`** — `get_project_files_list_items` no longer takes/uses a `revision` param; it returns all files (every main revision + shared supporting files), still excluding `SUPPORTING_CANDIDATE`. The current main is derived by comparing `File.revision` to `Project.current_revision`.
- **`lib/services/projects.py`** — `get_project_detailed_from_project` calls the files helper without a revision, so `ProjectDetailed.files` always carries the full history. Issues, workflow runs, and markdown remain scoped to the resolved revision.
- **`lib/api/routers/projects.py`** — reverted an interim query param; kept a small lazy-import cleanup in the revisions endpoint.
- **`lib/api/mcp/tools/files.py`** — the `list_files` MCP tool now returns all files; docstring updated to state that every main revision is included and the latest revision is the current one (reference matching stays scoped to `revision`).

### Frontend

- **`frontend/components/results/tabs/files-tab.tsx`** — main documents sort newest-first (current, then older); the role badge renders `Main · Current` for the latest and `Main · Revision N` for older ones; old revisions are download-only (no actions menu).
- **`frontend/components/results/components/replace-main-document-dialog.tsx`** — added `min-w-0` to the dialog's content grid item; without it the grid item's default `min-width: auto` let a `nowrap` filename stretch the whole dialog. This is the change that actually resolves the overflow.
- **`frontend/components/analysis-form/file-list-item.tsx`** — constrained the filename flex chain (`min-w-0` + `truncate`, `title` for hover) and made the remove button `flex-shrink-0` so long names ellipsize.

### Tests

- **`tests/integration/test_get_project_files_list_items.py`** — asserts all main revisions plus shared supports are returned with correct revision numbers.

## Risks and Mitigations

- **Shared response now includes old revisions.** `ProjectDetailed.files` feeds other tabs (reference-review, citation-suggester) and the file-count badge. Those consumers look files up by id, so extra main rows are inert; the badge count simply includes historical mains. Verified live in the browser.
- **MCP `list_files` output changed** to include all revisions — documented in the tool docstring; the latest revision is identifiable via `Project.current_revision`.
- **No DB migration** — no model changes.

Verified: `uv run mypy .` clean; affected backend tests pass incl. the new one; frontend `tsc` + ESLint clean; feature and dialog fix confirmed live against the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EKnTuxC934AYipLXKx2yBC
