### PR TITLE
feat(results): add DOCX/PDF export to SimpleDeepAgent report

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,8 +7,9 @@ RUN npm install -g pnpm
 FROM base AS deps
 WORKDIR /app
 
-# Copy package.json and lock files
+# Copy package.json, lock files, and patches (referenced by the lockfile)
 COPY package.json pnpm-lock.yaml ./
+COPY patches ./patches
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile

--- a/frontend/components/results/components/markdown-download-button.tsx
+++ b/frontend/components/results/components/markdown-download-button.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Markdown } from '@/components/markdown';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { convertMarkdownToDocx, downloadDocx } from '@mohtasham/md-to-docx';
+import { ChevronDown, Download, FileText, Loader2, Printer } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+interface MarkdownDownloadButtonProps {
+  /** Markdown source to export. */
+  markdown: string;
+  /** Base file name (without extension) used for the downloaded files. */
+  fileName: string;
+}
+
+/**
+ * A "Download" dropdown that exports the given markdown as DOCX or PDF, entirely
+ * client-side. DOCX conversion uses `@mohtasham/md-to-docx`; PDF uses a print
+ * window populated with the rendered markdown and the current page styles.
+ */
+export function MarkdownDownloadButton({ markdown, fileName }: MarkdownDownloadButtonProps) {
+  const [isConverting, setIsConverting] = useState(false);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleDownloadDocx = async () => {
+    setIsConverting(true);
+    try {
+      const blob = await convertMarkdownToDocx(markdown, {
+        style: {
+          fontFamily: 'Georgia',
+        },
+      });
+      downloadDocx(blob, `${fileName}.docx`);
+    } catch (error) {
+      console.error('Failed to convert markdown to DOCX:', error);
+      toast.error('Failed to generate DOCX file');
+    } finally {
+      setIsConverting(false);
+    }
+  };
+
+  const handleDownloadPdf = () => {
+    if (!contentRef.current) return;
+    const printWindow = window.open('', '_blank');
+    if (!printWindow) {
+      toast.error('Please allow pop-ups to download PDF');
+      return;
+    }
+
+    const styles = Array.from(document.styleSheets)
+      .map((sheet) => {
+        try {
+          return Array.from(sheet.cssRules)
+            .map((rule) => rule.cssText)
+            .join('\n');
+        } catch {
+          return '';
+        }
+      })
+      .join('\n');
+
+    printWindow.document.write(`<!DOCTYPE html>
+<html><head><title>${fileName}</title><style>${styles}</style></head>
+<body class="p-8 text-sm">${contentRef.current.innerHTML}</body></html>`);
+    printWindow.document.close();
+    printWindow.addEventListener('afterprint', () => printWindow.close());
+    printWindow.print();
+  };
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline" size="sm" disabled={isConverting}>
+            {isConverting ? <Loader2 className="animate-spin" /> : <Download />}
+            {isConverting ? 'Generating...' : 'Download'}
+            <ChevronDown />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem onClick={handleDownloadDocx} disabled={isConverting}>
+            <FileText />
+            Download as DOCX
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={handleDownloadPdf}>
+            <Printer />
+            Download as PDF
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {/* Off-screen render used solely as the source HTML for the PDF export. */}
+      <div ref={contentRef} className="hidden">
+        <Markdown>{markdown}</Markdown>
+      </div>
+    </>
+  );
+}

--- a/frontend/components/results/components/markdown-download-button.tsx
+++ b/frontend/components/results/components/markdown-download-button.tsx
@@ -66,10 +66,21 @@ export function MarkdownDownloadButton({ markdown, fileName }: MarkdownDownloadB
       })
       .join('\n');
 
-    printWindow.document.write(`<!DOCTYPE html>
-<html><head><title>${fileName}</title><style>${styles}</style></head>
-<body class="p-8 text-sm">${contentRef.current.innerHTML}</body></html>`);
-    printWindow.document.close();
+    // Build the print document via the DOM rather than an interpolated HTML
+    // string, so neither `fileName` nor the rendered content can inject markup.
+    const printDoc = printWindow.document;
+    printDoc.title = fileName;
+
+    const styleEl = printDoc.createElement('style');
+    styleEl.textContent = styles;
+    printDoc.head.appendChild(styleEl);
+
+    printDoc.body.className = 'p-8 text-sm';
+    // Clone the rendered markdown nodes (dropping the off-screen wrapper).
+    for (const child of Array.from(contentRef.current.childNodes)) {
+      printDoc.body.appendChild(printDoc.importNode(child, true));
+    }
+
     printWindow.addEventListener('afterprint', () => printWindow.close());
     printWindow.print();
   };

--- a/frontend/components/workflows/results/reviewer-2-results.tsx
+++ b/frontend/components/workflows/results/reviewer-2-results.tsx
@@ -1,17 +1,8 @@
 import { Markdown } from '@/components/markdown';
-import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { MarkdownDownloadButton } from '@/components/results/components/markdown-download-button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Reviewer2State, WorkflowRunDetail } from '@/lib/generated-api';
-import { convertMarkdownToDocx, downloadDocx } from '@mohtasham/md-to-docx';
-import { ChevronDown, Download, FileText, Loader2, Printer } from 'lucide-react';
-import { useRef, useState } from 'react';
-import { toast } from 'sonner';
+import { useState } from 'react';
 
 interface Reviewer2ResultsProps {
   workflowDetail: WorkflowRunDetail;
@@ -20,60 +11,12 @@ interface Reviewer2ResultsProps {
 export function Reviewer2Results({ workflowDetail }: Reviewer2ResultsProps) {
   const state = workflowDetail.state as Reviewer2State;
   const [activeTab, setActiveTab] = useState('peer-review');
-  const [isConverting, setIsConverting] = useState(false);
-  const contentRef = useRef<HTMLDivElement>(null);
 
   if (!state?.peer_review_markdown && !state?.rebuttal_markdown) {
     return <div className="p-4 text-center text-muted-foreground">No review available</div>;
   }
 
   const activeMarkdown = activeTab === 'peer-review' ? state.peer_review_markdown : state.rebuttal_markdown;
-
-  const handleDownloadDocx = async () => {
-    if (!activeMarkdown) return;
-    setIsConverting(true);
-    try {
-      const blob = await convertMarkdownToDocx(activeMarkdown, {
-        style: {
-          fontFamily: 'Georgia',
-        },
-      });
-      downloadDocx(blob, `${activeTab}.docx`);
-    } catch (error) {
-      console.error('Failed to convert markdown to DOCX:', error);
-      toast.error('Failed to generate DOCX file');
-    } finally {
-      setIsConverting(false);
-    }
-  };
-
-  const handleDownloadPdf = () => {
-    if (!contentRef.current) return;
-    const printWindow = window.open('', '_blank');
-    if (!printWindow) {
-      toast.error('Please allow pop-ups to download PDF');
-      return;
-    }
-
-    const styles = Array.from(document.styleSheets)
-      .map((sheet) => {
-        try {
-          return Array.from(sheet.cssRules)
-            .map((rule) => rule.cssText)
-            .join('\n');
-        } catch {
-          return '';
-        }
-      })
-      .join('\n');
-
-    printWindow.document.write(`<!DOCTYPE html>
-<html><head><title>${activeTab}</title><style>${styles}</style></head>
-<body class="p-8 text-sm">${contentRef.current.innerHTML}</body></html>`);
-    printWindow.document.close();
-    printWindow.addEventListener('afterprint', () => printWindow.close());
-    printWindow.print();
-  };
 
   return (
     <Tabs value={activeTab} onValueChange={setActiveTab}>
@@ -83,34 +26,12 @@ export function Reviewer2Results({ workflowDetail }: Reviewer2ResultsProps) {
           <TabsTrigger value="rebuttal">Rebuttal</TabsTrigger>
         </TabsList>
 
-        {activeMarkdown && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="sm" disabled={isConverting}>
-                {isConverting ? <Loader2 className="animate-spin" /> : <Download />}
-                {isConverting ? 'Generating...' : 'Download'}
-                <ChevronDown />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={handleDownloadDocx} disabled={isConverting}>
-                <FileText />
-                Download as DOCX
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleDownloadPdf}>
-                <Printer />
-                Download as PDF
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+        {activeMarkdown && <MarkdownDownloadButton markdown={activeMarkdown} fileName={activeTab} />}
       </div>
 
       <TabsContent value="peer-review" className="text-sm p-2">
         {state.peer_review_markdown ? (
-          <div ref={activeTab === 'peer-review' ? contentRef : undefined}>
-            <Markdown>{state.peer_review_markdown}</Markdown>
-          </div>
+          <Markdown>{state.peer_review_markdown}</Markdown>
         ) : (
           <div className="p-4 text-center text-muted-foreground">No peer review available</div>
         )}
@@ -118,9 +39,7 @@ export function Reviewer2Results({ workflowDetail }: Reviewer2ResultsProps) {
 
       <TabsContent value="rebuttal" className="text-sm p-2">
         {state.rebuttal_markdown ? (
-          <div ref={activeTab === 'rebuttal' ? contentRef : undefined}>
-            <Markdown>{state.rebuttal_markdown}</Markdown>
-          </div>
+          <Markdown>{state.rebuttal_markdown}</Markdown>
         ) : (
           <div className="p-4 text-center text-muted-foreground">No rebuttal available</div>
         )}

--- a/frontend/components/workflows/results/simple-deep-agent-results.tsx
+++ b/frontend/components/workflows/results/simple-deep-agent-results.tsx
@@ -3,6 +3,7 @@
 import { ReadonlyThread } from '@/components/assistant-ui/readonly-thread';
 import { Markdown } from '@/components/markdown';
 import { DocumentIssueCard } from '@/components/results/components/document-issue-card';
+import { MarkdownDownloadButton } from '@/components/results/components/markdown-download-button';
 import { EmptyState } from '@/components/shared/empty-state';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -86,6 +87,20 @@ function IssuesList({
   );
 }
 
+function ReportCard({ reportMarkdown }: { reportMarkdown: string }) {
+  return (
+    <Card className="gap-2">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <CardTitle className="text-sm">Report</CardTitle>
+        <MarkdownDownloadButton markdown={reportMarkdown} fileName="report" />
+      </CardHeader>
+      <CardContent className="text-sm">
+        <Markdown>{reportMarkdown}</Markdown>
+      </CardContent>
+    </Card>
+  );
+}
+
 export function SimpleDeepAgentResults({
   project,
   workflowDetail,
@@ -163,16 +178,7 @@ export function SimpleDeepAgentResults({
       </TabsList>
 
       <TabsContent value="results" className="space-y-4">
-        {result.report_markdown && (
-          <Card className="gap-2">
-            <CardHeader>
-              <CardTitle className="text-sm">Report</CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm">
-              <Markdown>{result.report_markdown}</Markdown>
-            </CardContent>
-          </Card>
-        )}
+        {result.report_markdown && <ReportCard reportMarkdown={result.report_markdown} />}
 
         <IssuesList issues={issues} onNavigateToDocumentExplorer={onNavigateToDocumentExplorer} />
       </TabsContent>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,5 +97,10 @@
     "tw-animate-css": "^1.3.8",
     "typescript": "^5",
     "unified": "^11.0.5"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@mohtasham/md-to-docx@2.9.0": "patches/@mohtasham__md-to-docx@2.9.0.patch"
+    }
   }
 }

--- a/frontend/patches/@mohtasham__md-to-docx@2.9.0.patch
+++ b/frontend/patches/@mohtasham__md-to-docx@2.9.0.patch
@@ -1,0 +1,35 @@
+diff --git a/dist/helpers.js b/dist/helpers.js
+index 04824c147ff8f5082f56f6b812643e4f143fb16c..126c25b1e3364b07eff770e7c5e24a422deffa4a 100644
+--- a/dist/helpers.js
++++ b/dist/helpers.js
+@@ -454,17 +454,20 @@ export function processBlockquote(text, style) {
+                 alignment = undefined;
+         }
+     }
++    // Preserve newlines inside the blockquote: Word ignores "\n" within a
++    // single run, so emit one run per line and insert a break before each
++    // line after the first.
++    const lines = text.split("\n");
+     return new Paragraph({
+-        children: [
+-            new TextRun({
+-                text: text,
+-                italics: true,
+-                color: "000000",
+-                size: style.blockquoteSize || 24, // Use custom blockquote size if provided
+-                font: fontFamily,
+-                rightToLeft: style.direction === "RTL",
+-            }),
+-        ],
++        children: lines.map((line, index) => new TextRun({
++            text: line,
++            break: index > 0 ? 1 : undefined,
++            italics: true,
++            color: "000000",
++            size: style.blockquoteSize || 24, // Use custom blockquote size if provided
++            font: fontFamily,
++            rightToLeft: style.direction === "RTL",
++        })),
+         indent: {
+             left: 720, // 0.5 inch indent
+         },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@mohtasham/md-to-docx@2.9.0':
+    hash: a40e47b0bd54244dc6dd936f626c73828cb065d1cdd333f41cf5f60a02dc295a
+    path: patches/@mohtasham__md-to-docx@2.9.0.patch
+
 importers:
 
   .:
@@ -25,7 +30,7 @@ importers:
         version: 2.2.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@mohtasham/md-to-docx':
         specifier: ^2.9.0
-        version: 2.9.0
+        version: 2.9.0(patch_hash=a40e47b0bd54244dc6dd936f626c73828cb065d1cdd333f41cf5f60a02dc295a)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4473,7 +4478,7 @@ snapshots:
 
   '@lukeed/ms@2.0.2': {}
 
-  '@mohtasham/md-to-docx@2.9.0':
+  '@mohtasham/md-to-docx@2.9.0(patch_hash=a40e47b0bd54244dc6dd936f626c73828cb065d1cdd333f41cf5f60a02dc295a)':
     dependencies:
       docx: 9.6.0
       file-saver: 2.0.5


### PR DESCRIPTION
## Summary

Adds the same **Export to DOCX / PDF** functionality that Reviewer 2 already has to the **SimpleDeepAgent** results, specifically for the "Report" output. To avoid duplicating the export logic, it is extracted into a single reusable `MarkdownDownloadButton` component that both result views now consume.

Also fixes a bug (surfaced while testing the new export) where multi-line blockquotes lost their line breaks in the generated DOCX.

## Motivation

SimpleDeepAgent-based workflows produce a markdown report but had no way to export it. Reviewer 2 already solved this exact problem client-side, so the feature is reused rather than reimplemented.

## What's Changed

### Frontend

- **`components/results/components/markdown-download-button.tsx`** (new) — Reusable "Download" dropdown that exports given markdown as DOCX (client-side via `@mohtasham/md-to-docx`) or PDF (print window populated with the rendered markdown + current page styles). Self-contained: it renders its own off-screen `<Markdown>` as the PDF source, so consumers only pass `markdown` and a `fileName`.
- **`components/workflows/results/simple-deep-agent-results.tsx`** — The "Report" card header now renders `<MarkdownDownloadButton>`, giving SimpleDeepAgent report DOCX/PDF export.
- **`components/workflows/results/reviewer-2-results.tsx`** — Refactored to use the shared component, removing its inline export handlers, `contentRef`, and conversion state (large net deletion).
- **`patches/@mohtasham__md-to-docx@2.9.0.patch`** (new), **`package.json`**, **`pnpm-lock.yaml`** — `pnpm patch` for the library's blockquote renderer: it previously placed multi-line quote text in a single Word run (which collapses `\n`); the patch emits one run per line with a break before each subsequent line so newlines are preserved.

### Backend

None.

## Risks and Mitigations

- **Patched dependency** — The `@mohtasham/md-to-docx` patch applies automatically on `pnpm install` (registered in `package.json` / lockfile). Verified a clean install reapplies it and the generated DOCX contains the expected `<w:br/>` breaks. Low risk: the change is scoped to the blockquote renderer.
- **Reviewer 2 PDF path change** — Reviewer 2 now prints an off-screen re-render of the same markdown rather than the visible DOM node. Output is identical (same `<Markdown>` component + global stylesheet), but worth a quick visual sanity check.
- **Shared component regression** — Both consumers exercise the same code now; verified `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014LiLu11RoxFHt8MZGLpHuf